### PR TITLE
fix: partner icon filtering by detecting link format conventions

### DIFF
--- a/src/components/ArtifactGrid.tsx
+++ b/src/components/ArtifactGrid.tsx
@@ -79,10 +79,11 @@ export const Pagination = ({ currentPage, totalPages, totalItems, onPageChange }
           <button
             key={pageNum}
             onClick={() => onPageChange(pageNum as number)}
-            className={`px-3 py-2 rounded-lg border transition-colors ${currentPage === pageNum
+            className={`px-3 py-2 rounded-lg border transition-colors ${
+              currentPage === pageNum
                 ? 'bg-blue-600 text-white border-blue-600 shadow-sm'
                 : 'bg-white border-gray-200 text-gray-700 hover:bg-gray-50'
-              }`}
+            }`}
           >
             {pageNum}
           </button>
@@ -281,12 +282,18 @@ export const ArtifactGrid: React.FC<ResourceGridProps> = ({ type }) => {
   // - Most use "partnerId/partnerId" (e.g., "ilastik/ilastik")
   // - Some use "bioimageio/partnerId" (e.g., "bioimageio/stardist", "bioimageio/qupath")
   const handlePartnerClick = useCallback((partnerId: string) => {
+    // Partner link strings are stored lowercase in the manifest, so we
+    // normalize once here and use the lowercase form for both the prefix
+    // lookup and the constructed query — anything else risks an
+    // asymmetry where a CamelCase input matches the prefix check but
+    // produces a query the backend never sees.
+    const id = partnerId.toLowerCase();
     // List of partners that use bioimageio/ prefix instead of partnerId/partnerId
     const bioimageioPartners = ['stardist', 'qupath'];
 
-    const partnerLinkQuery = bioimageioPartners.includes(partnerId.toLowerCase())
-      ? `bioimageio/${partnerId}`
-      : `${partnerId}/${partnerId}`;
+    const partnerLinkQuery = bioimageioPartners.includes(id)
+      ? `bioimageio/${id}`
+      : `${id}/${id}`;
 
     setSearchQuery(partnerId);
     setIsTyping(false);

--- a/src/store/hyphaStore.ts
+++ b/src/store/hyphaStore.ts
@@ -24,6 +24,7 @@ interface FilterOptions {
   type?: string;
   tags?: string[];
   manifest?: Record<string, string>;
+  partnerLink?: string; // For keyword search by partner links (e.g., "stardist/stardist")
 }
 
 export interface HyphaState {
@@ -229,13 +230,13 @@ export const useHyphaStore = create<HyphaState>((set, get) => ({
     try {
       console.log('Fetching resources for page:', page, searchQuery);
       const offset = (page - 1) * get().itemsPerPage;
-      
+
       // Construct the base URL
       let url = `${HYPHA_SERVER_URL}/bioimage-io/artifacts/bioimage.io/children?pagination=true&offset=${offset}&limit=${get().itemsPerPage}&stage=false&order_by=manifest.score>`;
-      
+
       // Prepare filters object
       const filters: any = {};
-      
+
       // Add type filter if resourceType is specified
       if (get().resourceType) {
         filters.type = get().resourceType;
@@ -253,8 +254,8 @@ export const useHyphaStore = create<HyphaState>((set, get) => ({
       if (Object.keys(filters).length > 0) {
         url += `&filters=${encodeURIComponent(JSON.stringify(filters))}`;
       }
-      
-      // Combine search query with tags
+
+      // Combine search query with tags and partner links as keywords
       let keywords = [];
       if (searchQuery) {
         keywords.push(...searchQuery.split(' ').map(k => k.trim()));
@@ -262,23 +263,28 @@ export const useHyphaStore = create<HyphaState>((set, get) => ({
       if (filterOptions?.tags) {
         keywords.push(...filterOptions.tags);
       }
-      
+      // Add partner link filter as a keyword search
+      // This searches for models where the links array contains the partner link (e.g., "ilastik/ilastik")
+      if (filterOptions?.partnerLink) {
+        keywords.push(filterOptions.partnerLink);
+      }
+
       // Add combined keywords to URL if any exist
       if (keywords.length > 0) {
         url += `&keywords=${encodeURIComponent(keywords.join(','))}`;
       }
-      
+
       const response = await fetch(url);
       const data = await response.json();
-      
-      set({ 
+
+      set({
         resources: data.items || [],
         totalItems: data.total || 0,
         isLoading: false
       });
     } catch (error) {
       console.error('Error fetching resources:', error);
-      set({ 
+      set({
         isLoading: false,
         error: (error instanceof Error) ? error.message : 'Failed to fetch resources'
       });
@@ -287,31 +293,31 @@ export const useHyphaStore = create<HyphaState>((set, get) => ({
   fetchResource: async (id: string, version?: string) => {
     set({ isLoading: true, selectedResource: null, error: null });
     try {
-      const [workspace, artifactName] = id.includes('/') 
+      const [workspace, artifactName] = id.includes('/')
         ? id.split('/')
         : ['bioimage-io', id];
 
       const url = `${HYPHA_SERVER_URL}/${workspace}/artifacts/${artifactName}` + (version ? `?version=${version}` : '');
-      
+
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error(`Failed to fetch artifact: ${artifactName} ${version ? `version: ${version}` : ''}`);
       }
-      
+
       const data = await response.json();
       set({ selectedResource: data, isLoading: false });
     } catch (error) {
       console.error('Error fetching artifact:', error);
-      set({ 
-        isLoading: false, 
+      set({
+        isLoading: false,
         error: error instanceof Error ? error.message : 'An unknown error occurred',
-        selectedResource: null 
+        selectedResource: null
       });
     }
   },
   login: async (username: string, password: string) => {
     const state = get();
-    
+
     if (state.isLoggingIn || state.isAuthenticated) {
       return;
     }
@@ -339,18 +345,18 @@ export const useHyphaStore = create<HyphaState>((set, get) => ({
       });
 
       // Set both isAuthenticated and isLoggedIn to true after successful login
-      set({ 
+      set({
         isAuthenticated: true,
-        isLoggedIn: true 
+        isLoggedIn: true
       });
 
     } catch (error) {
       console.error('Login failed:', error);
-      set({ 
+      set({
         isAuthenticated: false,
         isConnected: false,
         isLoggedIn: false,
-        user: null 
+        user: null
       });
       throw error;
     } finally {
@@ -386,4 +392,4 @@ export const useHyphaStore = create<HyphaState>((set, get) => ({
       error: null
     });
   },
-})); 
+}));


### PR DESCRIPTION
This PR fixes #28 by addressing a specific technical issue: clicking partner icons showed empty results because the code assumed all partners use the `partnerId/partnerId` link format. However, some partners (StarDist, QuPath) use the `bioimageio/partnerId` format instead.

The fix detects the correct link format based on whether a partner maintains their own workspace collection (e.g., `ilastik/ilastik`) or is hosted under the central bioimage.io collection (e.g., `bioimageio/stardist`).

![CleanShot 2026-02-28 at 01 05 32](https://github.com/user-attachments/assets/99c98e33-d62f-46e7-b21a-fc384d71d373)

Some context: 

While investigating why my model `modest-octopus` wasn't appearing under the StarDist icon, I discovered the model was missing proper `links` metadata, in addition to #28. This highlights a broader UX issue: the `links` field and its purpose may not be obvious to contributors outside the core bioimage.io community.

Currently, the model detail page shows **factual** "Compatibilities" (which is helpful), but I believe it would also make sense to support filtering by **intended** compatibility as declared by the model author. This would help users discover models through partner icons even when comprehensive compatibility testing hasn't been completed/fulfilled yet.

Anyways, this PR ensures that models with properly declared `links` entries are displayed when users click partner icons, making the existing functionality work as intended.

Related: #21, #28