### PR TITLE
feat(bioengine): improve K8s wizard UX and deployment YAML accuracy

### DIFF
--- a/src/components/bioengine/BioEngineGuide.tsx
+++ b/src/components/bioengine/BioEngineGuide.tsx
@@ -1,318 +1,236 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { hyphaWebsocketClient } from 'hypha-rpc';
+import { useHyphaStore } from '../../store/hyphaStore';
 
 type OSType = 'macos' | 'linux' | 'windows';
 type ModeType = 'single-machine' | 'slurm' | 'external-cluster';
 type ContainerRuntimeType = 'docker' | 'podman' | 'apptainer' | 'singularity';
 
+const DEFAULT_IMAGE = 'ghcr.io/aicell-lab/bioengine-worker:0.7.1';
+
 const BioEngineGuide: React.FC = () => {
+  const { server, isLoggedIn } = useHyphaStore();
   const [os, setOS] = useState<OSType>('macos');
   const [mode, setMode] = useState<ModeType>('single-machine');
   const [containerRuntime, setContainerRuntime] = useState<ContainerRuntimeType>('docker');
   const [cpus, setCpus] = useState(2);
-  const [hasGpu, setHasGpu] = useState(false);
-  const [gpus, setGpus] = useState(1);
-  const [runAsRoot, setRunAsRoot] = useState(false);
+  const [gpus, setGpus] = useState(0);
+  const [memory, setMemory] = useState(10);
   const [copied, setCopied] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
+  // Main settings
+  const [token, setToken] = useState('');
+  const [tokenIsManual, setTokenIsManual] = useState(false);
+  const [isGeneratingToken, setIsGeneratingToken] = useState(false);
+  const [tokenError, setTokenError] = useState<string | null>(null);
+
   // Advanced options
   const [workspace, setWorkspace] = useState('');
   const [serverUrl, setServerUrl] = useState('');
-  const [token, setToken] = useState('');
   const [rayAddress, setRayAddress] = useState('');
   const [adminUsers, setAdminUsers] = useState('');
+  const [workerName, setWorkerName] = useState('');
   const [workspaceDir, setWorkspaceDir] = useState('');
   const [showTroubleshooting, setShowTroubleshooting] = useState(false);
   const [promptCopied, setPromptCopied] = useState(false);
-  const [interactiveMode, setInteractiveMode] = useState(false);
   const [shmSize, setShmSize] = useState('8g');
   const [customImage, setCustomImage] = useState('');
   const [platformOverride, setPlatformOverride] = useState('');
   const [clientId, setClientId] = useState('');
   const [clientServerPort, setClientServerPort] = useState('10001');
   const [servePort, setServePort] = useState('8000');
+  const [runAsRoot, setRunAsRoot] = useState(false);
+  const [gpuIndices, setGpuIndices] = useState('');
 
+  // Kubernetes-specific options
+  const [hasPvc, setHasPvc] = useState(false);
+  const [rayWorkspaceDir, setRayWorkspaceDir] = useState('');
+  const [k8sNamespace, setK8sNamespace] = useState('bioengine');
+  const [showRayWorkspaceDirDialog, setShowRayWorkspaceDirDialog] = useState(false);
+  const [k8sSecretCopied, setK8sSecretCopied] = useState(false);
+  const [k8sYamlCopied, setK8sYamlCopied] = useState(false);
+  const [k8sApplyCopied, setK8sApplyCopied] = useState(false);
 
-  // Ref for the troubleshooting dialog
   const troubleshootingDialogRef = useRef<HTMLDivElement>(null);
 
-  // Effect to scroll to dialog when troubleshooting opens
   useEffect(() => {
     if (showTroubleshooting && troubleshootingDialogRef.current) {
-      // Small delay to ensure the dialog is rendered
       setTimeout(() => {
-        troubleshootingDialogRef.current?.scrollIntoView({
-          behavior: 'smooth',
-          block: 'center',
-          inline: 'center'
-        });
+        troubleshootingDialogRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
       }, 100);
     }
   }, [showTroubleshooting]);
 
-  const getPlatform = () => {
-    return platformOverride || '';
-  };
+  // Auto-generate token when user is logged in and no manual token is set
+  const generateToken = useCallback(async () => {
+    if (!isLoggedIn || !server) return;
+    setIsGeneratingToken(true);
+    setTokenError(null);
+    try {
+      const thirtyDays = 30 * 24 * 3600;
+      const generatedToken = await server.generateToken({ permission: 'admin', expires_in: thirtyDays });
+      setToken(generatedToken);
+      setTokenIsManual(false);
+    } catch (err) {
+      setTokenError(`Failed to generate token: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setIsGeneratingToken(false);
+    }
+  }, [isLoggedIn, server]);
+
+  useEffect(() => {
+    if (isLoggedIn && !tokenIsManual && !token) {
+      generateToken();
+    }
+  }, [isLoggedIn, tokenIsManual, token, generateToken]);
+
+  // When the token changes, briefly connect to Hypha to resolve the workspace
+  const [workspaceResolved, setWorkspaceResolved] = useState(false);
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    const resolveWorkspace = async () => {
+      try {
+        const url = serverUrl || 'https://hypha.aicell.io';
+        const tmpServer = await hyphaWebsocketClient.connectToServer({ server_url: url, token });
+        if (!cancelled) {
+          const ws = tmpServer?.config?.workspace as string | undefined;
+          if (ws) {
+            setWorkspace(ws);
+            setWorkspaceResolved(true);
+          }
+        }
+        try { await tmpServer?.disconnect?.(); } catch (_) { /* ignore */ }
+      } catch (_) {
+        // Token may be invalid or network unavailable — silently ignore
+      }
+    };
+    setWorkspaceResolved(false);
+    resolveWorkspace();
+    return () => { cancelled = true; };
+  // Only re-run when the token itself changes (not serverUrl/workspace to avoid loops)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  const getPlatform = () => platformOverride || '';
 
   const getContainerCacheDir = () => {
-    if (containerRuntime !== 'apptainer' && containerRuntime !== 'singularity') {
-      return '';
-    }
-
-    // Get the base workspace directory
+    if (containerRuntime !== 'apptainer' && containerRuntime !== 'singularity') return '';
     let baseWorkspace = workspaceDir;
     if (!baseWorkspace) {
-      if (os === 'windows') {
-        baseWorkspace = runAsRoot ? 'C:\\.bioengine' : '%USERPROFILE%\\.bioengine';
-      } else {
-        baseWorkspace = '$HOME/.bioengine';
-      }
+      baseWorkspace = os === 'windows' ? (runAsRoot ? 'C:\\.bioengine' : '%USERPROFILE%\\.bioengine') : '$HOME/.bioengine';
     }
-
-    // Remove trailing slash if present and append /images
-    const normalizedWorkspace = baseWorkspace.endsWith('/') || baseWorkspace.endsWith('\\')
-      ? baseWorkspace.slice(0, -1)
-      : baseWorkspace;
-
-    return os === 'windows'
-      ? `${normalizedWorkspace}\\images`
-      : `${normalizedWorkspace}/images`;
+    const normalized = baseWorkspace.endsWith('/') || baseWorkspace.endsWith('\\')
+      ? baseWorkspace.slice(0, -1) : baseWorkspace;
+    return os === 'windows' ? `${normalized}\\images` : `${normalized}/images`;
   };
-
-
 
   const getUserFlag = () => {
     if (runAsRoot) return '';
-
-    switch (os) {
-      case 'windows':
-        return ''; // Windows doesn't use the same user flag
-      default:
-        return '--user $(id -u):$(id -g) ';
-    }
+    return os === 'windows' ? '' : '--user $(id -u):$(id -g) ';
   };
 
   const getGpuFlag = () => {
-    if (!hasGpu) return '';
-
-    if (containerRuntime === 'podman') {
-      // Podman uses --device for GPU access
-      return '--device nvidia.com/gpu=all ';
-    } else if (containerRuntime === 'apptainer' || containerRuntime === 'singularity') {
-      // Both Apptainer and Singularity use --nv for NVIDIA GPU support
-      return '--nv ';
-    } else {
-      // Docker uses --gpus
-      return '--gpus=all ';
-    }
+    if (gpus <= 0) return '';
+    if (containerRuntime === 'podman') return '--device nvidia.com/gpu=all ';
+    if (containerRuntime === 'apptainer' || containerRuntime === 'singularity') return '--nv ';
+    return '--gpus=all ';
   };
 
   const getCommand = () => {
-    // Base arguments - exclude --mode for SLURM since the script handles it automatically
     let args: string[] = [];
 
-    // Add mode argument only for non-SLURM modes
     if (mode !== 'slurm') {
       args.push(`--mode ${mode}`);
     }
 
-    // Mode-specific arguments
     if (mode === 'single-machine') {
       args.push(`--head-num-cpus ${cpus}`);
-      if (hasGpu) {
-        args.push(`--head-num-gpus ${gpus}`);
-      }
+      if (gpus > 0) args.push(`--head-num-gpus ${gpus}`);
+      if (memory > 0) args.push(`--head-memory-in-gb ${memory}`);
     } else if (mode === 'external-cluster' && rayAddress) {
-      args.push(`--connection-address ${rayAddress}`);
-      // Add port configuration for external cluster
-      if (clientServerPort && clientServerPort !== '10001') {
-        args.push(`--client-server-port ${clientServerPort}`);
-      }
-      if (servePort && servePort !== '8000') {
-        args.push(`--serve-port ${servePort}`);
-      }
+      args.push(`--head-node-address ${rayAddress}`);
+      if (clientServerPort && clientServerPort !== '10001') args.push(`--client-server-port ${clientServerPort}`);
+      if (servePort && servePort !== '8000') args.push(`--serve-port ${servePort}`);
     }
 
-    // Advanced arguments
     if (workspace) args.push(`--workspace ${workspace}`);
     if (serverUrl) args.push(`--server-url ${serverUrl}`);
     if (token) args.push(`--token ${token}`);
-
-    // Handle admin users - only add flag if users are specified
     if (adminUsers) {
       if (adminUsers === '*') {
         args.push(`--admin-users "*"`);
       } else {
-        const users = adminUsers.split(',').map(u => u.trim()).join(' ');
-        args.push(`--admin-users ${users}`);
+        args.push(`--admin-users ${adminUsers.split(',').map(u => u.trim()).join(' ')}`);
       }
     }
-
+    if (workerName) args.push(`--worker-name "${workerName}"`);
     if (clientId) args.push(`--client-id ${clientId}`);
-
-    // Add custom image if specified
     if (customImage) args.push(`--image ${customImage}`);
 
     const argsString = args.length > 0 ? args.join(' ') : '';
 
-    // SLURM mode uses the bash script instead of Docker
     if (mode === 'slurm') {
-      // Add workspace directory for SLURM mode only
       if (workspaceDir) args.push(`--workspace-dir ${workspaceDir}`);
-
-      const slurmArgsString = args.length > 0 ? args.join(' ') : '';
-
-      if (interactiveMode) {
-        return {
-          dockerCmd: `# Download and inspect the script first (optional)`,
-          pythonCmd: `bash <(curl -s https://raw.githubusercontent.com/aicell-lab/bioengine-worker/refs/heads/main/scripts/start_hpc_worker.sh)${slurmArgsString ? ` ${slurmArgsString}` : ''}`
-        };
-      } else {
-        return `bash <(curl -s https://raw.githubusercontent.com/aicell-lab/bioengine-worker/refs/heads/main/scripts/start_hpc_worker.sh)${slurmArgsString ? ` ${slurmArgsString}` : ''}`;
-      }
+      const slurmArgs = args.join(' ');
+      return `bash <(curl -s https://raw.githubusercontent.com/aicell-lab/bioengine-worker/refs/heads/main/scripts/start_hpc_worker.sh)${slurmArgs ? ` ${slurmArgs}` : ''}`;
     }
 
-    // For single-machine and external-cluster modes, use container runtime
     const platform = getPlatform();
     const userFlag = getUserFlag();
     const gpuFlag = getGpuFlag();
     const shmFlag = (containerRuntime === 'apptainer' || containerRuntime === 'singularity') ? '' : `--shm-size=${shmSize} `;
     const platformFlag = platform && containerRuntime !== 'apptainer' && containerRuntime !== 'singularity' ? `--platform ${platform} ` : '';
-    const imageToUse = customImage || 'ghcr.io/aicell-lab/bioengine-worker:0.6.11';
+    const imageToUse = customImage || DEFAULT_IMAGE;
+    const gpuEnvFlag = (gpuIndices && gpus > 0 && containerRuntime !== 'apptainer' && containerRuntime !== 'singularity')
+      ? `-e CUDA_VISIBLE_DEVICES=${gpuIndices} ` : '';
 
-    // Build volume mounts
-    let volumeMounts = '';
     const mounts: string[] = [];
-
-    // Handle workspace directory mount
     if (workspaceDir) {
-      // User specified a custom workspace directory - mount it directly to /.bioengine
-      if (containerRuntime === 'apptainer' || containerRuntime === 'singularity') {
-        mounts.push(`--bind ${workspaceDir}:/.bioengine`);
-      } else {
-        mounts.push(`-v ${workspaceDir}:/.bioengine`);
-      }
+      mounts.push(containerRuntime === 'apptainer' || containerRuntime === 'singularity'
+        ? `--bind ${workspaceDir}:/.bioengine` : `-v ${workspaceDir}:/.bioengine`);
     } else {
-      // No custom workspace directory - mount default ~/.bioengine to /.bioengine
-      if (os === 'windows') {
-        const hostWorkspacePath = runAsRoot ? `C:\\.bioengine` : '%USERPROFILE%\\.bioengine';
-        if (containerRuntime === 'apptainer' || containerRuntime === 'singularity') {
-          mounts.push(`--bind ${hostWorkspacePath}:/.bioengine`);
-        } else {
-          mounts.push(`-v ${hostWorkspacePath}:/.bioengine`);
-        }
-      } else {
-        if (containerRuntime === 'apptainer' || containerRuntime === 'singularity') {
-          mounts.push(`--bind $HOME/.bioengine:/.bioengine`);
-        } else {
-          mounts.push(`-v $HOME/.bioengine:/.bioengine`);
-        }
-      }
+      const hostPath = os === 'windows'
+        ? (runAsRoot ? 'C:\\.bioengine' : '%USERPROFILE%\\.bioengine')
+        : '$HOME/.bioengine';
+      mounts.push(containerRuntime === 'apptainer' || containerRuntime === 'singularity'
+        ? `--bind ${hostPath}:/.bioengine` : `-v ${hostPath}:/.bioengine`);
     }
+    const volumeMounts = mounts.join(' ');
 
-    volumeMounts = mounts.join(' ');
-
-    // Create directory creation commands - only for default directories
     let createDirCmd = '';
+    const wsPath = workspaceDir || (os === 'windows' ? (runAsRoot ? 'C:\\.bioengine' : '%USERPROFILE%\\.bioengine') : '$HOME/.bioengine');
     if (os === 'windows') {
-      const dirs: string[] = [];
-
-      // Always create workspace directory
-      if (workspaceDir) {
-        dirs.push(`"${workspaceDir}"`);
-      } else {
-        const workspacePath = runAsRoot ? 'C:\\.bioengine' : '%USERPROFILE%\\.bioengine';
-        dirs.push(`"${workspacePath}"`);
-      }
-
-      if (dirs.length > 0) {
-        createDirCmd = dirs.map(dir => `cmd /c "mkdir ${dir} 2>nul || echo Directory already exists"`).join(' && ');
-      }
+      createDirCmd = `cmd /c "mkdir "${wsPath}" 2>nul || echo Directory already exists"`;
     } else {
-      const dirs: string[] = [];
-
-      // Always create workspace directory
-      if (workspaceDir) {
-        dirs.push(`"${workspaceDir}"`);
-      } else {
-        dirs.push('$HOME/.bioengine');
-      }
-
-      if (dirs.length > 0) {
-        createDirCmd = `mkdir -p ${dirs.join(' ')}`;
-      }
+      createDirCmd = `mkdir -p ${wsPath}`;
     }
 
-    if (interactiveMode) {
-      // Interactive mode - separate container run and python command
-      let containerCmd = '';
-      if (containerRuntime === 'apptainer' || containerRuntime === 'singularity') {
-        // Both Apptainer and Singularity use 'shell' command for interactive mode
-        const cacheEnv = getContainerCacheDir() ? `${containerRuntime.toUpperCase()}_CACHEDIR=${getContainerCacheDir()} ` : '';
-        if (os === 'windows') {
-          containerCmd = `cmd /c "${cacheEnv}${containerRuntime} shell ${gpuFlag}${volumeMounts} docker://${imageToUse}"`;
-        } else {
-          containerCmd = `${cacheEnv}${containerRuntime} shell ${gpuFlag}${volumeMounts} docker://${imageToUse}`;
-        }
-      } else {
-        // Docker/Podman use run with --entrypoint bash
-        if (os === 'windows') {
-          containerCmd = `cmd /c "${containerRuntime} run ${platformFlag}--rm -it ${shmFlag}--entrypoint bash ${gpuFlag}${volumeMounts} ${imageToUse}"`;
-        } else {
-          containerCmd = `${containerRuntime} run ${platformFlag}--rm -it ${shmFlag}${userFlag}--entrypoint bash ${gpuFlag}${volumeMounts} ${imageToUse}`;
-        }
-      }
-
-      const pythonCmd = `python -m bioengine.worker ${argsString}`;
-
-      return {
-        createDirCmd,
-        dockerCmd: containerCmd,
-        pythonCmd
-      };
+    let dockerCmd = '';
+    if (containerRuntime === 'apptainer' || containerRuntime === 'singularity') {
+      const cacheEnv = getContainerCacheDir() ? `${containerRuntime.toUpperCase()}_CACHEDIR=${getContainerCacheDir()} ` : '';
+      dockerCmd = `${cacheEnv}${containerRuntime} exec ${gpuFlag}${volumeMounts} docker://${imageToUse} python -m bioengine.worker ${argsString}`;
+    } else if (os === 'windows') {
+      dockerCmd = `cmd /c "${containerRuntime} run ${gpuFlag}${platformFlag}-it --rm ${shmFlag}${gpuEnvFlag}${volumeMounts} ${imageToUse} python -m bioengine.worker ${argsString}"`;
     } else {
-      // Single command mode
-      let dockerCmd = '';
-      if (containerRuntime === 'apptainer' || containerRuntime === 'singularity') {
-        // Both Apptainer and Singularity use 'exec' command for single execution
-        const cacheEnv = getContainerCacheDir() ? `${containerRuntime.toUpperCase()}_CACHEDIR=${getContainerCacheDir()} ` : '';
-        if (os === 'windows') {
-          dockerCmd = `cmd /c "${cacheEnv}${containerRuntime} exec ${gpuFlag}${volumeMounts} docker://${imageToUse} python -m bioengine.worker ${argsString}"`;
-        } else {
-          dockerCmd = `${cacheEnv}${containerRuntime} exec ${gpuFlag}${volumeMounts} docker://${imageToUse} python -m bioengine.worker ${argsString}`;
-        }
-      } else if (os === 'windows') {
-        dockerCmd = `cmd /c "${containerRuntime} run ${gpuFlag}${platformFlag}-it --rm ${shmFlag}${volumeMounts} ${imageToUse} python -m bioengine.worker ${argsString}"`;
-      } else {
-        dockerCmd = `${containerRuntime} run ${gpuFlag}${platformFlag}-it --rm ${shmFlag}${userFlag}${volumeMounts} ${imageToUse} python -m bioengine.worker ${argsString}`;
-      }
-
-      return {
-        createDirCmd,
-        dockerCmd
-      };
+      dockerCmd = `${containerRuntime} run ${gpuFlag}${platformFlag}-it --rm ${shmFlag}${userFlag}${gpuEnvFlag}${volumeMounts} ${imageToUse} python -m bioengine.worker ${argsString}`;
     }
+
+    return { createDirCmd, dockerCmd };
   };
 
   const copyToClipboard = async () => {
     try {
       const command = getCommand();
       const containerName = containerRuntime.charAt(0).toUpperCase() + containerRuntime.slice(1);
-
       let textToCopy = '';
-
       if (typeof command === 'string') {
-        // SLURM mode - simple string
         textToCopy = command;
-      } else if (command.pythonCmd) {
-        // Interactive mode
-        textToCopy = `# Step 1: Create directories\n${command.createDirCmd}\n\n# Step 2: Start ${containerName} container\n${command.dockerCmd}\n\n# Step 3: Inside the container, run:\n${command.pythonCmd}`;
       } else {
-        // Single command mode
         textToCopy = `# Step 1: Create directories\n${command.createDirCmd}\n\n# Step 2: Run ${containerName} container\n${command.dockerCmd}`;
       }
-
       await navigator.clipboard.writeText(textToCopy);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
@@ -324,16 +242,10 @@ const BioEngineGuide: React.FC = () => {
   const getTroubleshootingPrompt = () => {
     const currentCommand = getCommand();
     const containerName = containerRuntime.charAt(0).toUpperCase() + containerRuntime.slice(1);
-
     let commandText = '';
     if (typeof currentCommand === 'string') {
-      // SLURM mode - simple string
       commandText = currentCommand;
-    } else if (currentCommand.pythonCmd) {
-      // Interactive mode
-      commandText = `# Step 1: Create directories\n${currentCommand.createDirCmd}\n\n# Step 2: Start ${containerName} container\n${currentCommand.dockerCmd}\n\n# Step 3: Inside the container, run:\n${currentCommand.pythonCmd}`;
     } else {
-      // Single command mode
       commandText = `# Step 1: Create directories\n${currentCommand.createDirCmd}\n\n# Step 2: Run ${containerName} container\n${currentCommand.dockerCmd}`;
     }
 
@@ -341,206 +253,31 @@ const BioEngineGuide: React.FC = () => {
 
 ## Context & Background
 
-I'm trying to set up a **BioEngine Worker** for bioimage analysis. BioEngine is part of the AI4Life project and provides cloud-powered AI tools for bioimage analysis. Here's what I need help with:
-
-### What is BioEngine?
-- BioEngine is a distributed computing platform for running AI models on bioimage data
-- It uses Ray (distributed computing framework) and Hypha (service orchestration) 
-- Workers can run in different modes: single-machine (local), SLURM (HPC clusters), or connect to existing Ray clusters
-- The system allows deploying and running AI models for bioimage analysis tasks
+I'm trying to set up a **BioEngine Worker** (v0.7.1) for bioimage analysis. BioEngine is part of the AI4Life project and provides cloud-powered AI tools for bioimage analysis.
 
 ### My Current Setup
 - **Operating System**: ${os === 'macos' ? 'macOS' : os === 'linux' ? 'Linux' : 'Windows'}
-- **Container Runtime**: ${containerName}${mode !== 'slurm' ? ` (${containerRuntime === 'docker' ? 'traditional container runtime' : containerRuntime === 'podman' ? 'daemonless, rootless alternative to Docker' : containerRuntime === 'apptainer' ? 'HPC-focused container runtime, often used on clusters' : 'HPC container runtime, predecessor to Apptainer'})` : ''}
-- **Mode**: ${mode === 'single-machine' ? 'Single Machine (local)' : mode === 'slurm' ? 'SLURM (HPC cluster with bash script)' : 'Connect to existing Ray cluster'}
-${mode === 'single-machine' ? `- **CPUs**: ${cpus}
-- **GPUs**: ${hasGpu ? gpus : 'None'}` : ''}
+- **Container Runtime**: ${containerName}
+- **Mode**: ${mode === 'single-machine' ? 'Single Machine (local)' : mode === 'slurm' ? 'SLURM (HPC cluster)' : 'Connect to existing Ray cluster'}
+${mode === 'single-machine' ? `- **CPUs**: ${cpus}\n- **GPUs**: ${gpus}${gpus > 0 && gpuIndices ? ` (indices: ${gpuIndices})` : ''}\n- **Memory**: ${memory > 0 ? `${memory} GB` : 'auto-detect'}` : ''}
 ${mode === 'external-cluster' && rayAddress ? `- **Ray Address**: ${rayAddress}` : ''}
-${mode === 'external-cluster' && clientServerPort && clientServerPort !== '10001' ? `- **Client Server Port**: ${clientServerPort}` : ''}
-${mode === 'external-cluster' && servePort && servePort !== '8000' ? `- **Serve Port**: ${servePort}` : ''}
-${mode !== 'slurm' ? `- **Run as Root**: ${runAsRoot ? 'Yes' : 'No'}
-- **Shared Memory Size**: ${shmSize}` : ''}
-- **Interactive Mode**: ${interactiveMode ? (mode === 'slurm' ? 'Yes (can inspect script before running)' : `Yes (separate ${containerName} and Python commands${containerRuntime === 'apptainer' || containerRuntime === 'singularity' ? ` with ${containerRuntime} shell` : ' with --entrypoint bash'})`) : 'No (single command)'}
 
 ### Advanced Configuration
 ${workspace ? `- **Workspace**: ${workspace}` : ''}
 ${serverUrl ? `- **Server URL**: ${serverUrl}` : ''}
 ${token ? `- **Token**: [CONFIGURED]` : ''}
 ${adminUsers ? `- **Admin Users**: ${adminUsers}` : '- **Admin Users**: Default (logged-in user)'}
-${workspaceDir ? `- **Workspace Directory**: ${workspaceDir}` : ''}
+${workspaceDir ? `- **BioEngine Workspace Directory**: ${workspaceDir}` : ''}
 ${customImage ? `- **Custom Image**: ${customImage}` : ''}
-${platformOverride ? `- **Platform Override**: ${platformOverride}` : ''}
-${clientId ? `- **Client ID**: ${clientId}` : ''}
 
-### Generated ${containerName} Command
+### Generated Command
 \`\`\`bash
 ${commandText}
 \`\`\`
 
-## Complete BioEngine Worker Help Reference
-
-\`\`\`
-python -m bioengine.worker --help
-usage: __main__.py [-h] --mode MODE [--admin-users EMAIL [EMAIL ...]] [--workspace-dir PATH] [--ray-workspace-dir PATH] [--startup-applications JSON [JSON ...]]
-                   [--monitoring-interval-seconds SECONDS] [--dashboard-url URL] [--log-file PATH] [--debug] [--graceful-shutdown-timeout SECONDS] [--server-url URL]
-                   [--workspace NAME] [--token TOKEN] [--client-id ID] [--head-node-address ADDRESS] [--head-node-port PORT] [--node-manager-port PORT]
-                   [--object-manager-port PORT] [--redis-shard-port PORT] [--serve-port PORT] [--dashboard-port PORT] [--client-server-port PORT] [--redis-password PASSWORD]
-                   [--head-num-cpus COUNT] [--head-num-gpus COUNT] [--head-memory-in-gb GB] [--runtime-env-pip-cache-size-gb GB] [--no-ray-cleanup] [--image IMAGE]
-                   [--worker-workspace-dir PATH] [--default-num-gpus COUNT] [--default-num-cpus COUNT] [--default-mem-in-gb-per-cpu GB] [--default-time-limit TIME]
-                   [--further-slurm-args ARG [ARG ...]] [--min-workers COUNT] [--max-workers COUNT] [--scale-up-cooldown-seconds SECONDS]
-                   [--scale-down-check-interval-seconds SECONDS] [--scale-down-threshold-seconds SECONDS]
-
-BioEngine Worker - Enterprise AI Model Deployment Platform
-
-options:
-  -h, --help            show this help message and exit
-
-Core Options:
-  Basic worker configuration
-
-  --mode MODE           Deployment mode: 'single-machine' for local Ray cluster, 'slurm' for HPC clusters with SLURM job scheduling, 'external-cluster' for connecting to an
-                        existing Ray cluster
-  --admin-users EMAIL [EMAIL ...]
-                        List of user emails/IDs with administrative privileges for worker management. If not specified, defaults to the authenticated user from Hypha login.
-  --workspace-dir PATH  Directory for worker workspace, temporary files, and Ray data storage. Also used to detect running data servers for dataset access. Should be
-                        accessible across worker nodes in distributed deployments.
-  --ray-workspace-dir PATH
-                        Directory for Ray cluster workspace when connecting to an external Ray cluster. Only used in 'external-cluster' mode. This allows the remote Ray
-                        cluster to use a different workspace directory than the local machine. If not specified, uses the same directory as --workspace-dir. Not applicable for
-                        'single-machine' or 'slurm' modes.
-  --startup-applications JSON [JSON ...]
-                        List of applications to deploy automatically during worker startup. Each element should be a JSON string with deployment configuration. Example:
-                        '{"artifact_id": "my_model", "application_id": "my_app"}'
-  --monitoring-interval-seconds SECONDS
-                        Interval in seconds for worker status monitoring and health checks. Lower values provide faster response but increase overhead.
-  --dashboard-url URL   Base URL of the BioEngine dashboard for worker management interfaces.
-  --log-file PATH       Path to the log file. If set to 'off', logging will only go to console. If not specified (None), a log file will be created in '<workspace_dir>/logs'.
-  --debug               Enable debug-level logging for detailed troubleshooting and development. Increases log verbosity significantly.
-  --graceful-shutdown-timeout SECONDS
-                        Timeout in seconds for graceful shutdown operations.
-
-Hypha Options:
-  Server connection and authentication
-
-  --server-url URL      URL of the Hypha server for service registration and remote access. Must be accessible from the deployment environment.
-  --workspace NAME      Hypha workspace name for service isolation and organization. If not specified, uses the workspace associated with the authentication token.
-  --token TOKEN         Authentication token for Hypha server access. If not provided, will use the HYPHA_TOKEN environment variable or prompt for interactive login. Recommend
-                        using a long-lived token for production deployments.
-  --client-id ID        Unique client identifier for Hypha connection. If not specified, an identifier will be generated automatically to ensure unique registration.
-
-Ray Cluster Options:
-  Cluster networking and resource configuration
-
-  --head-node-address ADDRESS
-                        IP address of the Ray head node. For external-cluster mode, this specifies the cluster to connect to. If not set in other modes, uses the first
-                        available system IP address.
-  --head-node-port PORT
-                        Port for Ray head node and GCS (Global Control Service) server. Must be accessible from all worker nodes.
-  --node-manager-port PORT
-                        Port for Ray node manager services. Used for inter-node communication and coordination.
-  --object-manager-port PORT
-                        Port for Ray object manager service. Handles distributed object storage and transfer between nodes.
-  --redis-shard-port PORT
-                        Port for Redis sharding in Ray's internal metadata storage. Used for cluster state management.
-  --serve-port PORT     Port for Ray Serve HTTP endpoint serving deployed models and applications. This is where model inference requests are handled.
-  --dashboard-port PORT
-                        Port for Ray dashboard web interface. Provides cluster monitoring and debugging capabilities.
-  --client-server-port PORT
-                        Port for Ray client server connections. Used by external Ray clients to connect to the cluster.
-  --redis-password PASSWORD
-                        Password for Ray cluster Redis authentication. If not specified, a secure random password will be generated automatically.
-  --head-num-cpus COUNT
-                        Number of CPU cores allocated to the head node for task execution. Set to 0 to reserve head node for coordination only.
-  --head-num-gpus COUNT
-                        Number of GPU devices allocated to the head node for task execution. Typically 0 to reserve GPUs for worker nodes.
-  --head-memory-in-gb GB
-                        Memory allocation in GB for head node task execution. If not specified, Ray will auto-detect available memory.
-  --runtime-env-pip-cache-size-gb GB
-                        Size limit in GB for Ray runtime environment pip package cache. Larger cache improves environment setup time.
-  --no-ray-cleanup      Skip cleanup of previous Ray cluster processes and data. Use with caution as it may cause port conflicts or resource issues.
-
-SLURM Job Options:
-  HPC job scheduling and worker deployment
-
-  --image IMAGE         Container image for SLURM worker jobs. Should include all required dependencies and be accessible on compute nodes.
-  --worker-workspace-dir PATH
-                        Workspace directory path mounted to worker containers in SLURM jobs. Must be accessible from compute nodes. Required for SLURM mode.
-  --default-num-gpus COUNT
-                        Default number of GPU devices to request per SLURM worker job. Can be overridden per deployment.
-  --default-num-cpus COUNT
-                        Default number of CPU cores to request per SLURM worker job. Should match typical model inference requirements.
-  --default-mem-in-gb-per-cpu GB
-                        Default memory allocation in GB per CPU core for SLURM workers. Total memory = num_cpus * mem_per_cpu.
-  --default-time-limit TIME
-                        Default time limit for SLURM worker jobs in "HH:MM:SS" format. Jobs will be terminated after this duration.
-  --further-slurm-args ARG [ARG ...]
-                        Additional SLURM sbatch arguments for specialized cluster configurations. Example: "--partition=gpu" "--qos=high-priority"
-
-Ray Autoscaler Options:
-  Automatic worker scaling behavior
-
-  --min-workers COUNT   Minimum number of worker nodes to maintain in the cluster. Workers below this threshold will be started immediately.
-  --max-workers COUNT   Maximum number of worker nodes allowed in the cluster. Prevents unlimited scaling and controls costs.
-  --scale-up-cooldown-seconds SECONDS
-                        Cooldown period in seconds between scaling up operations. Prevents rapid scaling oscillations.
-  --scale-down-check-interval-seconds SECONDS
-                        Interval in seconds between checks for scaling down idle workers. More frequent checks enable faster response to load changes.
-  --scale-down-threshold-seconds SECONDS
-                        Time threshold in seconds before scaling down idle worker nodes. Longer thresholds reduce churn but may waste resources.
-
-Examples:
-  # SLURM HPC deployment with autoscaling
-  __main__.py --mode slurm --max-workers 10 --admin-users admin@institution.edu
-
-  # Single-machine development deployment  
-  __main__.py --mode single-machine --debug --workspace-dir ./workspace
-
-  # Connect to existing Ray cluster
-  __main__.py --mode external-cluster --head-node-address 10.0.0.100
-
-For detailed documentation, visit: https://github.com/aicell-lab/bioengine-worker
-\`\`\`
-
-## Troubleshooting Chain of Thought
-
-When helping me troubleshoot, please consider:
-
-1. **${containerName} Issues** (single-machine/external-cluster modes): Container startup, platform compatibility, volume mounting
-2. **SLURM Issues** (SLURM mode): Job submission, resource allocation, container runtime, shared filesystem
-3. **Network Issues**: Port conflicts, firewall settings, connectivity
-4. **Resource Issues**: CPU/GPU allocation, memory constraints
-5. **Permission Issues**: User permissions, file access, ${containerRuntime} daemon access, SLURM account permissions
-6. **Ray Cluster Issues**: Ray startup, cluster connectivity, node communication
-7. **Hypha Integration**: Workspace access, authentication, service registration
-8. **Configuration Issues**: Invalid arguments, missing dependencies, environment setup
-
-## Common Issues to Check
-
-${mode === 'slurm' ? `### SLURM Mode Specific:
-- SLURM commands (sbatch, squeue, scancel) are available and working
-- Sufficient SLURM allocation and account permissions
-- Singularity/Apptainer is installed on compute nodes
-- Shared filesystem is accessible from all nodes
-- Network connectivity from compute nodes to download container images
-- Proper SLURM partition and QOS settings
-- Container image can be pulled and cached successfully
-
-### General:` : `- ${containerName} is installed and running (for single-machine/external-cluster modes)`}
-- Sufficient system resources (CPU, memory, disk space)
-- Network ports are available (especially for Ray cluster communication)
-${mode !== 'slurm' ? '- A bioengine-workdir directory will be created in your home directory for data mounting' : ''}
-${mode === 'single-machine' && hasGpu ? `- For GPU mode: NVIDIA ${containerRuntime === 'docker' ? 'Docker runtime' : containerRuntime === 'podman' ? 'container toolkit for Podman' : 'drivers for Apptainer (--nv flag)'}` : ''}
-${mode === 'external-cluster' ? '- For external-cluster mode: Target Ray cluster is running and accessible' : ''}
-
 ## My Question
 
-[Please describe your specific issue or question here. For example:
-- Error messages you're seeing
-- What you expected to happen vs what actually happened
-- Steps you've already tried
-- Any specific error logs or output]
-
-Please help me troubleshoot this BioEngine Worker setup. Provide step-by-step guidance and explain the reasoning behind each suggestion.`;
+[Please describe your specific issue or error here]`;
   };
 
   const copyTroubleshootingPrompt = async () => {
@@ -551,6 +288,130 @@ Please help me troubleshoot this BioEngine Worker setup. Provide step-by-step gu
     } catch (err) {
       console.error('Failed to copy prompt:', err);
     }
+  };
+
+  const getK8sSecretCommand = () => {
+    const ns = k8sNamespace || 'hypha';
+    const tokenValue = token || '<your-admin-token>';
+    return `kubectl create secret generic bioengine-secrets \\\n  --from-literal=HYPHA_TOKEN=${tokenValue} \\\n  -n ${ns}`;
+  };
+
+  const getK8sApplyCommand = () => {
+    const ns = k8sNamespace || 'hypha';
+    return `kubectl apply -f bioengine-deployment.yaml -n ${ns}`;
+  };
+
+  const getKubernetesWorkerYaml = () => {
+    const serverUrlVal = serverUrl || 'https://hypha.aicell.io';
+    const workspaceVal = workspace || '<your-hypha-workspace>';
+    const rayAddr = rayAddress || 'ray://raycluster-kuberay-head-svc.ray-cluster.svc.cluster.local';
+    const ns = k8sNamespace || 'hypha';
+
+    const arg = (flag: string, value: string) => `\n        - "${flag}"\n        - "${value}"`;
+
+    let extraArgs = '';
+    if (workspaceDir) extraArgs += arg('--workspace-dir', workspaceDir);
+    if (rayWorkspaceDir) extraArgs += arg('--ray-workspace-dir', rayWorkspaceDir);
+    if (clientServerPort && clientServerPort !== '10001') extraArgs += arg('--client-server-port', clientServerPort);
+
+    if (adminUsers) {
+      if (adminUsers === '*') {
+        extraArgs += arg('--admin-users', '*');
+      } else {
+        adminUsers.split(',').map(u => u.trim()).filter(Boolean).forEach(u => {
+          extraArgs += arg('--admin-users', u);
+        });
+      }
+    }
+    if (workerName) extraArgs += arg('--worker-name', workerName);
+
+    return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bioengine-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bioengine-worker
+  template:
+    metadata:
+      labels:
+        app: bioengine-worker
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: bioengine-worker
+        image: ${customImage || DEFAULT_IMAGE}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        args:
+        - "python"
+        - "-m"
+        - "bioengine.worker"
+        - "--mode"
+        - "external-cluster"
+        - "--head-node-address"
+        - "${rayAddr}"
+        - "--server-url"
+        - "${serverUrlVal}"
+        - "--workspace"
+        - "${workspaceVal}"
+        - "--token"
+        - "$(HYPHA_TOKEN)"
+        - "--client-id"
+        - "$(BIOENGINE_CLIENT_ID)"${extraArgs}
+        env:
+        - name: HYPHA_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: bioengine-secrets
+              key: HYPHA_TOKEN
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: BIOENGINE_CLIENT_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        startupProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - 'curl -sf "${serverUrlVal}/${workspaceVal}/services/$POD_NAME:bioengine-worker/get_status"
+              | grep -E "\"is_ready\":\\s*true"'
+          initialDelaySeconds: 60
+          periodSeconds: 20
+          timeoutSeconds: 10
+          failureThreshold: 18
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - 'curl -sf "${serverUrlVal}/${workspaceVal}/services/$POD_NAME:bioengine-worker/get_status"
+              | grep -E "\"is_ready\":\\s*true"'
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 2${hasPvc ? `
+        volumeMounts:
+        - name: bioengine
+          mountPath: /home/bioengine
+      volumes:
+      - name: bioengine
+        persistentVolumeClaim:
+          claimName: bioengine-pvc` : ''}`;
   };
 
   return (
@@ -572,30 +433,17 @@ Please help me troubleshoot this BioEngine Worker setup. Provide step-by-step gu
             </svg>
           </div>
           <div>
-            <h4 className={`font-semibold transition-all duration-200 ${isExpanded
-                ? 'text-sm text-gray-700'
-                : 'text-lg text-gray-800'
-              }`}>Launch Your Own BioEngine Instance</h4>
-            <p className={`text-gray-500 transition-all duration-200 ${isExpanded
-                ? 'text-xs'
-                : 'text-sm font-medium'
-              }`}>Access our powerful deployment configurator</p>
+            <h4 className={`font-semibold transition-all duration-200 ${isExpanded ? 'text-sm text-gray-700' : 'text-lg text-gray-800'}`}>
+              Launch Your Own BioEngine Instance
+            </h4>
+            <p className={`text-gray-500 transition-all duration-200 ${isExpanded ? 'text-xs' : 'text-sm font-medium'}`}>
+              Deployment configurator
+            </p>
           </div>
         </div>
         <div className="flex items-center">
-          <span className={`text-gray-500 mr-3 transition-all duration-200 ${isExpanded
-              ? 'text-xs'
-              : 'text-sm font-medium'
-            }`}>{isExpanded ? 'Hide' : 'Show'}</span>
-          <svg
-            className={`text-gray-400 transition-all duration-200 ${isExpanded
-                ? 'w-4 h-4 rotate-180'
-                : 'w-5 h-5'
-              }`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
+          <span className={`text-gray-500 mr-3 transition-all duration-200 ${isExpanded ? 'text-xs' : 'text-sm font-medium'}`}>{isExpanded ? 'Hide' : 'Show'}</span>
+          <svg className={`text-gray-400 transition-all duration-200 ${isExpanded ? 'w-4 h-4 rotate-180' : 'w-5 h-5'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
         </div>
@@ -603,7 +451,8 @@ Please help me troubleshoot this BioEngine Worker setup. Provide step-by-step gu
 
       {isExpanded && (
         <div className="mt-4 space-y-6">
-          {/* Primary Mode Selection - More Prominent */}
+
+          {/* ── Mode selection ── */}
           <div className="bg-gradient-to-r from-blue-50 to-purple-50 p-6 rounded-xl border border-blue-200">
             <h4 className="text-lg font-semibold text-gray-800 mb-4 flex items-center">
               <svg className="w-5 h-5 mr-2 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -611,745 +460,695 @@ Please help me troubleshoot this BioEngine Worker setup. Provide step-by-step gu
               </svg>
               Where do you want to run BioEngine?
             </h4>
-
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {/* Desktop/Workstation Option */}
-              <div
-                className={`p-4 rounded-lg border-2 cursor-pointer transition-all duration-200 ${mode === 'single-machine'
-                    ? 'border-blue-500 bg-blue-50 shadow-md'
-                    : 'border-gray-200 bg-white hover:border-blue-300 hover:shadow-sm'
-                  }`}
-                onClick={() => setMode('single-machine')}
-              >
-                <div className="flex items-center mb-2">
-                  <input
-                    type="radio"
-                    name="deployment-mode"
-                    value="single-machine"
-                    checked={mode === 'single-machine'}
-                    onChange={(e) => setMode(e.target.value as ModeType)}
-                    className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500"
-                    aria-label="Desktop/Workstation deployment mode"
-                  />
-                  <span className="ml-2 font-medium text-gray-800">💻 Desktop/Workstation</span>
+              {[
+                { value: 'single-machine', label: '💻 Desktop/Workstation', desc: 'Run locally on your computer or workstation using Docker. Perfect for development or small-scale analysis.', badge: 'Easy Setup', color: 'blue', disabled: false },
+                { value: 'slurm', label: '🖥️ HPC Cluster', desc: 'Deploy on a high-performance computing cluster with SLURM job scheduler. Ideal for large-scale workloads.', badge: 'Coming Soon', color: 'purple', disabled: true },
+                { value: 'external-cluster', label: '☸️ Kubernetes Cluster', desc: 'Deploy on Kubernetes with KubeRay. Connect BioEngine to an existing Ray cluster for cloud-native deployment.', badge: 'Cloud Native', color: 'orange', disabled: false },
+              ].map(({ value, label, desc, badge, color, disabled }) => (
+                <div
+                  key={value}
+                  className={`p-4 rounded-lg border-2 transition-all duration-200 ${disabled
+                      ? 'cursor-not-allowed opacity-50 border-gray-200 bg-gray-50'
+                      : mode === value
+                        ? `cursor-pointer border-${color}-500 bg-${color}-50 shadow-md`
+                        : `cursor-pointer border-gray-200 bg-white hover:border-${color}-300 hover:shadow-sm`
+                    }`}
+                  onClick={() => !disabled && setMode(value as ModeType)}
+                >
+                  <div className="flex items-center mb-2">
+                    <input type="radio" name="deployment-mode" value={value} checked={mode === value}
+                      disabled={disabled}
+                      onChange={(e) => !disabled && setMode(e.target.value as ModeType)}
+                      className={`w-4 h-4 text-${color}-600`} />
+                    <span className="ml-2 font-medium text-gray-800">{label}</span>
+                  </div>
+                  <p className="text-sm text-gray-600 ml-6">{desc}</p>
+                  <div className="mt-2 ml-6">
+                    <span className={`inline-block px-2 py-1 text-xs bg-${color}-100 text-${color}-700 rounded`}>{badge}</span>
+                  </div>
                 </div>
-                <p className="text-sm text-gray-600 ml-6">
-                  Run locally on your personal computer or workstation using Docker.
-                  Perfect for development, testing, or small-scale analysis.
-                </p>
-                <div className="mt-2 ml-6">
-                  <span className="inline-block px-2 py-1 text-xs bg-green-100 text-green-700 rounded">
-                    Easy Setup
-                  </span>
-                </div>
-              </div>
-
-              {/* HPC Cluster Option */}
-              <div
-                className={`p-4 rounded-lg border-2 cursor-pointer transition-all duration-200 ${mode === 'slurm'
-                    ? 'border-purple-500 bg-purple-50 shadow-md'
-                    : 'border-gray-200 bg-white hover:border-purple-300 hover:shadow-sm'
-                  }`}
-                onClick={() => setMode('slurm')}
-              >
-                <div className="flex items-center mb-2">
-                  <input
-                    type="radio"
-                    name="deployment-mode"
-                    value="slurm"
-                    checked={mode === 'slurm'}
-                    onChange={(e) => setMode(e.target.value as ModeType)}
-                    className="w-4 h-4 text-purple-600 bg-gray-100 border-gray-300 focus:ring-purple-500"
-                    aria-label="HPC Cluster deployment mode"
-                  />
-                  <span className="ml-2 font-medium text-gray-800">🖥️ HPC Cluster</span>
-                </div>
-                <p className="text-sm text-gray-600 ml-6">
-                  Deploy on a high-performance computing cluster with SLURM job scheduler.
-                  Ideal for large-scale processing and production workloads.
-                </p>
-                <div className="mt-2 ml-6">
-                  <span className="inline-block px-2 py-1 text-xs bg-purple-100 text-purple-700 rounded">
-                    High Performance
-                  </span>
-                </div>
-              </div>
-
-              {/* Kubernetes Cluster Option */}
-              <div
-                className={`p-4 rounded-lg border-2 cursor-pointer transition-all duration-200 ${mode === 'external-cluster'
-                    ? 'border-orange-500 bg-orange-50 shadow-md'
-                    : 'border-gray-200 bg-white hover:border-orange-300 hover:shadow-sm'
-                  }`}
-                onClick={() => setMode('external-cluster')}
-              >
-                <div className="flex items-center mb-2">
-                  <input
-                    type="radio"
-                    name="deployment-mode"
-                    value="external-cluster"
-                    checked={mode === 'external-cluster'}
-                    onChange={(e) => setMode(e.target.value as ModeType)}
-                    className="w-4 h-4 text-orange-600 bg-gray-100 border-gray-300 focus:ring-orange-500"
-                    aria-label="Kubernetes cluster deployment mode"
-                  />
-                  <span className="ml-2 font-medium text-gray-800">☸️ Kubernetes Cluster</span>
-                </div>
-                <p className="text-sm text-gray-600 ml-6">
-                  Deploy on Kubernetes with KubeRay. Creates a Ray cluster on K8s
-                  and connects BioEngine to it for scalable, cloud-native deployment.
-                </p>
-                <div className="mt-2 ml-6">
-                  <span className="inline-block px-2 py-1 text-xs bg-orange-100 text-orange-700 rounded">
-                    Cloud Native
-                  </span>
-                </div>
-              </div>
+              ))}
             </div>
           </div>
 
-          {/* Kubernetes Cluster Setup Instructions - Outside the mode selection box */}
+          {/* ── Kubernetes setup ── */}
           {mode === 'external-cluster' && (
             <div className="space-y-4">
-              {/* Step 1: Create Ray Cluster */}
+
+              {/* Intro */}
               <div className="p-4 bg-orange-50 rounded-xl border border-orange-200">
-                <h5 className="text-sm font-medium text-orange-800 mb-3 flex items-center">
-                  <span className="w-5 h-5 bg-orange-600 text-white rounded-full flex items-center justify-center text-xs mr-2">1</span>
-                  Create a Ray Cluster on Kubernetes
-                </h5>
-                <div className="text-sm text-orange-700 space-y-2">
-                  <p>First, deploy a Ray cluster on your Kubernetes cluster using KubeRay:</p>
-                  <ol className="list-decimal list-inside space-y-1 ml-2 text-xs">
-                    <li>Install the KubeRay operator: <code className="bg-orange-100 px-1 rounded">helm install kuberay-operator kuberay/kuberay-operator</code></li>
-                    <li>Deploy a RayCluster: <code className="bg-orange-100 px-1 rounded">kubectl apply -f raycluster.yaml</code></li>
-                    <li>Get the Ray head service address: <code className="bg-orange-100 px-1 rounded">kubectl get svc</code></li>
-                  </ol>
+                <p className="text-sm font-semibold text-orange-800 mb-1">Starting from an existing Ray cluster</p>
+                <p className="text-sm text-orange-700">
+                  This mode connects the BioEngine worker to a Ray cluster already running on Kubernetes.
+                  If you don't have one yet, follow the{' '}
                   <a
-                    href="https://docs.ray.io/en/master/cluster/kubernetes/getting-started/raycluster-quick-start.html"
+                    href="https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/raycluster-quick-start.html"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center text-orange-600 hover:text-orange-800 font-medium mt-2"
+                    className="underline font-medium hover:text-orange-900"
                   >
-                    📚 KubeRay Quick Start Guide
-                    <svg className="w-3 h-3 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                    KubeRay Quick Start Guide
+                  </a>.
+                </p>
+              </div>
+
+              {/* Note 1: Ray workspace directory */}
+              <div className="p-4 bg-blue-50 rounded-xl border border-blue-200">
+                <div className="flex items-start justify-between">
+                  <div className="flex items-start flex-1 mr-3">
+                    <svg className="w-4 h-4 text-blue-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                     </svg>
-                  </a>
+                    <div className="text-sm text-blue-800">
+                      <p className="font-medium">Recommended: mount a shared PVC on your Ray cluster nodes</p>
+                      <p className="text-blue-700 text-xs mt-1">
+                        BioEngine apps run on Ray nodes and write to the Ray Workspace Directory. For apps that communicate through the filesystem (e.g. <code className="bg-blue-100 px-1 rounded">bioimage-io/model-runner</code>), scaling to multiple replicas requires a shared volume across all Ray nodes — otherwise only reduced functionality is available.
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => setShowRayWorkspaceDirDialog(true)}
+                    className="flex-shrink-0 px-2 py-1 text-xs text-blue-600 border border-blue-300 rounded-lg hover:bg-blue-100 transition-colors"
+                  >
+                    Learn more
+                  </button>
                 </div>
               </div>
 
-              {/* Step 2: Ray Cluster Address */}
-              <div className="p-4 bg-orange-50 rounded-xl border border-orange-200">
-                <h5 className="text-sm font-medium text-orange-800 mb-3 flex items-center">
-                  <span className="w-5 h-5 bg-orange-600 text-white rounded-full flex items-center justify-center text-xs mr-2">2</span>
-                  Enter Ray Cluster Address
-                </h5>
-                <input
-                  type="text"
-                  value={rayAddress}
-                  onChange={(e) => setRayAddress(e.target.value)}
-                  placeholder="ray://raycluster-head-svc:10001"
-                  className="w-full px-3 py-2 border border-orange-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500 focus:border-orange-500"
-                  aria-label="Ray cluster address"
-                />
-                <p className="text-xs text-orange-700 mt-1">
-                  Enter the Ray head service address from your Kubernetes cluster (e.g., <code className="bg-orange-100 px-1 rounded">ray://raycluster-head-svc:10001</code>)
-                </p>
+              {/* Note 2: PVC for BioEngine workspace dir */}
+              <div className="p-4 bg-blue-50 rounded-xl border border-blue-200">
+                <div className="flex items-start">
+                  <svg className="w-4 h-4 text-blue-500 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <p className="text-sm text-blue-800">
+                    <span className="font-medium">Recommended: mount a PVC at the BioEngine Workspace Directory</span>
+                    <span className="text-blue-700"> — worker logs will otherwise be lost when the pod restarts.</span>
+                  </p>
+                </div>
+              </div>
+
+              {/* Standard configuration fields */}
+              <div className="p-4 bg-gray-50 rounded-xl border border-gray-200">
+                <h5 className="text-sm font-semibold text-gray-700 mb-3">Configuration</h5>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="md:col-span-2">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Ray Cluster Address</label>
+                    <input
+                      type="text"
+                      value={rayAddress}
+                      onChange={(e) => setRayAddress(e.target.value)}
+                      placeholder="ray://raycluster-kuberay-head-svc.ray-cluster.svc.cluster.local"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">
+                      Internal Kubernetes service address of the Ray head node. Use <code className="bg-gray-100 px-1 rounded">kubectl get svc -n &lt;ray-namespace&gt;</code> to find the service name.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Ray Workspace Directory</label>
+                    <input
+                      type="text"
+                      value={rayWorkspaceDir}
+                      onChange={(e) => setRayWorkspaceDir(e.target.value)}
+                      placeholder="/home/bioengine"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">Writable path on Ray cluster nodes. Mount a shared ReadWriteMany PVC here for full app functionality.</p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Kubernetes Namespace</label>
+                    <input
+                      type="text"
+                      value={k8sNamespace}
+                      onChange={(e) => setK8sNamespace(e.target.value)}
+                      placeholder="hypha"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    <p className="text-xs text-gray-500 mt-1">Namespace to deploy the BioEngine worker pod into</p>
+                  </div>
+
+                  <div className="md:col-span-2">
+                    <label className="flex items-center gap-2 cursor-pointer select-none">
+                      <input
+                        type="checkbox"
+                        checked={hasPvc}
+                        onChange={(e) => setHasPvc(e.target.checked)}
+                        className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      />
+                      <span className="text-sm font-medium text-gray-700">I have a PVC named <code className="bg-gray-100 px-1 rounded">bioengine-pvc</code> available in this namespace</span>
+                    </label>
+                    <p className="text-xs text-gray-500 mt-1">Mounts the PVC into the <strong>BioEngine worker pod</strong> at <code className="bg-gray-100 px-1 rounded">/home/bioengine</code> to persist worker logs. This is separate from the Ray cluster PVC.</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Auth warning */}
+              {!token && (
+                <div className="p-4 bg-amber-50 rounded-xl border border-amber-200">
+                  <div className="flex items-start">
+                    <svg className="w-5 h-5 text-amber-600 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                    </svg>
+                    <div className="text-sm text-amber-800">
+                      <p className="font-medium mb-1">🔐 Important: Authentication Required</p>
+                      <div className="text-amber-700 space-y-1">
+                        {isLoggedIn ? (
+                          <p>Generating your authentication token… or set one manually in <strong>Advanced Options → Authentication Token</strong>.</p>
+                        ) : (
+                          <>
+                            <p>An authentication token is required. Either:</p>
+                            <ol className="list-decimal list-inside space-y-1 ml-2 text-xs">
+                              <li><strong>Log in</strong> to auto-generate a 30-day admin token, or</li>
+                              <li>Set a token manually in <strong>Advanced Options → Authentication Token</strong></li>
+                            </ol>
+                            <p className="text-xs italic mt-1">Manually provided tokens must have <strong>Permission Level: Admin</strong>.</p>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Advanced options */}
+              <div className="border-t border-gray-200 pt-4">
+                <button
+                  onClick={() => setShowAdvanced(!showAdvanced)}
+                  className="flex items-center text-sm text-gray-600 hover:text-gray-800 transition-colors"
+                >
+                  <svg className={`w-4 h-4 mr-2 transition-transform ${showAdvanced ? 'rotate-90' : ''}`}
+                    fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                  Advanced Options
+                </button>
+
+                {showAdvanced && (
+                  <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-gray-50 rounded-lg">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Admin Users</label>
+                      <input type="text" value={adminUsers} onChange={(e) => setAdminUsers(e.target.value)}
+                        placeholder="user1@example.com,user2@example.com or *"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">Users who can manage the worker (comma-separated, * for all)</p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Worker Name</label>
+                      <input type="text" value={workerName} onChange={(e) => setWorkerName(e.target.value)}
+                        placeholder="BioEngine Worker"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">Display name for this worker in the Hypha service registry</p>
+                    </div>
+
+                    <div className="md:col-span-2">
+                      <div className="flex items-center justify-between mb-1">
+                        <label className="block text-sm font-medium text-gray-700">Authentication Token</label>
+                        {isLoggedIn && (
+                          <button
+                            type="button"
+                            onClick={() => { setTokenIsManual(false); generateToken(); }}
+                            disabled={isGeneratingToken}
+                            className="flex items-center px-2 py-1 text-xs text-blue-600 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100 disabled:opacity-50 transition-colors"
+                          >
+                            {isGeneratingToken ? (
+                              <div className="w-3 h-3 border border-blue-600 border-t-transparent rounded-full animate-spin mr-1" />
+                            ) : (
+                              <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                              </svg>
+                            )}
+                            Regenerate (30 days)
+                          </button>
+                        )}
+                      </div>
+                      <input
+                        type="password"
+                        value={token}
+                        onChange={(e) => { setToken(e.target.value); setTokenIsManual(true); }}
+                        placeholder={isLoggedIn ? (isGeneratingToken ? 'Generating…' : 'Auto-generated — paste to override') : 'Paste your Hypha token'}
+                        autoComplete="new-password"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      />
+                      {tokenError && <p className="text-xs text-red-600 mt-1">{tokenError}</p>}
+                      {isLoggedIn && !tokenIsManual && token && (
+                        <p className="text-xs text-green-600 mt-1">Auto-generated 30-day admin token. Store as a Kubernetes secret for deployment.</p>
+                      )}
+                      <p className="text-xs text-gray-500 mt-1">Used to resolve workspace and populate the deployment YAML. Store in a Kubernetes secret for production.</p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Server URL</label>
+                      <input type="text" value={serverUrl} onChange={(e) => setServerUrl(e.target.value)}
+                        placeholder="https://hypha.aicell.io"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">Hypha server URL (defaults to public server)</p>
+                    </div>
+
+                    <div>
+                      <div className="flex items-center justify-between mb-1">
+                        <label className="block text-sm font-medium text-gray-700">Hypha Workspace</label>
+                        {workspaceResolved && workspace && (
+                          <span className="flex items-center text-xs text-green-600">
+                            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                            </svg>
+                            Resolved from token
+                          </span>
+                        )}
+                      </div>
+                      <input type="text" value={workspace} onChange={(e) => { setWorkspace(e.target.value); setWorkspaceResolved(false); }}
+                        placeholder="my-workspace" autoComplete="off"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">Hypha workspace for service registration (resolved from token if not set)</p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Container Image</label>
+                      <input type="text" value={customImage} onChange={(e) => setCustomImage(e.target.value)}
+                        placeholder={DEFAULT_IMAGE}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">Custom image. Leave empty for default ({DEFAULT_IMAGE})</p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Ray Client Server Port</label>
+                      <input type="number" value={clientServerPort} onChange={(e) => setClientServerPort(e.target.value)}
+                        placeholder="10001"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">Port exposed by the Ray head service</p>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Commands */}
+              <div className="space-y-4 border-t border-gray-200 pt-4">
+                <h5 className="text-sm font-semibold text-gray-700">Deploy to Kubernetes</h5>
+
+                {/* Step 1: Create secret */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <p className="text-sm text-gray-700 font-medium">1. Create Kubernetes secret</p>
+                    <button
+                      onClick={async () => {
+                        try { await navigator.clipboard.writeText(getK8sSecretCommand()); setK8sSecretCopied(true); setTimeout(() => setK8sSecretCopied(false), 2000); } catch (_) {}
+                      }}
+                      className="flex items-center px-2 py-1 text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded hover:bg-gray-200 transition-colors"
+                    >
+                      {k8sSecretCopied ? (
+                        <><svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>Copied!</>
+                      ) : (
+                        <><svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>Copy</>
+                      )}
+                    </button>
+                  </div>
+                  <div className="bg-gray-900 rounded-lg p-3 overflow-x-auto">
+                    <pre className="text-green-400 text-xs font-mono whitespace-pre">{getK8sSecretCommand()}</pre>
+                  </div>
+                  <p className="text-xs text-gray-500 mt-1">Replace <code className="bg-gray-100 px-1 rounded">&lt;your-admin-token&gt;</code> with your Hypha token (use Advanced Options → Authentication Token above to generate one).</p>
+                </div>
+
+                {/* Step 2: deployment YAML */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <p className="text-sm text-gray-700 font-medium">2. Save as <code className="bg-gray-100 px-1 rounded text-xs">bioengine-deployment.yaml</code></p>
+                    <button
+                      onClick={async () => {
+                        try { await navigator.clipboard.writeText(getKubernetesWorkerYaml()); setK8sYamlCopied(true); setTimeout(() => setK8sYamlCopied(false), 2000); } catch (_) {}
+                      }}
+                      className="flex items-center px-2 py-1 text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded hover:bg-gray-200 transition-colors"
+                    >
+                      {k8sYamlCopied ? (
+                        <><svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>Copied!</>
+                      ) : (
+                        <><svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>Copy YAML</>
+                      )}
+                    </button>
+                  </div>
+                  <div className="bg-gray-900 rounded-lg p-3">
+                    <pre className="text-green-400 text-xs font-mono overflow-x-auto max-h-72 overflow-y-auto whitespace-pre">{getKubernetesWorkerYaml()}</pre>
+                  </div>
+                </div>
+
+                {/* Step 3: apply */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <p className="text-sm text-gray-700 font-medium">3. Apply the deployment</p>
+                    <button
+                      onClick={async () => {
+                        try { await navigator.clipboard.writeText(getK8sApplyCommand()); setK8sApplyCopied(true); setTimeout(() => setK8sApplyCopied(false), 2000); } catch (_) {}
+                      }}
+                      className="flex items-center px-2 py-1 text-xs text-gray-600 bg-gray-100 border border-gray-200 rounded hover:bg-gray-200 transition-colors"
+                    >
+                      {k8sApplyCopied ? (
+                        <><svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>Copied!</>
+                      ) : (
+                        <><svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>Copy</>
+                      )}
+                    </button>
+                  </div>
+                  <div className="bg-gray-900 rounded-lg p-3">
+                    <pre className="text-green-400 text-xs font-mono whitespace-pre">{getK8sApplyCommand()}</pre>
+                  </div>
+                </div>
               </div>
             </div>
           )}
 
-          {/* System Configuration */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {/* Kubernetes basic options */}
-            {mode === 'external-cluster' && (
-              <>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">Admin Users</label>
-                  <input
-                    type="text"
-                    value={adminUsers}
-                    onChange={(e) => setAdminUsers(e.target.value)}
-                    placeholder="user1,user2 or *"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">Users who can manage the worker (use * for all)</p>
-                </div>
+          {/* ── Single-machine and SLURM settings ── */}
+          {mode !== 'external-cluster' && (
+            <div className="space-y-4">
 
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">Client ID</label>
-                  <input
-                    type="text"
-                    value={clientId}
-                    onChange={(e) => setClientId(e.target.value)}
-                    placeholder="bioengine-worker-123"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">Custom client ID (auto-generated if empty)</p>
-                </div>
-              </>
-            )}
-
-            {/* Operating System */}
-            {mode === 'single-machine' && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Operating System</label>
-                <select
-                  value={os}
-                  onChange={(e) => setOS(e.target.value as OSType)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  aria-label="Select operating system"
-                >
-                  <option value="macos">macOS</option>
-                  <option value="linux">Linux</option>
-                  <option value="windows">Windows</option>
-                </select>
-                <p className="text-xs text-gray-500 mt-1">
-                  {os === 'windows' ? 'PowerShell/Command Prompt commands' : 'Terminal commands'}
-                </p>
-              </div>
-            )}
-
-            {/* Container Runtime */}
-            {mode === 'single-machine' && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Container Runtime</label>
-                <select
-                  value={containerRuntime}
-                  onChange={(e) => setContainerRuntime(e.target.value as ContainerRuntimeType)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  aria-label="Select container runtime"
-                >
-                  <option value="docker">Docker</option>
-                  <option value="podman">Podman</option>
-                  <option value="apptainer">Apptainer</option>
-                  <option value="singularity">Singularity</option>
-                </select>
-                <p className="text-xs text-gray-500 mt-1">
-                  {containerRuntime === 'docker'
-                    ? 'Docker - Most common container runtime'
-                    : containerRuntime === 'podman'
-                      ? 'Podman - Daemonless, rootless alternative to Docker'
-                      : containerRuntime === 'apptainer'
-                        ? 'Apptainer - Modern HPC-focused container runtime, successor to Singularity'
-                        : 'Singularity - Original HPC container runtime, now superseded by Apptainer'}
-                </p>
-              </div>
-            )}
-
-            {/* Shared Memory Size */}
-            {mode === 'single-machine' && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Shared Memory Size</label>
-                <select
-                  value={shmSize}
-                  onChange={(e) => setShmSize(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  aria-label="Select shared memory size"
-                >
-                  <option value="1g">1 GB</option>
-                  <option value="2g">2 GB</option>
-                  <option value="4g">4 GB</option>
-                  <option value="6g">6 GB</option>
-                  <option value="8g">8 GB</option>
-                  <option value="10g">10 GB</option>
-                  <option value="12g">12 GB</option>
-                  <option value="14g">14 GB</option>
-                  <option value="16g">16 GB</option>
-                </select>
-                <p className="text-xs text-gray-500 mt-1">
-                  {containerRuntime} shared memory size for Ray operations and data processing, you will likely need to increase this for large models.
-                  {(containerRuntime === 'apptainer' || containerRuntime === 'singularity') ? ` (Note: ${containerRuntime} uses system shared memory)` : ''}
-                </p>
-              </div>
-            )}
-
-            {/* CPU Count - only for single-machine mode */}
-            {mode === 'single-machine' && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">CPU Cores</label>
-                <input
-                  type="number"
-                  min="1"
-                  max="32"
-                  value={cpus}
-                  onChange={(e) => setCpus(parseInt(e.target.value) || 1)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  aria-label="Number of CPU cores"
-                />
-                <p className="text-xs text-gray-500 mt-1">
-                  Number of CPU cores for the Ray head node
-                </p>
-              </div>
-            )}
-
-            {/* GPU Options - only for single-machine mode */}
-            {mode === 'single-machine' && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">GPU Support</label>
-                <div className="flex items-center space-x-4">
-                  <label className="flex items-center">
-                    <input
-                      type="checkbox"
-                      checked={hasGpu}
-                      onChange={(e) => setHasGpu(e.target.checked)}
-                      className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
-                    />
-                    <span className="ml-2 text-sm text-gray-700">Enable GPU</span>
-                  </label>
-                </div>
-                {hasGpu && (
-                  <input
-                    type="number"
-                    min="1"
-                    max="8"
-                    value={gpus}
-                    onChange={(e) => setGpus(parseInt(e.target.value) || 1)}
-                    placeholder="GPU count"
-                    className="w-full mt-2 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  />
-                )}
-                <p className="text-xs text-gray-500 mt-1">
-                  {hasGpu ? `Requires NVIDIA ${containerRuntime === 'docker' ? 'Docker runtime' : containerRuntime === 'podman' ? 'container toolkit for Podman' : `drivers for ${containerRuntime} (--nv flag)`}` : 'CPU-only mode, no GPU acceleration'}
-                </p>
-              </div>
-            )}
-
-            {/* Run as Root */}
-            {mode === 'single-machine' && (containerRuntime === 'docker' || containerRuntime === 'podman') && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Permissions</label>
-                <label className="flex items-center">
-                  <input
-                    type="checkbox"
-                    checked={runAsRoot}
-                    onChange={(e) => setRunAsRoot(e.target.checked)}
-                    className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
-                  />
-                  <span className="ml-2 text-sm text-gray-700">Run as root</span>
-                </label>
-                <p className="text-xs text-gray-500 mt-1">
-                  {runAsRoot ? "Root privileges - may be needed for some Docker setups" : "User permissions - recommended for security"}
-                </p>
-              </div>
-            )}
-
-            {/* Interactive Mode */}
-            {mode === 'single-machine' && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Execution Mode</label>
-                <label className="flex items-center">
-                  <input
-                    type="checkbox"
-                    checked={interactiveMode}
-                    onChange={(e) => setInteractiveMode(e.target.checked)}
-                    className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
-                  />
-                  <span className="ml-2 text-sm text-gray-700">Interactive mode</span>
-                </label>
-                <p className="text-xs text-gray-500 mt-1">
-                  {interactiveMode ? `Yes (separate ${containerRuntime.charAt(0).toUpperCase() + containerRuntime.slice(1)} and Python commands${containerRuntime === 'apptainer' || containerRuntime === 'singularity' ? ` with ${containerRuntime} shell` : ' with --entrypoint bash'})` : 'No (single command)'}
-                </p>
-              </div>
-            )}
-          </div>
-
-          {/* Advanced Options Toggle */}
-          <div className="border-t border-gray-200 pt-4">
-            <button
-              onClick={() => setShowAdvanced(!showAdvanced)}
-              className="flex items-center text-sm text-gray-600 hover:text-gray-800 transition-colors duration-200"
-            >
-              <svg
-                className={`w-4 h-4 mr-2 transition-transform duration-200 ${showAdvanced ? 'rotate-90' : ''}`}
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-              Advanced Options
-            </button>
-          </div>
-
-          {/* Advanced Options */}
-          {showAdvanced && (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-gray-50 rounded-lg">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Admin Users</label>
-                <input
-                  type="text"
-                  value={adminUsers}
-                  onChange={(e) => setAdminUsers(e.target.value)}
-                  placeholder="user1,user2,user3 or *"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">Users who can manage the BioEngine worker. Leave empty to use the logged-in user as admin, use * for all users, or provide comma-separated list</p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Workspace Directory</label>
-                <input
-                  type="text"
-                  value={workspaceDir}
-                  onChange={(e) => {
-                    let value = e.target.value;
-                    // Validate path format based on OS
-                    if (value) {
-                      if (os === 'windows') {
-                        // Windows: must start with C:\
-                        if (!value.startsWith('C:\\')) {
-                          if (value.startsWith('/')) {
-                            // Convert Unix-style to Windows
-                            value = 'C:' + value.replace(/\//g, '\\');
-                          } else if (!value.startsWith('C:')) {
-                            value = 'C:\\' + value;
-                          }
-                        }
-                      } else {
-                        // Unix: must start with /
-                        if (!value.startsWith('/')) {
-                          value = '/' + value;
-                        }
-                      }
-                    }
-                    setWorkspaceDir(value);
-                  }}
-                  placeholder={os === 'windows' ? 'C:\\path\\to\\workspace' : '/path/to/workspace'}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">
-                  Directory for worker workspace, temporary files, and Ray data storage. Defaults to ~/.bioengine if not specified. {os === 'windows' ? 'Windows path starting with C:\\' : 'Absolute path starting with /'}
-                </p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Client ID</label>
-                <input
-                  type="text"
-                  value={clientId}
-                  onChange={(e) => setClientId(e.target.value)}
-                  placeholder="bioengine-worker-123"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">Custom client ID for the worker. If not set, one will be generated automatically</p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Server URL</label>
-                <input
-                  type="text"
-                  value={serverUrl}
-                  onChange={(e) => setServerUrl(e.target.value)}
-                  placeholder="https://hypha.aicell.io"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">Custom Hypha server URL (defaults to public server)</p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Workspace</label>
-                <input
-                  type="text"
-                  value={workspace}
-                  onChange={(e) => setWorkspace(e.target.value)}
-                  placeholder="my-workspace"
-                  autoComplete="off"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">Hypha workspace name (optional, uses token's workspace if not set)</p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Token</label>
-                <input
-                  type="password"
-                  value={token}
-                  onChange={(e) => setToken(e.target.value)}
-                  placeholder="Enter token"
-                  autoComplete="new-password"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">Hypha authentication token (optional, will prompt for login if not set)</p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Container Image</label>
-                <input
-                  type="text"
-                  value={customImage}
-                  onChange={(e) => setCustomImage(e.target.value)}
-                  placeholder="ghcr.io/aicell-lab/bioengine-worker:0.6.11"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">Custom container image to use. Leave empty for default bioengine-worker image</p>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">Platform Override</label>
-                <select
-                  value={platformOverride}
-                  onChange={(e) => setPlatformOverride(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  aria-label="Select platform override"
-                >
-                  <option value="">Auto-detect (default)</option>
-                  <option value="linux/amd64">linux/amd64</option>
-                  <option value="linux/arm64">linux/arm64</option>
-                </select>
-                <p className="text-xs text-gray-500 mt-1">Override platform detection. Docker usually auto-detects correctly, so leave as default unless needed</p>
-              </div>
-
-              {/* External Cluster Port Configuration */}
-              {mode === 'external-cluster' && (
-                <>
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Client Server Port</label>
-                    <input
-                      type="number"
-                      min="1024"
-                      max="65535"
-                      value={clientServerPort}
-                      onChange={(e) => setClientServerPort(e.target.value)}
-                      placeholder="10001"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <p className="text-xs text-gray-500 mt-1">Port for Ray client server (default: 10001)</p>
+              {/* Authentication Required warning when no token */}
+              {!token && (
+                <div className="p-4 bg-amber-50 rounded-xl border border-amber-200">
+                  <div className="flex items-start">
+                    <svg className="w-5 h-5 text-amber-600 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                    </svg>
+                    <div className="text-sm text-amber-800">
+                      <p className="font-medium mb-1">🔐 Important: Authentication Required</p>
+                      <div className="text-amber-700 space-y-1">
+                        {isLoggedIn ? (
+                          <p>Generating your authentication token… or set one manually in <strong>Advanced Options → Authentication Token</strong>.</p>
+                        ) : (
+                          <>
+                            <p>An authentication token is required. Either:</p>
+                            <ol className="list-decimal list-inside space-y-1 ml-2 text-xs">
+                              <li><strong>Log in</strong> to auto-generate a 30-day admin token, or</li>
+                              <li>Set a token manually in <strong>Advanced Options → Authentication Token</strong></li>
+                            </ol>
+                            <p className="text-xs italic mt-1">Manually provided tokens must have <strong>Permission Level: Admin</strong>.</p>
+                          </>
+                        )}
+                      </div>
+                    </div>
                   </div>
+                </div>
+              )}
 
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-2">Serve Port</label>
-                    <input
-                      type="number"
-                      min="1024"
-                      max="65535"
-                      value={servePort}
-                      onChange={(e) => setServePort(e.target.value)}
-                      placeholder="8000"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    />
-                    <p className="text-xs text-gray-500 mt-1">Port for Ray Serve (default: 8000)</p>
+              {/* Runtime / compute settings */}
+              {mode === 'single-machine' && (
+                <div className="p-4 bg-gray-50 rounded-xl border border-gray-200">
+                  <h5 className="text-sm font-semibold text-gray-700 mb-3">Container & Compute</h5>
+                  <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Operating System</label>
+                      <select value={os} onChange={(e) => setOS(e.target.value as OSType)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                        <option value="macos">macOS</option>
+                        <option value="linux">Linux</option>
+                        <option value="windows">Windows</option>
+                      </select>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Container Runtime</label>
+                      <select value={containerRuntime} onChange={(e) => setContainerRuntime(e.target.value as ContainerRuntimeType)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                        <option value="docker">Docker</option>
+                        <option value="podman">Podman</option>
+                        <option value="apptainer">Apptainer</option>
+                        <option value="singularity">Singularity</option>
+                      </select>
+                      <p className="text-xs text-gray-500 mt-1">
+                        {containerRuntime === 'docker' ? 'Most common runtime'
+                          : containerRuntime === 'podman' ? 'Rootless Docker alternative'
+                          : containerRuntime === 'apptainer' ? 'HPC runtime (Singularity successor)'
+                          : 'Original HPC runtime'}
+                      </p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Shared Memory Size</label>
+                      <select value={shmSize} onChange={(e) => setShmSize(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                        {['1g','2g','4g','6g','8g','10g','12g','16g'].map(v => (
+                          <option key={v} value={v}>{v.replace('g', ' GB')}</option>
+                        ))}
+                      </select>
+                      <p className="text-xs text-gray-500 mt-1">Increase for large models{(containerRuntime === 'apptainer' || containerRuntime === 'singularity') ? ' (uses system shm)' : ''}</p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">CPU Cores</label>
+                      <input type="number" min="1" max="64" value={cpus}
+                        onChange={(e) => setCpus(parseInt(e.target.value) || 1)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">CPUs allocated to Ray head node</p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">GPUs</label>
+                      <input type="number" min="0" max="16" value={gpus}
+                        onChange={(e) => setGpus(parseInt(e.target.value) || 0)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">
+                        {gpus > 0 ? `Requires NVIDIA ${containerRuntime === 'docker' ? 'Docker runtime' : containerRuntime === 'podman' ? 'container toolkit' : `drivers (--nv flag)`}` : 'Set to 0 for CPU-only mode'}
+                      </p>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Memory (GB)</label>
+                      <input type="number" min="0" max="512" value={memory}
+                        onChange={(e) => setMemory(parseInt(e.target.value) || 0)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">RAM for Ray head node in GB (0 = auto-detect)</p>
+                    </div>
                   </div>
-                </>
+                </div>
               )}
             </div>
           )}
 
-          {/* Kubernetes Deployment YAML - Only for Kubernetes mode */}
-          {mode === 'external-cluster' && (
-            <div className="p-4 bg-blue-50 rounded-xl border border-blue-200">
-              <h5 className="text-sm font-medium text-blue-800 mb-3 flex items-center">
-                <span className="w-5 h-5 bg-blue-600 text-white rounded-full flex items-center justify-center text-xs mr-2">3</span>
-                Deploy BioEngine Worker on Kubernetes
-              </h5>
-              <p className="text-sm text-blue-700 mb-3">
-                Deploy BioEngine as a Kubernetes Deployment alongside your Ray cluster. Configure options above then copy the generated YAML:
-              </p>
-              <div className="bg-gray-900 rounded-lg p-3 relative">
-                <button
-                  onClick={async () => {
-                    // Build optional args
-                    let optionalArgs = '';
-                    if (serverUrl) {
-                      optionalArgs += `        - "--server-url"\n        - "${serverUrl}"\n`;
-                    }
-                    if (workspace) {
-                      optionalArgs += `        - "--workspace"\n        - "${workspace}"\n`;
-                    }
-                    if (token) {
-                      optionalArgs += `        - "--token"\n        - "${token}"\n`;
-                    }
-                    if (adminUsers) {
-                      optionalArgs += `        - "--admin-users"\n        - "${adminUsers}"\n`;
-                    }
-                    if (clientId) {
-                      optionalArgs += `        - "--client-id"\n        - "${clientId}"\n`;
-                    }
-
-                    const yaml = `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: bioengine-worker
-  labels:
-    app: bioengine-worker
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: bioengine-worker
-  template:
-    metadata:
-      labels:
-        app: bioengine-worker
-    spec:
-      containers:
-      - name: bioengine-worker
-        image: ghcr.io/aicell-lab/bioengine-worker:0.6.11
-        args:
-        - "python"
-        - "-m"
-        - "bioengine.worker"
-        - "--mode"
-        - "external-cluster"
-        - "--connection-address"
-        - "${rayAddress || 'ray://raycluster-head-svc:10001'}"
-${optionalArgs}        resources:
-          requests:
-            memory: "2Gi"
-            cpu: "1"
-          limits:
-            memory: "4Gi"
-            cpu: "2"
-        volumeMounts:
-        - name: bioengine-cache
-          mountPath: /.bioengine
-      volumes:
-      - name: bioengine-cache
-        persistentVolumeClaim:
-          claimName: bioengine-cache-pvc
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: bioengine-cache-pvc
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 10Gi`;
-                    try {
-                      await navigator.clipboard.writeText(yaml);
-                    } catch (err) {
-                      console.error('Failed to copy:', err);
-                    }
-                  }}
-                  className="absolute top-2 right-2 px-2 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded transition-colors duration-200"
-                >
-                  Copy YAML
-                </button>
-                <pre className="text-green-400 text-xs font-mono overflow-x-auto max-h-48 overflow-y-auto">
-{`apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: bioengine-worker
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: bioengine-worker
-  template:
-    spec:
-      containers:
-      - name: bioengine-worker
-        image: ghcr.io/aicell-lab/bioengine-worker:0.6.11
-        args:
-        - "python"
-        - "-m"
-        - "bioengine.worker"
-        - "--mode"
-        - "external-cluster"
-        - "--connection-address"
-        - "${rayAddress || 'ray://raycluster-head-svc:10001'}"${serverUrl ? `
-        - "--server-url"
-        - "${serverUrl}"` : ''}${workspace ? `
-        - "--workspace"
-        - "${workspace}"` : ''}${token ? `
-        - "--token"
-        - "${token}"` : ''}${adminUsers ? `
-        - "--admin-users"
-        - "${adminUsers}"` : ''}${clientId ? `
-        - "--client-id"
-        - "${clientId}"` : ''}
-        volumeMounts:
-        - name: bioengine-cache
-          mountPath: /.bioengine
-      volumes:
-      - name: bioengine-cache
-        persistentVolumeClaim:
-          claimName: bioengine-cache-pvc`}
-                </pre>
-              </div>
-              <p className="text-xs text-blue-700 mt-2">
-                Save this as <code className="bg-blue-100 px-1 rounded">bioengine-deployment.yaml</code> and apply with: <code className="bg-blue-100 px-1 rounded">kubectl apply -f bioengine-deployment.yaml</code>
-              </p>
-            </div>
-          )}
-
-          {/* Generated Command - Hidden for Kubernetes mode */}
+          {/* ── Advanced options ── */}
           {mode !== 'external-cluster' && (
-          <div className="bg-gray-900 rounded-xl p-4 relative">
-            <div className="flex justify-between items-start mb-2">
-              <h4 className="text-sm font-medium text-gray-300">
-                {mode === 'slurm'
-                  ? 'SLURM Cluster Command:'
-                  : os === 'windows'
-                    ? 'PowerShell/Command Prompt Command:'
-                    : 'Terminal Command:'
-                }
-              </h4>
+            <div className="border-t border-gray-200 pt-4">
               <button
-                onClick={copyToClipboard}
-                className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded-lg transition-colors duration-200 flex items-center"
+                onClick={() => setShowAdvanced(!showAdvanced)}
+                className="flex items-center text-sm text-gray-600 hover:text-gray-800 transition-colors"
               >
-                {copied ? (
-                  <>
-                    <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                    </svg>
-                    Copied!
-                  </>
-                ) : (
-                  <>
-                    <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                    </svg>
-                    Copy
-                  </>
-                )}
+                <svg className={`w-4 h-4 mr-2 transition-transform ${showAdvanced ? 'rotate-90' : ''}`}
+                  fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+                Advanced Options
               </button>
+
+              {showAdvanced && (
+                <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4 p-4 bg-gray-50 rounded-lg">
+
+                  {/* ── Worker identity ── */}
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Admin Users</label>
+                    <input type="text" value={adminUsers} onChange={(e) => setAdminUsers(e.target.value)}
+                      placeholder="user1@example.com,user2@example.com or *"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    <p className="text-xs text-gray-500 mt-1">Users who can manage the worker. Leave empty to use the logged-in user</p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Worker Name</label>
+                    <input type="text" value={workerName} onChange={(e) => setWorkerName(e.target.value)}
+                      placeholder="BioEngine Worker"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    <p className="text-xs text-gray-500 mt-1">Display name for this worker in the Hypha service registry</p>
+                  </div>
+
+                  {/* ── BioEngine data directory ── */}
+                  <div className="md:col-span-2">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">BioEngine Workspace Directory</label>
+                    <input type="text" value={workspaceDir}
+                      onChange={(e) => setWorkspaceDir(e.target.value)}
+                      placeholder={os === 'windows' ? '%USERPROFILE%\\.bioengine' : '~/.bioengine'}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    <p className="text-xs text-gray-500 mt-1">
+                      Directory for BioEngine apps, logs and ray cluster temporary files. Defaults to ~/.bioengine.
+                    </p>
+                  </div>
+
+                  {/* ── Hypha connection ── */}
+                  <div className="md:col-span-2">
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="block text-sm font-medium text-gray-700">
+                        Authentication Token
+                      </label>
+                      {isLoggedIn && (
+                        <button
+                          type="button"
+                          onClick={() => { setTokenIsManual(false); generateToken(); }}
+                          disabled={isGeneratingToken}
+                          className="flex items-center px-2 py-1 text-xs text-blue-600 bg-blue-50 border border-blue-200 rounded hover:bg-blue-100 disabled:opacity-50 transition-colors"
+                        >
+                          {isGeneratingToken ? (
+                            <div className="w-3 h-3 border border-blue-600 border-t-transparent rounded-full animate-spin mr-1" />
+                          ) : (
+                            <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                            </svg>
+                          )}
+                          Regenerate (30 days)
+                        </button>
+                      )}
+                    </div>
+                    <input
+                      type="password"
+                      value={token}
+                      onChange={(e) => { setToken(e.target.value); setTokenIsManual(true); }}
+                      placeholder={isLoggedIn ? (isGeneratingToken ? 'Generating…' : 'Auto-generated — paste to override') : 'Paste your Hypha token'}
+                      autoComplete="new-password"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    />
+                    {tokenError && <p className="text-xs text-red-600 mt-1">{tokenError}</p>}
+                    {isLoggedIn && !tokenIsManual && token && (
+                      <p className="text-xs text-green-600 mt-1">Auto-generated 30-day admin token.</p>
+                    )}
+                    <p className="text-xs text-gray-500 mt-1">
+                      Required. Manually provided tokens must have <strong>Permission Level: Admin</strong>.
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Server URL</label>
+                    <input type="text" value={serverUrl} onChange={(e) => setServerUrl(e.target.value)}
+                      placeholder="https://hypha.aicell.io"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    <p className="text-xs text-gray-500 mt-1">Hypha server URL (defaults to public server)</p>
+                  </div>
+
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="block text-sm font-medium text-gray-700">Hypha Workspace</label>
+                      {workspaceResolved && workspace && (
+                        <span className="flex items-center text-xs text-green-600">
+                          <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                          </svg>
+                          Resolved from token
+                        </span>
+                      )}
+                    </div>
+                    <input type="text" value={workspace} onChange={(e) => { setWorkspace(e.target.value); setWorkspaceResolved(false); }}
+                      placeholder="my-workspace" autoComplete="off"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    <p className="text-xs text-gray-500 mt-1">Hypha workspace name for service registration (uses token's workspace if not set)</p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">Client ID</label>
+                    <input type="text" value={clientId} onChange={(e) => setClientId(e.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                    <p className="text-xs text-gray-500 mt-1">Custom client ID (auto-generated if empty)</p>
+                  </div>
+
+                  {/* ── GPU indices ── */}
+                  {mode === 'single-machine' && gpus > 0 && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">GPU Indices</label>
+                      <input type="text" value={gpuIndices} onChange={(e) => setGpuIndices(e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                      <p className="text-xs text-gray-500 mt-1">CUDA_VISIBLE_DEVICES — comma-separated GPU indices (e.g. 0,1). Leave empty to use all GPUs</p>
+                    </div>
+                  )}
+
+                  {/* ── Container / runtime ── */}
+                  {mode === 'single-machine' && (
+                    <>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Container Image</label>
+                        <input type="text" value={customImage} onChange={(e) => setCustomImage(e.target.value)}
+                          placeholder={DEFAULT_IMAGE}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                        <p className="text-xs text-gray-500 mt-1">Custom image. Leave empty for default ({DEFAULT_IMAGE})</p>
+                      </div>
+
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Platform Override</label>
+                        <select value={platformOverride} onChange={(e) => setPlatformOverride(e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500">
+                          <option value="">Auto-detect (default)</option>
+                          <option value="linux/amd64">linux/amd64</option>
+                          <option value="linux/arm64">linux/arm64</option>
+                        </select>
+                        <p className="text-xs text-gray-500 mt-1">Override platform only if auto-detection is wrong</p>
+                      </div>
+                    </>
+                  )}
+
+                  {mode === 'external-cluster' && (
+                    <>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Client Server Port</label>
+                        <input type="number" min="1024" max="65535" value={clientServerPort}
+                          onChange={(e) => setClientServerPort(e.target.value)} placeholder="10001"
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                        <p className="text-xs text-gray-500 mt-1">Port for Ray client server (default: 10001)</p>
+                      </div>
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">Serve Port</label>
+                        <input type="number" min="1024" max="65535" value={servePort}
+                          onChange={(e) => setServePort(e.target.value)} placeholder="8000"
+                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                        <p className="text-xs text-gray-500 mt-1">Port for Ray Serve (default: 8000)</p>
+                      </div>
+                    </>
+                  )}
+
+                  {/* ── Permissions — last ── */}
+                  {mode === 'single-machine' && (containerRuntime === 'docker' || containerRuntime === 'podman') && (
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 mb-1">Permissions</label>
+                      <label className="flex items-center mt-2">
+                        <input type="checkbox" checked={runAsRoot} onChange={(e) => setRunAsRoot(e.target.checked)}
+                          className="w-4 h-4 text-blue-600 border-gray-300 rounded" />
+                        <span className="ml-2 text-sm text-gray-700">Run as root</span>
+                      </label>
+                      <p className="text-xs text-gray-500 mt-1">
+                        {runAsRoot ? 'Root – may be required for some Docker setups' : 'User permissions – recommended for security'}
+                      </p>
+                    </div>
+                  )}
+
+                </div>
+              )}
             </div>
-            <code className="text-green-400 text-sm font-mono break-all whitespace-pre-wrap">
-              {(() => {
-                const command = getCommand();
-                let commandText = '';
-
-                if (typeof command === 'string') {
-                  // SLURM mode - simple string
-                  commandText = command;
-                } else if (command.pythonCmd) {
-                  // Interactive mode
-                  const containerName = containerRuntime.charAt(0).toUpperCase() + containerRuntime.slice(1);
-                  commandText = `# Step 1: Create directories\n${command.createDirCmd}\n\n# Step 2: Start ${containerName} container\n${command.dockerCmd}\n\n# Step 3: Inside the container, run:\n${command.pythonCmd}`;
-                } else {
-                  // Single command mode
-                  const containerName = containerRuntime.charAt(0).toUpperCase() + containerRuntime.slice(1);
-                  commandText = `# Step 1: Create directories\n${command.createDirCmd}\n\n# Step 2: Run ${containerName} container\n${command.dockerCmd}`;
-                }
-
-                // Add volume mount information
-                if (mode !== 'slurm') {
-                  let mountInfo = '\n\n# Volume mounts:';
-
-                  if (workspaceDir) {
-                    mountInfo += `\n# - ${workspaceDir} → /.bioengine (workspace)`;
-                  } else {
-                    const hostPath = os === 'windows'
-                      ? (runAsRoot ? 'C:\\.bioengine' : '%USERPROFILE%\\.bioengine')
-                      : '$HOME/.bioengine';
-                    mountInfo += `\n# - ${hostPath} → /.bioengine (workspace)`;
-                  }
-
-                  commandText += mountInfo;
-                }
-
-                return commandText;
-              })()}
-            </code>
-          </div>
           )}
 
-          {/* SLURM-specific information */}
+          {/* ── Generated command ── */}
+          {mode !== 'external-cluster' && (
+            <div className="bg-gray-900 rounded-xl p-4 relative">
+              <div className="flex justify-between items-start mb-2">
+                <h4 className="text-sm font-medium text-gray-300">
+                  {mode === 'slurm' ? 'SLURM Cluster Command:' : os === 'windows' ? 'PowerShell/Command Prompt Command:' : 'Terminal Command:'}
+                </h4>
+                <button onClick={copyToClipboard}
+                  className="px-3 py-1 bg-blue-600 hover:bg-blue-700 text-white text-xs rounded-lg flex items-center">
+                  {copied ? (
+                    <><svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>Copied!</>
+                  ) : (
+                    <><svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>Copy</>
+                  )}
+                </button>
+              </div>
+              <code className="text-green-400 text-sm font-mono break-all whitespace-pre-wrap">
+                {(() => {
+                  const command = getCommand();
+                  if (typeof command === 'string') return command;
+                  const containerName = containerRuntime.charAt(0).toUpperCase() + containerRuntime.slice(1);
+                  const text = `# Step 1: Create directories\n${command.createDirCmd}\n\n# Step 2: Run ${containerName} container\n${command.dockerCmd}`;
+                  return text;
+                })()}
+              </code>
+            </div>
+          )}
+
+
+          {/* ── SLURM info ── */}
           {mode === 'slurm' && (
             <div className="p-4 bg-purple-50 rounded-xl border border-purple-200">
               <div className="flex items-start">
@@ -1358,22 +1157,15 @@ spec:
                 </svg>
                 <div className="text-sm text-purple-800">
                   <p className="font-medium mb-2">🖥️ SLURM Cluster Mode</p>
-                  <div className="text-purple-700 space-y-2">
-                    <p>The start_worker.sh script will automatically:</p>
-                    <ul className="list-disc list-inside space-y-1 ml-2">
-                      <li>Download and set up the BioEngine worker container using Singularity/Apptainer</li>
-                      <li>Submit SLURM jobs to manage Ray cluster nodes</li>
-                      <li>Handle container image caching and shared filesystem setup</li>
-                      <li>Configure network communication between cluster nodes</li>
-                      <li>Monitor and manage worker node lifecycle</li>
-                    </ul>
-                    <div className="mt-3 p-3 bg-purple-100 rounded-lg">
-                      <p className="font-medium text-purple-900 mb-1">💡 Pro Tips:</p>
+                  <div className="text-purple-700 space-y-1">
+                    <p>The script automatically downloads the BioEngine worker, submits SLURM jobs for Ray nodes, handles container caching, and manages the worker lifecycle.</p>
+                    <div className="mt-2 p-3 bg-purple-100 rounded-lg">
+                      <p className="font-medium text-purple-900 mb-1">💡 Tips:</p>
                       <ul className="list-disc list-inside space-y-1 text-purple-800 text-xs">
-                        <li>Run this command from a login node with SLURM access</li>
-                        <li>Ensure your SLURM account has sufficient allocation</li>
-                        <li>The script supports additional SLURM-specific arguments (check the script source for details)</li>
-                        <li>Monitor your jobs with <code className="bg-purple-200 px-1 rounded">squeue -u $USER</code></li>
+                        <li>Run from a login node with SLURM access</li>
+                        <li>Ensure your account has sufficient allocation</li>
+                        <li>Monitor jobs: <code className="bg-purple-200 px-1 rounded">squeue -u $USER</code></li>
+                        <li>Singularity/Apptainer must be available on compute nodes</li>
                       </ul>
                     </div>
                   </div>
@@ -1382,93 +1174,106 @@ spec:
             </div>
           )}
 
-          {/* Login Instructions - Hidden for Kubernetes mode */}
+          {/* ── Prerequisites ── */}
           {mode !== 'external-cluster' && (
-          <div className="p-4 bg-amber-50 rounded-xl border border-amber-200">
-            <div className="flex items-start">
-              <svg className="w-5 h-5 text-amber-600 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z" />
-              </svg>
-              <div className="text-sm text-amber-800">
-                <p className="font-medium mb-2">🔐 Important: Authentication Required</p>
-                <div className="text-amber-700 space-y-2">
-                  <p>After running the command above, you'll see output in your terminal. Look for a line that says:</p>
-                  <div className="bg-amber-100 border border-amber-300 rounded p-2 font-mono text-xs">
-                    Please open your browser and login at https://hypha.aicell.io/public/apps/hypha-login/?key=...
-                  </div>
-                  <div className="space-y-1">
-                    <p className="font-medium">Follow these steps:</p>
-                    <ol className="list-decimal list-inside space-y-1 ml-2">
-                      <li>Copy the complete URL from your terminal output</li>
-                      <li>Open the URL in your web browser</li>
-                      <li>Login using Google, GitHub, or another supported provider</li>
-                      <li>Return to your terminal - the BioEngine worker will continue automatically</li>
-                    </ol>
-                  </div>
-                  <p className="text-xs italic">
-                    💡 This one-time login creates your workspace and authenticates your BioEngine worker.
-                  </p>
+            <div className="p-4 bg-blue-50 rounded-xl border border-blue-200">
+              <div className="flex items-start">
+                <svg className="w-5 h-5 text-blue-600 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div className="text-sm text-blue-800">
+                  <p className="font-medium mb-1">Prerequisites:</p>
+                  <ul className="list-disc list-inside space-y-1 text-blue-700">
+                    {mode === 'slurm' ? (
+                      <>
+                        <li>SLURM cluster access with sbatch/squeue/scancel</li>
+                        <li>Singularity/Apptainer on compute nodes</li>
+                        <li>Network access from compute nodes to pull container images</li>
+                        <li>Shared filesystem accessible from all nodes</li>
+                      </>
+                    ) : (
+                      <>
+                        <li>{containerRuntime.charAt(0).toUpperCase() + containerRuntime.slice(1)} installed and running</li>
+                        {gpus > 0 && <li>NVIDIA {containerRuntime === 'docker' ? 'Docker runtime' : containerRuntime === 'podman' ? 'container toolkit' : 'drivers'} for GPU support</li>}
+                      </>
+                    )}
+                    <li>A BioEngine data directory will be created at <code className="bg-blue-100 px-1 rounded">~/.bioengine</code> (or custom path) and mounted into the container</li>
+                    <li>After starting, connect using the service ID printed in the terminal</li>
+                  </ul>
                 </div>
               </div>
             </div>
-          </div>
           )}
 
-          {/* Additional Info - Hidden for Kubernetes mode */}
+          {/* ── Troubleshooting ── */}
           {mode !== 'external-cluster' && (
-          <div className="p-4 bg-blue-50 rounded-xl border border-blue-200">
-            <div className="flex items-start">
-              <svg className="w-5 h-5 text-blue-600 mr-2 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <div className="text-sm text-blue-800">
-                <p className="font-medium mb-1">Prerequisites & Notes:</p>
-                <ul className="list-disc list-inside space-y-1 text-blue-700">
-                  {mode === 'slurm' ? (
-                    <>
-                      <li>Access to a SLURM cluster with proper permissions</li>
-                      <li>SLURM commands (sbatch, squeue, scancel) available in your PATH</li>
-                      <li>Singularity/Apptainer container runtime on the cluster</li>
-                      <li>Network access from compute nodes to download the container image</li>
-                      <li>Shared filesystem accessible from all compute nodes</li>
-                    </>
-                  ) : (
-                    <>
-                      <li>{containerRuntime.charAt(0).toUpperCase() + containerRuntime.slice(1)} must be installed and running{(containerRuntime === 'apptainer' || containerRuntime === 'singularity') ? ' (or available on your system)' : ''}</li>
-                      {mode === 'single-machine' && hasGpu && <li>NVIDIA {containerRuntime === 'docker' ? 'Docker runtime' : containerRuntime === 'podman' ? 'container toolkit' : 'drivers'} required for GPU support</li>}
-                    </>
-                  )}
-                  {interactiveMode && mode !== 'slurm' && <li>Interactive mode: Run the {containerRuntime} command first, then execute the Python command inside the container</li>}
-                  {interactiveMode && mode === 'slurm' && <li>Interactive mode: You can inspect the script before running it</li>}
-                  <li>A directory will be created in your home directory for workspace storage and mounted to /.bioengine in the container</li>
-                  <li>You'll need to authenticate via browser when prompted (see authentication section above)</li>
-                  <li>After running, the worker will be available at the service ID shown in the terminal</li>
-                  <li>Use the service ID to connect to your BioEngine worker from this interface</li>
-                  {mode === 'slurm' && <li>The script will automatically handle SLURM job submission and container management</li>}
-                </ul>
-              </div>
+            <div className="flex justify-center pt-4 border-t border-gray-200">
+              <button onClick={() => setShowTroubleshooting(true)}
+                className="flex items-center px-4 py-2 text-sm text-orange-600 bg-orange-50 border border-orange-200 rounded-lg hover:bg-orange-100 transition-colors">
+                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                Need Help? Get AI Troubleshooting Prompt
+              </button>
             </div>
-          </div>
-          )}
-
-          {/* Troubleshooting Button - Hidden for Kubernetes mode */}
-          {mode !== 'external-cluster' && (
-          <div className="flex justify-center pt-4 border-t border-gray-200">
-            <button
-              onClick={() => setShowTroubleshooting(true)}
-              className="flex items-center px-4 py-2 text-sm text-orange-600 bg-orange-50 border border-orange-200 rounded-lg hover:bg-orange-100 hover:border-orange-300 transition-colors duration-200"
-            >
-              <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              Need Help? Get AI Troubleshooting Prompt
-            </button>
-          </div>
           )}
         </div>
       )}
 
-      {/* Troubleshooting Dialog */}
+      {/* ── Ray workspace dir explanation dialog ── */}
+      {showRayWorkspaceDirDialog && (
+        <>
+          {/* Click-away backdrop */}
+          <div
+            onClick={() => setShowRayWorkspaceDirDialog(false)}
+            style={{ position: 'fixed', inset: 0, zIndex: 998 }}
+          />
+          {/* Dialog centered in viewport */}
+          <div style={{
+            position: 'fixed',
+            top: '50vh',
+            left: '50vw',
+            transform: 'translate(-50%, -50%)',
+            zIndex: 999,
+            width: 'min(640px, 90vw)',
+            maxHeight: '80vh',
+            overflowY: 'auto',
+          }} className="bg-white rounded-2xl shadow-2xl border border-gray-200">
+            <div className="p-5 border-b border-gray-200 flex justify-between items-center">
+              <h3 className="text-base font-semibold text-gray-800">Ray Workspace Directory — Why It Matters</h3>
+              <button onClick={() => setShowRayWorkspaceDirDialog(false)}
+                className="text-gray-400 hover:text-gray-600 p-1.5 rounded-lg hover:bg-gray-100">
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="p-5 space-y-4 text-sm text-gray-700">
+              <p>
+                The BioEngine worker runs in its own pod and writes to the <strong>BioEngine Workspace Directory</strong> (e.g. <code className="bg-gray-100 px-1 rounded">/home/bioengine</code>). This is the same directory configured with <code className="bg-gray-100 px-1 rounded">--workspace-dir</code> in single-machine mode.
+              </p>
+              <p>
+                In Kubernetes mode the actual BioEngine apps execute on <strong>Ray cluster nodes</strong>, not inside the worker pod. Those nodes need their own writable directory, set with <code className="bg-gray-100 px-1 rounded">--ray-workspace-dir</code>. If this flag is not set, the worker falls back to the same path as <code className="bg-gray-100 px-1 rounded">--workspace-dir</code> — which only works if the Ray nodes can also reach that path.
+              </p>
+              <div className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                <p className="font-medium text-amber-800 mb-1">Impact on scaling</p>
+                <p className="text-amber-700">
+                  Some apps, like <code className="bg-amber-100 px-1 rounded">bioimage-io/model-runner</code>, communicate between the worker and Ray nodes through the filesystem. Without a shared <strong>ReadWriteMany</strong> PVC mounted at the same path on all Ray nodes, running more than one app replica will result in reduced functionality — only the replica on the node that holds the file will work correctly.
+                </p>
+              </div>
+              <p>
+                <strong>Recommended setup:</strong> mount a ReadWriteMany PVC (e.g. NFS, <code className="bg-gray-100 px-1 rounded">ontap-nas</code>) at <code className="bg-gray-100 px-1 rounded">/home/bioengine</code> on all Ray head and worker nodes, and set <code className="bg-gray-100 px-1 rounded">--ray-workspace-dir /home/bioengine</code>.
+              </p>
+            </div>
+            <div className="p-4 border-t border-gray-200 flex justify-end">
+              <button onClick={() => setShowRayWorkspaceDirDialog(false)}
+                className="px-5 py-2 bg-gray-600 text-white text-sm rounded-lg hover:bg-gray-700">Close</button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* ── Troubleshooting dialog ── */}
       {showTroubleshooting && (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
           <div ref={troubleshootingDialogRef} className="bg-white rounded-2xl shadow-lg max-w-4xl w-full max-h-[90vh] flex flex-col">
@@ -1484,72 +1289,34 @@ spec:
                   <p className="text-sm text-gray-600">Copy this prompt to ChatGPT, Claude, Gemini, or your favorite LLM</p>
                 </div>
               </div>
-              <button
-                onClick={() => setShowTroubleshooting(false)}
-                className="text-gray-400 hover:text-gray-600 p-2 rounded-xl hover:bg-gray-100 transition-all duration-200"
-                aria-label="Close dialog"
-              >
+              <button onClick={() => setShowTroubleshooting(false)}
+                className="text-gray-400 hover:text-gray-600 p-2 rounded-xl hover:bg-gray-100">
                 <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
                 </svg>
               </button>
             </div>
-
             <div className="flex-1 p-6 overflow-hidden flex flex-col">
-              <div className="mb-4">
-                <div className="flex justify-between items-center mb-2">
-                  <h4 className="text-sm font-medium text-gray-700">Comprehensive Troubleshooting Prompt</h4>
-                  <button
-                    onClick={copyTroubleshootingPrompt}
-                    className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-lg transition-colors duration-200 flex items-center"
-                  >
-                    {promptCopied ? (
-                      <>
-                        <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                        </svg>
-                        Copied!
-                      </>
-                    ) : (
-                      <>
-                        <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
-                        </svg>
-                        Copy Prompt
-                      </>
-                    )}
-                  </button>
-                </div>
-                <p className="text-xs text-gray-500 mb-4">
-                  This prompt includes your current configuration, the complete BioEngine help documentation,
-                  troubleshooting guidelines, and context about what you're trying to achieve.
-                  Just add your specific question or error message at the end.
-                </p>
+              <div className="mb-4 flex justify-between items-center">
+                <h4 className="text-sm font-medium text-gray-700">Troubleshooting Prompt</h4>
+                <button onClick={copyTroubleshootingPrompt}
+                  className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded-lg flex items-center">
+                  {promptCopied ? (
+                    <><svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" /></svg>Copied!</>
+                  ) : (
+                    <><svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" /></svg>Copy Prompt</>
+                  )}
+                </button>
               </div>
-
               <div className="flex-1 overflow-auto">
                 <pre className="text-xs text-gray-700 bg-gray-50 p-4 rounded-lg border whitespace-pre-wrap font-mono leading-relaxed">
                   {getTroubleshootingPrompt()}
                 </pre>
               </div>
-
-              <div className="p-6 border-t border-gray-200 bg-gray-50 flex justify-between items-center">
-                <div className="text-sm text-gray-600">
-                  <p className="font-medium mb-1">How to use:</p>
-                  <ol className="list-decimal list-inside space-y-1 text-xs">
-                    <li>Copy the prompt above</li>
-                    <li>Paste it into ChatGPT, Claude, Gemini, or your preferred AI assistant</li>
-                    <li>Add your specific question or error message at the end</li>
-                    <li>Get detailed, context-aware troubleshooting help</li>
-                  </ol>
-                </div>
-                <button
-                  onClick={() => setShowTroubleshooting(false)}
-                  className="px-6 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors duration-200"
-                >
-                  Close
-                </button>
-              </div>
+            </div>
+            <div className="p-4 border-t border-gray-200 flex justify-end">
+              <button onClick={() => setShowTroubleshooting(false)}
+                className="px-6 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700">Close</button>
             </div>
           </div>
         </div>

--- a/src/components/bioengine/BioEngineHome.tsx
+++ b/src/components/bioengine/BioEngineHome.tsx
@@ -1,26 +1,37 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useHyphaStore } from '../../store/hyphaStore';
 import BioEngineGuide from './BioEngineGuide';
+
+const STORAGE_KEY = 'bioengine-observed-workspaces';
+const DEFAULT_PUBLIC_WORKSPACE = 'bioimage-io';
 
 type BioEngineService = {
   id: string;
   name: string;
   description: string;
-  service?: any;
 };
 
-// Helper function to compare arrays
-const arraysEqual = (a: string[], b: string[]): boolean => {
-  if (a.length !== b.length) return false;
-  return a.every((val, index) => val === b[index]);
+type WorkspaceStatus = 'loading' | 'loaded' | 'error';
+
+// Extract full service IDs from the "Multiple services found" error message
+const parseMultipleServicesFromError = (errStr: string): string[] => {
+  const regex = /services:public\|bioengine-worker:([^@']+)@\*/g;
+  const ids: string[] = [];
+  let match;
+  while ((match = regex.exec(errStr)) !== null) {
+    if (!ids.includes(match[1])) ids.push(match[1]);
+  }
+  return ids;
 };
 
-// ServiceCard component for fancy instance cards
+const FEATURED_SERVICE_NAME = 'BioImage.IO BioEngine Worker';
+
 const ServiceCard: React.FC<{
   service: BioEngineService;
   onNavigate: (serviceId: string) => void;
-}> = ({ service, onNavigate }) => {
+  featured?: boolean;
+}> = ({ service, onNavigate, featured }) => {
   const [copied, setCopied] = useState(false);
 
   const copyServiceId = async () => {
@@ -34,20 +45,28 @@ const ServiceCard: React.FC<{
   };
 
   return (
-    <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-white/20 flex flex-col h-full hover:shadow-md transition-all duration-200 hover:border-blue-200">
+    <div className={`backdrop-blur-sm rounded-2xl flex flex-col h-full transition-all duration-200 ${
+      featured
+        ? 'bg-gradient-to-br from-blue-50 to-purple-50 border-2 border-blue-300 shadow-md hover:shadow-lg hover:border-blue-400'
+        : 'bg-white/80 border border-white/20 shadow-sm hover:shadow-md hover:border-blue-200'
+    }`}>
       <div className="p-6 flex-grow">
         <div className="flex items-center mb-4">
-          <div className="w-10 h-10 bg-white rounded-xl flex items-center justify-center mr-3 p-1">
+          <div className={`w-10 h-10 rounded-xl flex items-center justify-center mr-3 p-1 ${featured ? 'bg-white shadow-sm' : 'bg-white'}`}>
             <img src="/bioengine-icon.svg" alt="BioEngine" className="w-8 h-8" />
           </div>
           <div className="flex-1">
             <h3 className="text-xl font-semibold text-gray-800">{service.name}</h3>
+            {featured && (
+              <span className="inline-flex items-center mt-1 px-2 py-0.5 bg-blue-100 text-blue-700 text-xs font-medium rounded-full">
+                ⚡ Powers this website
+              </span>
+            )}
           </div>
         </div>
 
         <p className="text-gray-600 mb-4 leading-relaxed">{service.description || 'No description available'}</p>
 
-        {/* Copyable Service ID */}
         <div className="mb-4">
           <label className="block text-sm font-medium text-gray-700 mb-2">Service ID</label>
           <div className="relative">
@@ -88,258 +107,148 @@ const ServiceCard: React.FC<{
 const BioEngineHome: React.FC = () => {
   const navigate = useNavigate();
   const { server, isLoggedIn } = useHyphaStore();
-  const servicesRef = useRef<HTMLDivElement>(null);
 
-  const [bioEngineServices, setBioEngineServices] = useState<BioEngineService[]>([]);
-  const [servicesLoading, setServicesLoading] = useState(false);
-  const [servicesError, setServicesError] = useState<string | null>(null);
-  const [customServiceId, setCustomServiceId] = useState('');
-  const [tokenDialogOpen, setTokenDialogOpen] = useState(false);
-  const [customToken, setCustomToken] = useState('');
-  const [connectionLoading, setConnectionLoading] = useState(false);
-  const [connectionError, setConnectionError] = useState<string | null>(null);
-  const [defaultServiceOnline, setDefaultServiceOnline] = useState<boolean | null>(null);
+  // Custom workspaces persisted in localStorage (default workspaces not stored here)
+  const [customWorkspaces, setCustomWorkspaces] = useState<string[]>(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : [];
+    } catch { return []; }
+  });
+  const [workspaceInput, setWorkspaceInput] = useState('');
+  const [workspaceServices, setWorkspaceServices] = useState<Record<string, BioEngineService[]>>({});
+  const [workspaceStatus, setWorkspaceStatus] = useState<Record<string, WorkspaceStatus>>({});
   const [manualRefreshLoading, setManualRefreshLoading] = useState(false);
 
-  const fetchBioEngineServices = useCallback(async (isManualRefresh = false) => {
-    if (!isLoggedIn) {
-      setServicesLoading(!isManualRefresh);
-      setServicesError('Please log in to view your BioEngine instances');
-      return;
+  const userWorkspace = server?.config?.workspace as string | undefined;
+
+  // Default workspaces: always bioimage-io, plus logged-in user's workspace
+  const defaultWorkspaces = useMemo(() => {
+    const ws = [DEFAULT_PUBLIC_WORKSPACE];
+    if (isLoggedIn && userWorkspace && userWorkspace !== DEFAULT_PUBLIC_WORKSPACE) {
+      ws.push(userWorkspace);
     }
+    return ws;
+  }, [isLoggedIn, userWorkspace]);
+
+  // All observed workspaces = defaults + custom (deduped)
+  const observedWorkspaces = useMemo(() => {
+    const all = [...defaultWorkspaces];
+    for (const ws of customWorkspaces) {
+      if (!all.includes(ws)) all.push(ws);
+    }
+    return all;
+  }, [defaultWorkspaces, customWorkspaces]);
+
+  // Persist custom workspaces to localStorage on change
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(customWorkspaces));
+  }, [customWorkspaces]);
+
+  const addWorkspace = () => {
+    const trimmed = workspaceInput.trim();
+    if (!trimmed || observedWorkspaces.includes(trimmed)) return;
+    setCustomWorkspaces(prev => [...prev, trimmed]);
+    setWorkspaceInput('');
+  };
+
+  const removeWorkspace = (ws: string) => {
+    setCustomWorkspaces(prev => prev.filter(w => w !== ws));
+    setWorkspaceServices(prev => { const next = { ...prev }; delete next[ws]; return next; });
+    setWorkspaceStatus(prev => { const next = { ...prev }; delete next[ws]; return next; });
+  };
+
+  // Fetch services for a single workspace
+  const fetchWorkspaceServices = useCallback(async (workspace: string) => {
+    if (!server) return;
+
+    setWorkspaceStatus(prev => ({ ...prev, [workspace]: 'loading' }));
 
     try {
-      if (isManualRefresh) {
-        setManualRefreshLoading(true);
+      let services: BioEngineService[] = [];
+
+      if (isLoggedIn && workspace === userWorkspace) {
+        // Own workspace: enumerate all bioengine-worker services
+        const list = await server.listServices({ type: 'bioengine-worker' });
+        services = list.map((s: any) => ({
+          id: s.id,
+          name: s.name || s.id,
+          description: s.description || '',
+        }));
       } else {
-        // Only show loading if we don't have any services yet
-        if (bioEngineServices.length === 0) {
-          setServicesLoading(true);
-        }
-      }
-      setServicesError(null);
-      
-      // Get the list of services from the workspace
-      const services = await server.listServices({ "type": "bioengine-worker" });
-
-      const defaultService: BioEngineService = {
-        id: "bioimage-io/bioengine-worker",
-        name: "BioImage.IO BioEngine Worker",
-        description: "Default BioEngine worker instance for the BioImage.IO community"
-      };
-
-      const hasDefaultService = services.some((service: BioEngineService) => service.id === defaultService.id);
-
-      let allServices = [...services];
-      let isDefaultOnline = false;
-
-      // If default service is not in the workspace list, try to access it directly
-      if (!hasDefaultService) {
+        // External workspace: probe with short service ID
         try {
-          await server.getService("bioimage-io/bioengine-worker", { mode: "first"});
-          allServices = [defaultService, ...services];
-          isDefaultOnline = true;
-          console.log('Default BioEngine service is online and added to list');
+          const svc = await server.getService(`${workspace}/bioengine-worker`);
+          services = [{ id: svc.id, name: svc.name || svc.id, description: svc.description || '' }];
         } catch (err) {
-          // Default service is not accessible, don't add it
-          console.log('Default BioEngine service is not accessible:', err instanceof Error ? err.message : String(err));
-          isDefaultOnline = false;
-        }
-      } else {
-        isDefaultOnline = true; // It's in the workspace list
-      }
-
-      // Compare with current services list to see if anything changed
-      const servicesChanged = !arraysEqual(
-        allServices.map(s => s.id).sort(),
-        bioEngineServices.map(s => s.id).sort()
-      );
-
-      const defaultStatusChanged = isDefaultOnline !== defaultServiceOnline;
-
-      // Only update state if something actually changed
-      if (servicesChanged || defaultStatusChanged) {
-        setDefaultServiceOnline(isDefaultOnline);
-        setBioEngineServices(allServices);
-        
-        // Check if we found new services and scroll to them
-        const foundNewServices = allServices.length > bioEngineServices.length;
-        if (foundNewServices && allServices.length > 0 && servicesRef.current) {
-          setTimeout(() => {
-            servicesRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          }, 100);
+          const errStr = String(err);
+          if (errStr.includes('Multiple services found')) {
+            // Parse all service IDs from the error, then fetch each for details
+            const ids = parseMultipleServicesFromError(errStr);
+            const results = await Promise.allSettled(ids.map(id => server.getService(id)));
+            services = results.map((result, i) => {
+              if (result.status === 'fulfilled') {
+                const s = result.value;
+                return { id: s.id || ids[i], name: s.name || ids[i], description: s.description || '' };
+              }
+              return { id: ids[i], name: ids[i], description: '' };
+            });
+          }
+          // Not found or other error → services remains empty
         }
       }
 
-      if (isManualRefresh) {
-        setManualRefreshLoading(false);
-      } else {
-        setServicesLoading(false);
-      }
+      setWorkspaceServices(prev => ({ ...prev, [workspace]: services }));
+      setWorkspaceStatus(prev => ({ ...prev, [workspace]: 'loaded' }));
     } catch (err) {
-      setServicesError(`Failed to fetch BioEngine instances: ${err instanceof Error ? err.message : String(err)}`);
-      if (isManualRefresh) {
-        setManualRefreshLoading(false);
-      } else {
-        setServicesLoading(false);
-      }
+      console.error(`Failed to fetch services for workspace ${workspace}:`, err);
+      setWorkspaceStatus(prev => ({ ...prev, [workspace]: 'error' }));
     }
-  }, [isLoggedIn, server, bioEngineServices, defaultServiceOnline, servicesRef]);
+  }, [server, isLoggedIn, userWorkspace]);
 
-  // Initialize services on mount
+  // Fetch all observed workspaces
+  const fetchAllWorkspaces = useCallback(async (isManual = false) => {
+    if (isManual) setManualRefreshLoading(true);
+    await Promise.allSettled(observedWorkspaces.map(ws => fetchWorkspaceServices(ws)));
+    if (isManual) setManualRefreshLoading(false);
+  }, [observedWorkspaces, fetchWorkspaceServices]);
+
+  // Fetch on mount and whenever server connection or workspace list changes
   useEffect(() => {
-    if (isLoggedIn) {
-      fetchBioEngineServices();
-    }
-  }, [isLoggedIn, fetchBioEngineServices]);
+    if (server) fetchAllWorkspaces();
+  }, [server, observedWorkspaces]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Fetch services when login state changes (avoid duplicate with initial effect)
+  // Auto-refresh every 10 seconds
   useEffect(() => {
-    if (!isLoggedIn) {
-      // Reset services state when logged out
-      setBioEngineServices([]);
-      setServicesLoading(false);
-      setServicesError('Please log in to view your BioEngine instances');
-      setDefaultServiceOnline(null);
-    }
-  }, [isLoggedIn]);
-
-  // Auto-refresh services every 5 seconds
-  useEffect(() => {
-    if (!isLoggedIn) return;
-
+    if (!server) return;
     const interval = setInterval(() => {
-      fetchBioEngineServices();
-    }, 5000); // 5 seconds
-
+      observedWorkspaces.forEach(ws => fetchWorkspaceServices(ws));
+    }, 10000);
     return () => clearInterval(interval);
-  }, [isLoggedIn, fetchBioEngineServices]);
-
-  // Manual refresh handler
-  const handleManualRefresh = () => {
-    fetchBioEngineServices(true);
-  };
+  }, [server, observedWorkspaces, fetchWorkspaceServices]);
 
   const navigateToDashboard = (serviceId: string) => {
     navigate(`/bioengine/worker?service_id=${serviceId}`);
   };
 
-  const handleCustomServiceIdSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-    if (!customServiceId.trim()) return;
-
-    console.log(`Connecting to custom BioEngine service: '${customServiceId}'`);
-
-    setConnectionLoading(true);
-    setConnectionError(null);
-
-    try {
-      await server.getService(customServiceId);
-      navigateToDashboard(customServiceId);
-    } catch (err) {
-      const errorMessage = String(err);
-      if (errorMessage.includes('denied') || errorMessage.includes('unauthorized') || errorMessage.includes('permission')) {
-        setTokenDialogOpen(true);
-      } else {
-        setConnectionError(`Could not connect: ${errorMessage}`);
+  const allServices = useMemo(() => {
+    return observedWorkspaces.flatMap(ws => {
+      const services = workspaceServices[ws] || [];
+      if (ws === DEFAULT_PUBLIC_WORKSPACE) {
+        // Put the featured worker first within bioimage-io
+        const featured = services.filter(s => s.name === FEATURED_SERVICE_NAME);
+        const rest = services.filter(s => s.name !== FEATURED_SERVICE_NAME);
+        return [...featured, ...rest];
       }
-    } finally {
-      setConnectionLoading(false);
-    }
-  };
+      return services;
+    });
+  }, [observedWorkspaces, workspaceServices]);
 
-  const handleTokenSubmit = async (event: React.FormEvent) => {
-    event.preventDefault();
-    if (!customToken.trim()) return;
-
-    setConnectionLoading(true);
-
-    try {
-      await server.getService(customServiceId, { token: customToken });
-      setTokenDialogOpen(false);
-      navigateToDashboard(customServiceId);
-    } catch (err) {
-      setConnectionError(`Invalid token: ${String(err)}`);
-    } finally {
-      setConnectionLoading(false);
-    }
-  };
-
-  const handleTokenDialogClose = () => {
-    setTokenDialogOpen(false);
-    setCustomToken('');
-    setConnectionError(null);
-  };
-
-  // Services List Component
-  const ServicesList = () => {
-    if (servicesLoading) {
-      return (
-        <div className="flex justify-center items-center h-64">
-          <div className="flex flex-col items-center">
-            <img
-              src="/static/img/bioengine-logo-black.svg"
-              alt="BioEngine Loading"
-              className="w-32 h-auto opacity-60 animate-pulse"
-            />
-            <p className="text-gray-500 text-sm mt-4 animate-pulse">Loading BioEngine instances...</p>
-          </div>
-        </div>
-      );
-    }
-
-    if (servicesError) {
-      return (
-        <div className="flex justify-center items-center h-64">
-          <div className="text-center">
-            <div className="w-16 h-16 bg-gradient-to-r from-blue-100 to-purple-100 rounded-xl flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-            </div>
-            <p className="text-gray-600 font-medium mb-2">Authentication Required</p>
-            <p className="text-gray-500 text-sm">{servicesError}</p>
-          </div>
-        </div>
-      );
-    }
-
-    if (bioEngineServices.length === 0) {
-      return (
-        <div className="flex flex-col items-center justify-center h-64 text-gray-500">
-          <div className="w-20 h-20 bg-gradient-to-r from-blue-100 to-purple-100 rounded-2xl flex items-center justify-center mb-6">
-            <svg className="w-10 h-10 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
-            </svg>
-          </div>
-          <p className="text-gray-600 font-medium mb-2 text-center">No BioEngine instances found</p>
-          <p className="text-gray-500 text-sm text-center mb-4">No instances available in workspace <span className="font-mono bg-gray-100 px-2 py-1 rounded text-xs">{server?.config?.workspace || 'current'}</span></p>
-          {defaultServiceOnline === false && (
-            <p className="text-sm text-gray-400 text-center">
-              Note: Default BioEngine service is currently offline
-            </p>
-          )}
-          {defaultServiceOnline === null && (
-            <p className="text-sm text-gray-400 text-center">
-              Checking default BioEngine service status...
-            </p>
-          )}
-        </div>
-      );
-    }
-
-    return (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {bioEngineServices.map((service) => (
-          <ServiceCard key={service.id} service={service} onNavigate={navigateToDashboard} />
-        ))}
-      </div>
-    );
-  };
+  const isAnyLoading = observedWorkspaces.some(ws => workspaceStatus[ws] === 'loading');
 
   return (
-            <div className="max-w-[1400px] mx-auto px-4 py-8">
-      {/* Fancy Header - Always visible */}
+    <div className="max-w-[1400px] mx-auto px-4 py-8">
+      {/* Header */}
       <div className="text-center mb-12">
         <div className="flex items-end justify-center gap-4 mb-4">
           <img src="/bioengine-icon.svg" alt="BioEngine Logo" className="w-12 h-12 mb-3" />
@@ -351,23 +260,22 @@ const BioEngineHome: React.FC = () => {
         <p className="mt-4 text-xl text-gray-600 font-medium">
           Unveiling cloud-powered AI for simplified Bioimage Analysis
         </p>
-        
       </div>
 
-      {/* BioEngine Guide - Always visible */}
+      {/* BioEngine Guide */}
       <div className="max-w-6xl mx-auto mb-8">
         <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-white/20 p-6 hover:shadow-md transition-all duration-200">
           <BioEngineGuide />
         </div>
       </div>
 
-      {/* Services List - Shows login warning when needed */}
-      <div className="mb-8" ref={servicesRef}>
+      {/* Available Instances */}
+      <div className="mb-8">
         <div className="flex items-center justify-center mb-6">
           <h2 className="text-2xl font-semibold text-gray-800 mr-4">Available BioEngine Instances</h2>
           <button
-            onClick={handleManualRefresh}
-            disabled={manualRefreshLoading || !isLoggedIn}
+            onClick={() => fetchAllWorkspaces(true)}
+            disabled={manualRefreshLoading || !server}
             className="px-4 py-2 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-lg hover:from-green-700 hover:to-green-800 disabled:from-gray-400 disabled:to-gray-500 disabled:cursor-not-allowed flex items-center shadow-sm hover:shadow-md transition-all duration-200"
             title="Refresh services list"
           >
@@ -382,131 +290,134 @@ const BioEngineHome: React.FC = () => {
           </button>
         </div>
 
-        {/* Combined section with Connect and Services List */}
         <div className="max-w-6xl mx-auto">
-          <div className={`bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-white/20 p-6 hover:shadow-md transition-all duration-200 ${!isLoggedIn ? 'opacity-60' : ''
-            }`}>
-            <div className="flex items-center mb-4">
-              <div className="w-10 h-10 bg-white rounded-xl flex items-center justify-center mr-3 p-1">
-                <img src="/bioengine-icon.svg" alt="BioEngine" className="w-8 h-8" />
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-800">Connect to BioEngine Worker</h3>
-                <p className="text-sm text-gray-600">Enter a service ID to connect to an existing BioEngine worker</p>
-              </div>
-            </div>
+          <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-white/20 p-6 hover:shadow-md transition-all duration-200">
 
-            {!isLoggedIn && (
-              <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-                <p className="text-amber-600 text-sm flex items-center">
-                  <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
-                  </svg>
-                  Please log in to connect to BioEngine workers
-                </p>
-              </div>
-            )}
+            {/* Workspace management */}
+            <div className="mb-6">
+              <h3 className="text-sm font-semibold text-gray-700 mb-3">Observed Workspaces</h3>
 
-            <form onSubmit={handleCustomServiceIdSubmit}>
-              <div className="relative flex items-center">
+              {/* Add workspace input */}
+              <form
+                onSubmit={(e) => { e.preventDefault(); addWorkspace(); }}
+                className="flex gap-2 mb-3"
+              >
                 <input
                   type="text"
-                  placeholder="Enter BioEngine Worker Service ID (e.g., workspace/service-name)"
-                  value={customServiceId}
-                  onChange={(e) => setCustomServiceId(e.target.value)}
-                  disabled={connectionLoading || !isLoggedIn}
-                  className={`w-full px-4 py-3 border-2 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-all duration-200 ${connectionError ? 'border-red-300 bg-red-50' : 'border-gray-200 bg-white'
-                    } ${connectionLoading || !isLoggedIn ? 'bg-gray-100' : ''}`}
+                  value={workspaceInput}
+                  onChange={(e) => setWorkspaceInput(e.target.value)}
+                  placeholder="Add workspace name..."
+                  className="flex-1 px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 text-sm"
                 />
                 <button
                   type="submit"
-                  disabled={!customServiceId.trim() || connectionLoading || !isLoggedIn}
-                  className="absolute right-2 px-6 py-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-lg hover:from-blue-700 hover:to-blue-800 disabled:from-gray-400 disabled:to-gray-500 disabled:cursor-not-allowed flex items-center justify-center min-w-[100px] shadow-sm hover:shadow-md transition-all duration-200"
+                  disabled={!workspaceInput.trim() || observedWorkspaces.includes(workspaceInput.trim())}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed text-sm font-medium transition-colors"
                 >
-                  {connectionLoading ? (
-                    <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin"></div>
-                  ) : (
-                    "Connect"
-                  )}
+                  Add
                 </button>
+              </form>
+
+              {/* Workspace chips */}
+              <div className="flex flex-wrap gap-2">
+                {observedWorkspaces.map(ws => {
+                  const isDefault = defaultWorkspaces.includes(ws);
+                  const isUserWs = isLoggedIn && ws === userWorkspace;
+                  const isPublicDefault = ws === DEFAULT_PUBLIC_WORKSPACE;
+                  const status = workspaceStatus[ws];
+                  const count = workspaceServices[ws]?.length ?? null;
+
+                  return (
+                    <div
+                      key={ws}
+                      className="group relative flex items-center gap-1.5 px-3 py-1.5 bg-gray-100 rounded-full text-sm text-gray-700 hover:bg-gray-200 transition-colors"
+                    >
+                      {status === 'loading' && (
+                        <div className="w-2.5 h-2.5 border border-gray-400 border-t-transparent rounded-full animate-spin flex-shrink-0" />
+                      )}
+                      {status === 'loaded' && (
+                        <div className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${count && count > 0 ? 'bg-green-500' : 'bg-gray-400'}`} />
+                      )}
+                      {status === 'error' && (
+                        <div className="w-2.5 h-2.5 rounded-full bg-red-400 flex-shrink-0" />
+                      )}
+                      {!status && (
+                        <div className="w-2.5 h-2.5 rounded-full bg-gray-300 flex-shrink-0" />
+                      )}
+                      <span className="font-mono">{ws}</span>
+                      {isPublicDefault && <span className="text-xs text-gray-400">(public)</span>}
+                      {isUserWs && !isPublicDefault && <span className="text-xs text-blue-500">(you)</span>}
+                      {count !== null && status === 'loaded' && (
+                        <span className="text-xs text-gray-400">{count} worker{count !== 1 ? 's' : ''}</span>
+                      )}
+                      {!isDefault && (
+                        <button
+                          onClick={() => removeWorkspace(ws)}
+                          className="ml-0.5 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-all flex-shrink-0"
+                          title="Remove workspace"
+                        >
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                          </svg>
+                        </button>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
-              {connectionError && (
-                <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
-                  <p className="text-red-600 text-sm flex items-center">
-                    <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </div>
+
+            {/* Services list */}
+            <div className="border-t border-gray-200/50 pt-6">
+              {!server ? (
+                <div className="flex justify-center items-center h-40">
+                  <div className="text-center">
+                    <div className="w-16 h-16 bg-gradient-to-r from-blue-100 to-purple-100 rounded-xl flex items-center justify-center mx-auto mb-4">
+                      <svg className="w-8 h-8 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                      </svg>
+                    </div>
+                    <p className="text-gray-600 font-medium mb-1">Not connected</p>
+                    <p className="text-gray-500 text-sm">Please log in to view BioEngine instances</p>
+                  </div>
+                </div>
+              ) : allServices.length === 0 && isAnyLoading ? (
+                <div className="flex justify-center items-center h-40">
+                  <div className="flex flex-col items-center">
+                    <img
+                      src="/static/img/bioengine-logo-black.svg"
+                      alt="BioEngine Loading"
+                      className="w-32 h-auto opacity-60 animate-pulse"
+                    />
+                    <p className="text-gray-500 text-sm mt-4 animate-pulse">Loading BioEngine instances...</p>
+                  </div>
+                </div>
+              ) : allServices.length === 0 ? (
+                <div className="flex flex-col items-center justify-center h-40 text-gray-500">
+                  <div className="w-20 h-20 bg-gradient-to-r from-blue-100 to-purple-100 rounded-2xl flex items-center justify-center mb-4">
+                    <svg className="w-10 h-10 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
                     </svg>
-                    {connectionError}
-                  </p>
+                  </div>
+                  <p className="text-gray-600 font-medium mb-1">No BioEngine instances found</p>
+                  <p className="text-gray-500 text-sm">No running workers found in any observed workspace</p>
+                </div>
+              ) : (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {allServices.map(service => (
+                    <ServiceCard
+                      key={service.id}
+                      service={service}
+                      onNavigate={navigateToDashboard}
+                      featured={service.name === FEATURED_SERVICE_NAME}
+                    />
+                  ))}
                 </div>
               )}
-            </form>
-
-            {/* Services List inside the same frame */}
-            <div className="mt-8 pt-6 border-t border-gray-200/50">
-              <ServicesList />
             </div>
           </div>
         </div>
       </div>
-
-      {/* Token Dialog */}
-      {tokenDialogOpen && (
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 animate-fadeIn">
-          <div className="bg-white/95 backdrop-blur-md rounded-2xl shadow-lg max-w-md w-full mx-4 border border-white/20 animate-slideUp">
-            <div className="p-6 border-b border-gray-200/50">
-              <div className="flex items-center">
-                <div className="w-10 h-10 bg-gradient-to-r from-amber-500 to-orange-500 rounded-xl flex items-center justify-center mr-3">
-                  <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-                  </svg>
-                </div>
-                <h3 className="text-lg font-semibold text-gray-800">Authentication Required</h3>
-              </div>
-            </div>
-            <form onSubmit={handleTokenSubmit}>
-              <div className="p-6">
-                <p className="text-gray-600 mb-4">
-                  Access to this BioEngine service requires authentication. Please enter a token:
-                </p>
-                <input
-                  type="password"
-                  placeholder="Token"
-                  value={customToken}
-                  onChange={(e) => setCustomToken(e.target.value)}
-                  disabled={connectionLoading}
-                  autoFocus
-                  className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 ${connectionError ? 'border-red-500' : 'border-gray-300'
-                    } ${connectionLoading ? 'bg-gray-100' : 'bg-white'}`}
-                />
-                {connectionError && (
-                  <p className="text-red-500 text-sm mt-2">{connectionError}</p>
-                )}
-              </div>
-              <div className="p-6 pt-0 border-t border-gray-200/50 flex justify-end space-x-3">
-                <button
-                  type="button"
-                  onClick={handleTokenDialogClose}
-                  disabled={connectionLoading}
-                  className="px-6 py-3 text-gray-600 bg-white border-2 border-gray-200 rounded-xl hover:bg-gray-50 hover:border-gray-300 disabled:opacity-50 shadow-sm hover:shadow-md transition-all duration-200"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={!customToken.trim() || connectionLoading}
-                  className="px-6 py-3 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-xl hover:from-blue-700 hover:to-blue-800 disabled:from-gray-400 disabled:to-gray-500 disabled:cursor-not-allowed flex items-center shadow-sm hover:shadow-md transition-all duration-200"
-                >
-                  {connectionLoading ? (
-                    <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
-                  ) : null}
-                  Connect
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
- Replace service ID input with observed Hypha workspaces system (localStorage-persisted, chip UI, auto-refresh)
- Rewrite K8s section: assume existing Ray cluster, KubeRay Quick Start link, PVC checkbox, deploy commands
- Add startup/liveness probes from kth-k8s (check is_ready), full security context (seccompProfile, capabilities)
- Set BIOENGINE_CLIENT_ID directly via fieldRef metadata.name
- Fix probe shell commands to use $POD_NAME (not $(POD_NAME))
- Remove namespace from deployment manifest (controlled via -n flag only)
- Make PVC optional via checkbox; omit volumeMounts/volumes when unchecked
- Fill Hypha token into kubectl create secret command
- Move Ray Client Server Port to advanced options
- Various label/description cleanups