### PR TITLE
Remove homepage field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "bioimage-model-zoo",
   "version": "0.1.0",
   "private": true,
-  "homepage": "/bioimage-io",
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",


### PR DESCRIPTION
The "homepage": "/bioimage-io" field was incorrectly added, hardcoding the asset base path and breaking the production deployment at bioimage.io. The CI deployment sets PUBLIC_URL correctly at build time.