### PR TITLE
feat(annotate): mobile and tablet responsive annotation UI

### DIFF
--- a/src/components/annotate/FloatingBanners.tsx
+++ b/src/components/annotate/FloatingBanners.tsx
@@ -103,7 +103,9 @@ const FloatingBanners: React.FC<FloatingBannersProps> = ({ banners }) => {
           flexDirection: 'column',
           gap: 1,
           pointerEvents: 'none',
-          maxWidth: 360,
+          // On phones, banners stretch near full width; on desktop cap at 360px
+          maxWidth: { xs: 'calc(100% - 16px)', sm: 360 },
+          width: { xs: 'calc(100% - 16px)', sm: 'auto' },
         }}
       >
         {banners.map((banner) => (

--- a/src/components/annotate/ToolBar.tsx
+++ b/src/components/annotate/ToolBar.tsx
@@ -7,6 +7,8 @@ import {
   Divider,
   ButtonBase,
   Button,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
@@ -94,14 +96,33 @@ const ToolBar: React.FC<ToolBarProps> = ({
   const imageHeight = useAnnotationStore((s) => s.imageHeight);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
+  const theme = useTheme();
+  // Phone: < 600px (xs/sm), tablet: 600–900px
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
   const [isExpanded, setIsExpanded] = React.useState(() => {
-    try { return localStorage.getItem(EXPANDED_KEY) !== 'false'; } catch { return true; }
+    try {
+      const stored = localStorage.getItem(EXPANDED_KEY);
+      if (stored !== null) return stored !== 'false';
+      // Default: collapsed on mobile/tablet, expanded on desktop
+      return window.innerWidth >= 900;
+    } catch { return true; }
   });
+
+  // Sync collapse state when screen size changes (e.g. orientation change)
+  const wasAutoCollapsed = React.useRef(false);
+  React.useEffect(() => {
+    if (isMobile && isExpanded && !wasAutoCollapsed.current) {
+      wasAutoCollapsed.current = true;
+      setIsExpanded(false);
+    }
+  }, [isMobile]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleExpanded = () => {
     setIsExpanded(v => {
       const next = !v;
       try { localStorage.setItem(EXPANDED_KEY, String(next)); } catch {}
+      wasAutoCollapsed.current = false;
       return next;
     });
   };
@@ -123,20 +144,29 @@ const ToolBar: React.FC<ToolBarProps> = ({
     />
   );
 
+  // On mobile, collapsed toolbar is 60px with medium-sized buttons for touch targets.
+  // On desktop, 52px with small buttons.
+  const collapsedWidth = isMobile ? 60 : 52;
+  // MUI IconButton size="medium" gives ~40px, size="small" ~32px.
+  const btnSize = isMobile ? 'medium' : 'small';
+  // Minimum 44px touch target for mobile (add extra padding via minWidth/minHeight)
+  const touchSx = isMobile ? { minWidth: 44, minHeight: 44 } : {};
+
   // ── Collapsed ──────────────────────────────────────────────────────────────
   if (!isExpanded) {
     return (
       <Box sx={{
         display: 'flex', flexDirection: 'column', alignItems: 'center',
-        py: 1, px: 0.5, gap: 0.5,
-        width: 52, flexShrink: 0,
+        py: 1, px: isMobile ? 0.75 : 0.5, gap: isMobile ? 0.75 : 0.5,
+        width: collapsedWidth, flexShrink: 0,
         background: 'rgba(255,255,255,0.20)',
         backdropFilter: 'blur(6px)',
         borderRight: '1px solid rgba(255,255,255,0.28)',
+        overflowY: 'auto',
       }}>
         {/* Expand toggle */}
         <Tooltip title="Expand toolbar" placement="right">
-          <IconButton size="small" onClick={toggleExpanded} sx={{ ...collapsedBtnSx(), mb: 0.25 }}>
+          <IconButton size={btnSize} onClick={toggleExpanded} sx={{ ...collapsedBtnSx(), mb: 0.25, ...touchSx }}>
             <ChevronRightIcon fontSize="small" />
           </IconButton>
         </Tooltip>
@@ -146,10 +176,10 @@ const ToolBar: React.FC<ToolBarProps> = ({
           <React.Fragment key={tool.id}>
             <Tooltip title={`${tool.name} (${tool.shortcut})`} placement="right">
               <IconButton
-                size="small"
+                size={btnSize}
                 data-tool={tool.id}
                 onClick={() => setActiveTool(tool.id)}
-                sx={collapsedBtnSx(activeTool === tool.id)}
+                sx={{ ...collapsedBtnSx(activeTool === tool.id), ...touchSx }}
               >
                 {tool.icon}
               </IconButton>
@@ -163,7 +193,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
               >
                 <span>
                   <IconButton
-                    size="small"
+                    size={btnSize}
                     data-tool="cellpose"
                     onClick={onOpenCellposeConfig}
                     disabled={isRunningCellpose || !cellposeAvailable}
@@ -172,6 +202,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
                       bgcolor: cellposeAvailable ? 'rgba(156,39,176,0.12)' : undefined,
                       color: cellposeAvailable ? 'secondary.main' : undefined,
                       '&:hover': { bgcolor: cellposeAvailable ? 'rgba(156,39,176,0.22)' : undefined },
+                      ...touchSx,
                     }}
                   >
                     <AutoAwesomeIcon fontSize="small" />
@@ -183,8 +214,8 @@ const ToolBar: React.FC<ToolBarProps> = ({
             {tool.id === 'expander' && (
               <Tooltip title="Save Annotation" placement="right">
                 <span>
-                  <IconButton size="small" data-tool="save" onClick={onSave} disabled={isSaving}
-                    sx={{ ...collapsedBtnSx(), color: 'success.main' }}>
+                  <IconButton size={btnSize} data-tool="save" onClick={onSave} disabled={isSaving}
+                    sx={{ ...collapsedBtnSx(), color: 'success.main', ...touchSx }}>
                     <SaveIcon fontSize="small" />
                   </IconButton>
                 </span>
@@ -197,15 +228,15 @@ const ToolBar: React.FC<ToolBarProps> = ({
 
         <Tooltip title="Undo (Ctrl+Z)" placement="right">
           <span>
-            <IconButton size="small" data-tool="undo" onClick={onUndo} disabled={!canUndo} sx={collapsedBtnSx()}>
+            <IconButton size={btnSize} data-tool="undo" onClick={onUndo} disabled={!canUndo} sx={{ ...collapsedBtnSx(), ...touchSx }}>
               <UndoIcon fontSize="small" />
             </IconButton>
           </span>
         </Tooltip>
 
         <Tooltip title="Clear All Annotations" placement="right">
-          <IconButton size="small" data-tool="clear" onClick={onClearAll}
-            sx={{ ...collapsedBtnSx(), color: 'error.main' }}>
+          <IconButton size={btnSize} data-tool="clear" onClick={onClearAll}
+            sx={{ ...collapsedBtnSx(), color: 'error.main', ...touchSx }}>
             <DeleteSweepIcon fontSize="small" />
           </IconButton>
         </Tooltip>
@@ -213,20 +244,20 @@ const ToolBar: React.FC<ToolBarProps> = ({
         <Divider flexItem sx={{ my: 0.25, opacity: 0.35 }} />
 
         <Tooltip title="Filter Masks by Area" placement="right">
-          <IconButton size="small" data-tool="filter" onClick={onOpenMaskFilter} sx={collapsedBtnSx()}>
+          <IconButton size={btnSize} data-tool="filter" onClick={onOpenMaskFilter} sx={{ ...collapsedBtnSx(), ...touchSx }}>
             <FilterListIcon fontSize="small" />
           </IconButton>
         </Tooltip>
 
         <Tooltip title="Fit to Image" placement="right">
-          <IconButton size="small" data-tool="fit" onClick={onResetView} sx={collapsedBtnSx()}>
+          <IconButton size={btnSize} data-tool="fit" onClick={onResetView} sx={{ ...collapsedBtnSx(), ...touchSx }}>
             <CenterFocusStrongIcon fontSize="small" />
           </IconButton>
         </Tooltip>
 
         <Tooltip title={isCLAHEActive ? 'Restore Original Image' : isLowContrast && !isCLAHEActive ? 'Low contrast detected — Enhance Contrast (CLAHE)' : 'Enhance Contrast (CLAHE)'} placement="right">
-          <IconButton size="small" data-tool="clahe" onClick={onToggleCLAHE}
-            sx={isCLAHEActive ? collapsedBtnSx(true) : isLowContrast ? {
+          <IconButton size={btnSize} data-tool="clahe" onClick={onToggleCLAHE}
+            sx={isCLAHEActive ? { ...collapsedBtnSx(true), ...touchSx } : isLowContrast ? {
               ...collapsedBtnSx(),
               color: 'warning.main',
               animation: 'clahe-pulse 2s ease-in-out infinite',
@@ -234,7 +265,8 @@ const ToolBar: React.FC<ToolBarProps> = ({
                 '0%, 100%': { boxShadow: '0 1px 3px rgba(0,0,0,0.18)' },
                 '50%': { boxShadow: '0 0 0 3px rgba(237,108,2,0.35)' },
               },
-            } : collapsedBtnSx()}>
+              ...touchSx,
+            } : { ...collapsedBtnSx(), ...touchSx }}>
             <ContrastIcon fontSize="small" />
           </IconButton>
         </Tooltip>
@@ -242,13 +274,13 @@ const ToolBar: React.FC<ToolBarProps> = ({
         <Divider flexItem sx={{ my: 0.25, opacity: 0.35 }} />
 
         <Tooltip title={`${imageName || 'No image'} — ${imageWidth}×${imageHeight} px`} placement="right">
-          <IconButton size="small" data-tool="info" sx={collapsedBtnSx()}>
+          <IconButton size={btnSize} data-tool="info" sx={{ ...collapsedBtnSx(), ...touchSx }}>
             <InfoIcon fontSize="small" />
           </IconButton>
         </Tooltip>
 
         <Tooltip title="Upload GeoJSON" placement="right">
-          <IconButton size="small" data-tool="upload" onClick={() => fileInputRef.current?.click()} sx={collapsedBtnSx()}>
+          <IconButton size={btnSize} data-tool="upload" onClick={() => fileInputRef.current?.click()} sx={{ ...collapsedBtnSx(), ...touchSx }}>
             <UploadFileIcon fontSize="small" />
           </IconButton>
         </Tooltip>
@@ -256,9 +288,9 @@ const ToolBar: React.FC<ToolBarProps> = ({
 
         {sessionUrl && (
           <Tooltip title="Session overview — view all images, annotation progress & training" placement="right">
-            <IconButton size="small" data-tool="session"
+            <IconButton size={btnSize} data-tool="session"
               onClick={() => window.open(sessionUrl, '_blank', 'noopener,noreferrer')}
-              sx={{ ...collapsedBtnSx(), color: 'info.main' }}>
+              sx={{ ...collapsedBtnSx(), color: 'info.main', ...touchSx }}>
               <OpenInNewIcon fontSize="small" />
             </IconButton>
           </Tooltip>
@@ -267,7 +299,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
         <Box sx={{ flex: 1 }} />
 
         <Tooltip title="Help & Tutorial" placement="right">
-          <IconButton size="small" data-tool="help" onClick={onHelp} sx={collapsedBtnSx()}>
+          <IconButton size={btnSize} data-tool="help" onClick={onHelp} sx={{ ...collapsedBtnSx(), ...touchSx }}>
             <HelpOutlineIcon fontSize="small" />
           </IconButton>
         </Tooltip>
@@ -278,13 +310,15 @@ const ToolBar: React.FC<ToolBarProps> = ({
   // ── Expanded ──────────────────────────────────────────────────────────────
   const rowSx = (active = false) => ({
     display: 'flex', alignItems: 'flex-start', gap: 1,
-    px: 1, py: 0.7, borderRadius: 1.5, width: '100%', textAlign: 'left' as const,
+    px: 1, py: isMobile ? 1 : 0.7, borderRadius: 1.5, width: '100%', textAlign: 'left' as const,
     bgcolor: active ? 'rgba(25,118,210,0.08)' : 'transparent',
     border: '1px solid',
     borderColor: active ? 'rgba(25,118,210,0.25)' : 'transparent',
     '&:hover': { bgcolor: active ? 'rgba(25,118,210,0.10)' : 'rgba(0,0,0,0.04)' },
     transition: 'background 0.12s',
     '&.Mui-disabled': { opacity: 0.45 },
+    // Minimum 44px touch target height for mobile
+    minHeight: isMobile ? 48 : undefined,
   });
 
   const ShortcutBadge = ({ k }: { k: string }) => (
@@ -294,245 +328,281 @@ const ToolBar: React.FC<ToolBarProps> = ({
     }}>{k}</Typography>
   );
 
+  // On mobile, expanded toolbar overlays the map (absolute) so the map gets full width.
+  // A semi-transparent backdrop allows dismissal by tapping outside.
+  const expandedContainerSx = isMobile ? {
+    position: 'absolute' as const,
+    top: 0, bottom: 0, left: 0,
+    zIndex: 1000,
+    width: '85vw',
+    maxWidth: 300,
+  } : {
+    width: 224,
+    flexShrink: 0,
+  };
+
   return (
-    <Box sx={{
-      display: 'flex', flexDirection: 'column',
-      py: 1, px: 1, gap: 0.25,
-      width: 224, flexShrink: 0,
-      background: 'rgba(255,255,255,0.97)',
-      backdropFilter: 'blur(12px)',
-      borderRight: '1px solid rgba(0,0,0,0.09)',
-      boxShadow: '2px 0 10px rgba(0,0,0,0.07)',
-      overflowY: 'auto', overflowX: 'hidden',
-    }}>
-      {/* Header with prominent collapse button */}
-      <Tooltip title="Collapse toolbar" placement="right">
+    <>
+      {/* Backdrop for mobile overlay — tap to close */}
+      {isMobile && (
         <Box
           onClick={toggleExpanded}
           sx={{
-            display: 'flex', alignItems: 'center', px: 1, py: 0.6, mb: 0.25,
-            borderRadius: 1.5, cursor: 'pointer',
-            bgcolor: 'rgba(0,0,0,0.04)',
-            border: '1px solid rgba(0,0,0,0.07)',
-            '&:hover': { bgcolor: 'rgba(0,0,0,0.08)' },
-            transition: 'background 0.15s',
+            position: 'absolute', inset: 0, zIndex: 999,
+            bgcolor: 'rgba(0,0,0,0.35)',
           }}
-        >
-          <Typography variant="caption" sx={{
-            fontWeight: 700, color: 'text.disabled',
-            textTransform: 'uppercase', letterSpacing: 1, fontSize: '0.58rem', flex: 1,
-          }}>
-            Annotation Tools
-          </Typography>
-          <ChevronLeftIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
-        </Box>
-      </Tooltip>
-
-      {/* Drawing tools */}
-      {TOOLS.map((tool) => {
-        const active = activeTool === tool.id;
-        return (
-          <React.Fragment key={tool.id}>
-            <ButtonBase onClick={() => setActiveTool(tool.id)} data-tool={tool.id} sx={rowSx(active)}>
-              <Box sx={{ color: active ? 'primary.main' : 'text.secondary', mt: 0.2, flexShrink: 0, display: 'flex' }}>
-                {tool.icon}
-              </Box>
-              <Box>
-                <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.6 }}>
-                  <Typography variant="caption" fontWeight={600} color={active ? 'primary.main' : 'text.primary'}>
-                    {tool.name}
-                  </Typography>
-                  <ShortcutBadge k={tool.shortcut} />
-                </Box>
-                <Typography variant="caption" color="text.secondary" display="block"
-                  sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
-                  {tool.description}
-                </Typography>
-              </Box>
-            </ButtonBase>
-
-            {/* AI Segmentation — prominently after Draw Mask */}
-            {tool.id === 'polygon' && (
-              <Tooltip
-                title={cellposeAvailable ? '' : 'Cellpose service is currently offline'}
-                placement="right"
-                disableHoverListener={cellposeAvailable}
-              >
-                <span style={{ width: '100%' }}>
-                  <Button
-                    variant="contained"
-                    color="secondary"
-                    size="small"
-                    fullWidth
-                    startIcon={<AutoAwesomeIcon fontSize="small" />}
-                    onClick={onOpenCellposeConfig}
-                    disabled={isRunningCellpose || !cellposeAvailable}
-                    data-tool="cellpose"
-                    sx={{
-                      textTransform: 'none', borderRadius: 1.5,
-                      justifyContent: 'flex-start', px: 1.25, py: 0.7, my: 0.25,
-                    }}
-                  >
-                    <Box sx={{ textAlign: 'left', ml: 0.25 }}>
-                      <Typography variant="caption" fontWeight={700} display="block" sx={{ lineHeight: 1.2 }}>
-                        AI Pre-Segmentation
-                      </Typography>
-                      <Typography variant="caption" display="block" sx={{ fontSize: '0.6rem', opacity: 0.85, lineHeight: 1.2 }}>
-                        {cellposeAvailable ? modelLabel : 'Service offline'}
-                      </Typography>
-                    </Box>
-                  </Button>
-                </span>
-              </Tooltip>
-            )}
-
-            {/* Save — prominently after Expand Mask */}
-            {tool.id === 'expander' && (
-              <Button
-                variant="contained"
-                color="success"
-                size="small"
-                fullWidth
-                startIcon={<SaveIcon />}
-                onClick={onSave}
-                disabled={isSaving}
-                data-tool="save"
-                sx={{ textTransform: 'none', borderRadius: 1.5, justifyContent: 'flex-start', px: 1.25, py: 0.7, my: 0.25 }}
-              >
-                <Box sx={{ textAlign: 'left', ml: 0.25 }}>
-                  <Typography variant="caption" fontWeight={700} display="block" sx={{ lineHeight: 1.2 }}>
-                    {isSaving ? 'Saving…' : 'Save Annotation'}
-                  </Typography>
-                  <Typography variant="caption" display="block" sx={{ fontSize: '0.6rem', opacity: 0.85, lineHeight: 1.2 }}>
-                    Upload masks to cloud storage
-                  </Typography>
-                </Box>
-              </Button>
-            )}
-          </React.Fragment>
-        );
-      })}
-
-      <Divider sx={{ my: 0.5 }} />
-
-      {/* View utilities */}
-      <ButtonBase onClick={onResetView} data-tool="fit" sx={rowSx()}>
-        <CenterFocusStrongIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
-        <Box>
-          <Typography variant="caption" fontWeight={600} display="block">Fit to Image</Typography>
-          <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
-            Reset the view to show the full image
-          </Typography>
-        </Box>
-      </ButtonBase>
-
-      <ButtonBase onClick={onToggleCLAHE} data-tool="clahe"
-        sx={{ ...rowSx(isCLAHEActive), '&:hover': { bgcolor: isCLAHEActive ? 'rgba(25,118,210,0.10)' : isLowContrast ? 'rgba(237,108,2,0.08)' : 'rgba(0,0,0,0.04)' } }}>
-        <ContrastIcon fontSize="small" sx={{ color: isCLAHEActive ? 'primary.main' : isLowContrast ? 'warning.main' : 'text.secondary', mt: 0.2, flexShrink: 0 }} />
-        <Box>
-          <Typography variant="caption" fontWeight={600} color={isCLAHEActive ? 'primary.main' : isLowContrast ? 'warning.main' : 'text.primary'} display="block">
-            {isCLAHEActive ? 'Restore Original' : 'Enhance Contrast'}
-          </Typography>
-          <Typography variant="caption" color={isLowContrast && !isCLAHEActive ? 'warning.main' : 'text.secondary'} display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
-            {isLowContrast && !isCLAHEActive ? 'Low contrast detected' : 'CLAHE contrast enhancement'}
-          </Typography>
-        </Box>
-      </ButtonBase>
-
-      {/* Undo */}
-      <ButtonBase onClick={onUndo} disabled={!canUndo} data-tool="undo" sx={rowSx()}>
-        <UndoIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
-        <Box>
-          <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.6 }}>
-            <Typography variant="caption" fontWeight={600}>Undo</Typography>
-            <ShortcutBadge k="Ctrl+Z" />
-          </Box>
-          <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
-            Revert last annotation change
-          </Typography>
-        </Box>
-      </ButtonBase>
-
-      {/* Clear All */}
-      <ButtonBase onClick={onClearAll} data-tool="clear"
-        sx={{ ...rowSx(), '&:hover': { bgcolor: 'rgba(211,47,47,0.06)' } }}>
-        <DeleteSweepIcon fontSize="small" sx={{ color: 'error.main', mt: 0.2, flexShrink: 0 }} />
-        <Box>
-          <Typography variant="caption" fontWeight={600} color="error.main" display="block">Clear All</Typography>
-          <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
-            Remove all annotations on this image
-          </Typography>
-        </Box>
-      </ButtonBase>
-
-      <Divider sx={{ my: 0.5 }} />
-
-      <ButtonBase onClick={onOpenMaskFilter} data-tool="filter" sx={rowSx()}>
-        <FilterListIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
-        <Box>
-          <Typography variant="caption" fontWeight={600} display="block">Filter Masks</Typography>
-          <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
-            Remove masks below a minimum area
-          </Typography>
-        </Box>
-      </ButtonBase>
-
-      {/* File */}
-      <ButtonBase onClick={() => fileInputRef.current?.click()} data-tool="upload" sx={rowSx()}>
-        <UploadFileIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
-        <Box>
-          <Typography variant="caption" fontWeight={600} display="block">Upload GeoJSON</Typography>
-          <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
-            Import annotations from a file
-          </Typography>
-        </Box>
-      </ButtonBase>
-      {fileInput}
-
-      {/* Image info */}
-      {(imageName || (imageWidth && imageHeight)) && (
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 1, py: 0.4 }}>
-          <InfoIcon sx={{ fontSize: '0.85rem', color: 'text.disabled' }} />
-          <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.6rem' }} noWrap>
-            {imageName}{imageWidth && imageHeight ? ` — ${imageWidth}×${imageHeight} px` : ''}
-          </Typography>
-        </Box>
+        />
       )}
 
-      <Box sx={{ flex: 1 }} />
-      <Divider sx={{ my: 0.5 }} />
-
-      {sessionUrl && (
-        <Button
-          variant="contained"
-          size="small"
-          fullWidth
-          startIcon={<OpenInNewIcon fontSize="small" />}
-          onClick={() => window.open(sessionUrl, '_blank', 'noopener,noreferrer')}
-          data-tool="session"
-          sx={{
-            textTransform: 'none', borderRadius: 1.5, mb: 0.5,
-            justifyContent: 'flex-start', px: 1.25, py: 0.65,
-            bgcolor: '#0288d1', '&:hover': { bgcolor: '#0277bd' },
-          }}
-        >
-          <Box sx={{ textAlign: 'left', ml: 0.25 }}>
-            <Typography variant="caption" fontWeight={700} display="block" sx={{ lineHeight: 1.2 }}>
-              Session Overview
+      <Box sx={{
+        display: 'flex', flexDirection: 'column',
+        py: 1, px: 1, gap: 0.25,
+        ...expandedContainerSx,
+        background: 'rgba(255,255,255,0.97)',
+        backdropFilter: 'blur(12px)',
+        borderRight: '1px solid rgba(0,0,0,0.09)',
+        boxShadow: isMobile ? '4px 0 20px rgba(0,0,0,0.18)' : '2px 0 10px rgba(0,0,0,0.07)',
+        overflowY: 'auto', overflowX: 'hidden',
+      }}>
+        {/* Header with prominent collapse button */}
+        <Tooltip title="Collapse toolbar" placement="right">
+          <Box
+            onClick={toggleExpanded}
+            sx={{
+              display: 'flex', alignItems: 'center', px: 1, py: isMobile ? 1 : 0.6, mb: 0.25,
+              borderRadius: 1.5, cursor: 'pointer',
+              bgcolor: 'rgba(0,0,0,0.04)',
+              border: '1px solid rgba(0,0,0,0.07)',
+              '&:hover': { bgcolor: 'rgba(0,0,0,0.08)' },
+              transition: 'background 0.15s',
+              minHeight: isMobile ? 44 : undefined,
+            }}
+          >
+            <Typography variant="caption" sx={{
+              fontWeight: 700, color: 'text.disabled',
+              textTransform: 'uppercase', letterSpacing: 1, fontSize: '0.58rem', flex: 1,
+            }}>
+              Annotation Tools
             </Typography>
-            <Typography variant="caption" display="block" sx={{ fontSize: '0.6rem', opacity: 0.88, lineHeight: 1.2 }}>
-              Images, progress &amp; training
+            <ChevronLeftIcon sx={{ fontSize: 16, color: 'text.disabled' }} />
+          </Box>
+        </Tooltip>
+
+        {/* Drawing tools */}
+        {TOOLS.map((tool) => {
+          const active = activeTool === tool.id;
+          return (
+            <React.Fragment key={tool.id}>
+              <ButtonBase onClick={() => setActiveTool(tool.id)} data-tool={tool.id} sx={rowSx(active)}>
+                <Box sx={{ color: active ? 'primary.main' : 'text.secondary', mt: 0.2, flexShrink: 0, display: 'flex' }}>
+                  {tool.icon}
+                </Box>
+                <Box>
+                  <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.6 }}>
+                    <Typography variant="caption" fontWeight={600} color={active ? 'primary.main' : 'text.primary'}>
+                      {tool.name}
+                    </Typography>
+                    {!isMobile && <ShortcutBadge k={tool.shortcut} />}
+                  </Box>
+                  <Typography variant="caption" color="text.secondary" display="block"
+                    sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
+                    {tool.description}
+                  </Typography>
+                </Box>
+              </ButtonBase>
+
+              {/* AI Segmentation — prominently after Draw Mask */}
+              {tool.id === 'polygon' && (
+                <Tooltip
+                  title={cellposeAvailable ? '' : 'Cellpose service is currently offline'}
+                  placement="right"
+                  disableHoverListener={cellposeAvailable}
+                >
+                  <span style={{ width: '100%' }}>
+                    <Button
+                      variant="contained"
+                      color="secondary"
+                      size="small"
+                      fullWidth
+                      startIcon={<AutoAwesomeIcon fontSize="small" />}
+                      onClick={onOpenCellposeConfig}
+                      disabled={isRunningCellpose || !cellposeAvailable}
+                      data-tool="cellpose"
+                      sx={{
+                        textTransform: 'none', borderRadius: 1.5,
+                        justifyContent: 'flex-start', px: 1.25,
+                        py: isMobile ? 1 : 0.7, my: 0.25,
+                        minHeight: isMobile ? 48 : undefined,
+                      }}
+                    >
+                      <Box sx={{ textAlign: 'left', ml: 0.25 }}>
+                        <Typography variant="caption" fontWeight={700} display="block" sx={{ lineHeight: 1.2 }}>
+                          AI Pre-Segmentation
+                        </Typography>
+                        <Typography variant="caption" display="block" sx={{ fontSize: '0.6rem', opacity: 0.85, lineHeight: 1.2 }}>
+                          {cellposeAvailable ? modelLabel : 'Service offline'}
+                        </Typography>
+                      </Box>
+                    </Button>
+                  </span>
+                </Tooltip>
+              )}
+
+              {/* Save — prominently after Expand Mask */}
+              {tool.id === 'expander' && (
+                <Button
+                  variant="contained"
+                  color="success"
+                  size="small"
+                  fullWidth
+                  startIcon={<SaveIcon />}
+                  onClick={onSave}
+                  disabled={isSaving}
+                  data-tool="save"
+                  sx={{
+                    textTransform: 'none', borderRadius: 1.5,
+                    justifyContent: 'flex-start', px: 1.25,
+                    py: isMobile ? 1 : 0.7, my: 0.25,
+                    minHeight: isMobile ? 48 : undefined,
+                  }}
+                >
+                  <Box sx={{ textAlign: 'left', ml: 0.25 }}>
+                    <Typography variant="caption" fontWeight={700} display="block" sx={{ lineHeight: 1.2 }}>
+                      {isSaving ? 'Saving…' : 'Save Annotation'}
+                    </Typography>
+                    <Typography variant="caption" display="block" sx={{ fontSize: '0.6rem', opacity: 0.85, lineHeight: 1.2 }}>
+                      Upload masks to cloud storage
+                    </Typography>
+                  </Box>
+                </Button>
+              )}
+            </React.Fragment>
+          );
+        })}
+
+        <Divider sx={{ my: 0.5 }} />
+
+        {/* View utilities */}
+        <ButtonBase onClick={onResetView} data-tool="fit" sx={rowSx()}>
+          <CenterFocusStrongIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
+          <Box>
+            <Typography variant="caption" fontWeight={600} display="block">Fit to Image</Typography>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
+              Reset the view to show the full image
             </Typography>
           </Box>
-        </Button>
-      )}
+        </ButtonBase>
 
-      <ButtonBase onClick={onHelp} data-tool="help"
-        sx={{ ...rowSx(), '&:hover': { bgcolor: 'rgba(0,0,0,0.04)' } }}>
-        <HelpOutlineIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
-        <Typography variant="caption" fontWeight={600}>Help & Tutorial</Typography>
-      </ButtonBase>
-    </Box>
+        <ButtonBase onClick={onToggleCLAHE} data-tool="clahe"
+          sx={{ ...rowSx(isCLAHEActive), '&:hover': { bgcolor: isCLAHEActive ? 'rgba(25,118,210,0.10)' : isLowContrast ? 'rgba(237,108,2,0.08)' : 'rgba(0,0,0,0.04)' } }}>
+          <ContrastIcon fontSize="small" sx={{ color: isCLAHEActive ? 'primary.main' : isLowContrast ? 'warning.main' : 'text.secondary', mt: 0.2, flexShrink: 0 }} />
+          <Box>
+            <Typography variant="caption" fontWeight={600} color={isCLAHEActive ? 'primary.main' : isLowContrast ? 'warning.main' : 'text.primary'} display="block">
+              {isCLAHEActive ? 'Restore Original' : 'Enhance Contrast'}
+            </Typography>
+            <Typography variant="caption" color={isLowContrast && !isCLAHEActive ? 'warning.main' : 'text.secondary'} display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
+              {isLowContrast && !isCLAHEActive ? 'Low contrast detected' : 'CLAHE contrast enhancement'}
+            </Typography>
+          </Box>
+        </ButtonBase>
+
+        {/* Undo */}
+        <ButtonBase onClick={onUndo} disabled={!canUndo} data-tool="undo" sx={rowSx()}>
+          <UndoIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
+          <Box>
+            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 0.6 }}>
+              <Typography variant="caption" fontWeight={600}>Undo</Typography>
+              {!isMobile && <ShortcutBadge k="Ctrl+Z" />}
+            </Box>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
+              Revert last annotation change
+            </Typography>
+          </Box>
+        </ButtonBase>
+
+        {/* Clear All */}
+        <ButtonBase onClick={onClearAll} data-tool="clear"
+          sx={{ ...rowSx(), '&:hover': { bgcolor: 'rgba(211,47,47,0.06)' } }}>
+          <DeleteSweepIcon fontSize="small" sx={{ color: 'error.main', mt: 0.2, flexShrink: 0 }} />
+          <Box>
+            <Typography variant="caption" fontWeight={600} color="error.main" display="block">Clear All</Typography>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
+              Remove all annotations on this image
+            </Typography>
+          </Box>
+        </ButtonBase>
+
+        <Divider sx={{ my: 0.5 }} />
+
+        <ButtonBase onClick={onOpenMaskFilter} data-tool="filter" sx={rowSx()}>
+          <FilterListIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
+          <Box>
+            <Typography variant="caption" fontWeight={600} display="block">Filter Masks</Typography>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
+              Remove masks below a minimum area
+            </Typography>
+          </Box>
+        </ButtonBase>
+
+        {/* File */}
+        <ButtonBase onClick={() => fileInputRef.current?.click()} data-tool="upload" sx={rowSx()}>
+          <UploadFileIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
+          <Box>
+            <Typography variant="caption" fontWeight={600} display="block">Upload GeoJSON</Typography>
+            <Typography variant="caption" color="text.secondary" display="block" sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
+              Import annotations from a file
+            </Typography>
+          </Box>
+        </ButtonBase>
+        {fileInput}
+
+        {/* Image info */}
+        {(imageName || (imageWidth && imageHeight)) && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 1, py: 0.4 }}>
+            <InfoIcon sx={{ fontSize: '0.85rem', color: 'text.disabled' }} />
+            <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.6rem' }} noWrap>
+              {imageName}{imageWidth && imageHeight ? ` — ${imageWidth}×${imageHeight} px` : ''}
+            </Typography>
+          </Box>
+        )}
+
+        <Box sx={{ flex: 1 }} />
+        <Divider sx={{ my: 0.5 }} />
+
+        {sessionUrl && (
+          <Button
+            variant="contained"
+            size="small"
+            fullWidth
+            startIcon={<OpenInNewIcon fontSize="small" />}
+            onClick={() => window.open(sessionUrl, '_blank', 'noopener,noreferrer')}
+            data-tool="session"
+            sx={{
+              textTransform: 'none', borderRadius: 1.5, mb: 0.5,
+              justifyContent: 'flex-start', px: 1.25,
+              py: isMobile ? 1 : 0.65,
+              minHeight: isMobile ? 48 : undefined,
+              bgcolor: '#0288d1', '&:hover': { bgcolor: '#0277bd' },
+            }}
+          >
+            <Box sx={{ textAlign: 'left', ml: 0.25 }}>
+              <Typography variant="caption" fontWeight={700} display="block" sx={{ lineHeight: 1.2 }}>
+                Session Overview
+              </Typography>
+              <Typography variant="caption" display="block" sx={{ fontSize: '0.6rem', opacity: 0.88, lineHeight: 1.2 }}>
+                Images, progress &amp; training
+              </Typography>
+            </Box>
+          </Button>
+        )}
+
+        <ButtonBase onClick={onHelp} data-tool="help"
+          sx={{ ...rowSx(), '&:hover': { bgcolor: 'rgba(0,0,0,0.04)' } }}>
+          <HelpOutlineIcon fontSize="small" sx={{ color: 'text.secondary', mt: 0.2, flexShrink: 0 }} />
+          <Typography variant="caption" fontWeight={600}>Help & Tutorial</Typography>
+        </ButtonBase>
+      </Box>
+    </>
   );
 };
 

--- a/src/pages/AnnotatePage.tsx
+++ b/src/pages/AnnotatePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useLocation, Link, useNavigate } from 'react-router-dom';
-import { Box, CircularProgress, Typography, Alert, Button as MuiButton, Tooltip } from '@mui/material';
+import { Box, CircularProgress, Typography, Alert, Button as MuiButton, Tooltip, useMediaQuery, useTheme } from '@mui/material';
 import LoginButton from '../components/LoginButton';
 import AnnotationViewer from '../components/annotate/AnnotationViewer';
 import ToolBar from '../components/annotate/ToolBar';
@@ -66,11 +66,14 @@ const AnnotatePage: React.FC<AnnotatePageProps> = ({ backTo }) => {
     return backTo || '/colab';
   }, [sessionId, serviceConfig?.label, backTo]);
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm')); // < 600px
+
   const { service, loading: serviceLoading, error: serviceError, cellposeAvailable } = useHyphaService(serviceConfig);
   const { banners, addBanner, removeBanner } = useBanners();
   const runCellposeRef = React.useRef<(config: CellposeConfig) => void>(() => {});
   const [isRunningCellpose, setIsRunningCellpose] = useState(false);
-  
+
   const [dynamicCellposeModel, setDynamicCellposeModel] = useState<string | undefined>(undefined);
   
   const { config: cellposeConfig, openDialog: openCellposeConfig, dialogElement: cellposeDialogElement, setConfig: setCellposeConfig } = useCellposeConfig({
@@ -636,6 +639,43 @@ print("CLAHE_RESULT:" + result_b64)
     }
   }, [measurePhase, measurePt1, getOlMap]);
 
+  // Touch equivalents for the measurement overlay (mobile/tablet support)
+  const handleMeasureTouchMove = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+    if (measurePhase === 'idle') return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    setMeasureScreenMouse([touch.clientX - rect.left, touch.clientY - rect.top]);
+  }, [measurePhase]);
+
+  const handleMeasureTouchEnd = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
+    const map = getOlMap?.();
+    if (!map) return;
+    // Use changedTouches (the finger that was lifted)
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const pixel: [number, number] = [touch.clientX - rect.left, touch.clientY - rect.top];
+    const coord = map.getCoordinateFromPixel(pixel);
+    const screenPos: [number, number] = pixel;
+
+    if (measurePhase === 'first') {
+      setMeasurePt1([coord[0], coord[1]]);
+      setMeasureScreenPt1(screenPos);
+      setMeasurePhase('second');
+    } else if (measurePhase === 'second' && measurePt1) {
+      const dx = coord[0] - measurePt1[0];
+      const dy = coord[1] - measurePt1[1];
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      measureCallbackRef.current?.(dist);
+      measureCallbackRef.current = null;
+      setMeasurePhase('idle');
+      setMeasurePt1(null);
+      setMeasureScreenPt1(null);
+      setMeasureScreenMouse(null);
+    }
+  }, [measurePhase, measurePt1, getOlMap]);
+
   const handleUploadGeoJSON = useCallback((file: File) => {
     const reader = new FileReader();
     reader.onload = (e) => {
@@ -686,10 +726,10 @@ print("CLAHE_RESULT:" + result_b64)
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
       {/* Compact header with logo and user button */}
       <div
-        className="flex items-center justify-between px-4 h-10 flex-shrink-0 bg-gradient-to-r from-blue-100/90 via-purple-100/85 to-cyan-100/90 backdrop-blur-lg border-b border-blue-200/40 shadow-sm"
-        style={{ position: 'relative', zIndex: 1000 }}
+        className="flex items-center justify-between px-3 flex-shrink-0 bg-gradient-to-r from-blue-100/90 via-purple-100/85 to-cyan-100/90 backdrop-blur-lg border-b border-blue-200/40 shadow-sm"
+        style={{ position: 'relative', zIndex: 1000, height: isMobile ? 48 : 40 }}
       >
-        <div className="flex items-center gap-2 z-10">
+        <div className="flex items-center gap-2 z-10 flex-shrink-0">
           {sessionUrl && (
             <Tooltip title="Go back to the Colab session — view all images, annotation progress, and training">
               <MuiButton
@@ -699,7 +739,7 @@ print("CLAHE_RESULT:" + result_b64)
                 onClick={() => navigate(backTarget)}
                 sx={{
                   minWidth: 'auto',
-                  padding: '3px 10px',
+                  padding: isMobile ? '5px 8px' : '3px 10px',
                   color: '#1976d2',
                   borderColor: 'rgba(25,118,210,0.45)',
                   bgcolor: 'rgba(255,255,255,0.7)',
@@ -713,14 +753,17 @@ print("CLAHE_RESULT:" + result_b64)
                   }
                 }}
               >
-                Session overview
+                {/* Hide text on phones to save space */}
+                <Box component="span" sx={{ display: { xs: 'none', sm: 'inline' } }}>
+                  Session overview
+                </Box>
               </MuiButton>
             </Tooltip>
           )}
         </div>
 
-        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-3">
-          <Link to="/" className="flex items-center group">
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center gap-2">
+          <Link to="/" className="flex items-center group flex-shrink-0">
             <img
               src={`${process.env.PUBLIC_URL}/static/img/bioimage-io-logo.svg`}
               alt="BioImage.IO"
@@ -728,13 +771,13 @@ print("CLAHE_RESULT:" + result_b64)
             />
           </Link>
           {serviceConfig?.label && (
-            <span className="px-2.5 py-0.5 rounded-full text-xs font-semibold bg-purple-100 text-purple-800 border border-purple-300 tracking-wide">
+            <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-purple-100 text-purple-800 border border-purple-300 tracking-wide max-w-[120px] truncate sm:max-w-none">
               {serviceConfig.label}
             </span>
           )}
         </div>
 
-        <div className="z-10">
+        <div className="z-10 flex-shrink-0">
           <LoginButton />
         </div>
       </div>
@@ -777,22 +820,26 @@ print("CLAHE_RESULT:" + result_b64)
         {/* Diameter measurement overlay */}
         {measurePhase !== 'idle' && (
           <Box
-            sx={{ position: 'absolute', inset: 0, zIndex: 500, cursor: 'crosshair' }}
+            sx={{ position: 'absolute', inset: 0, zIndex: 500, cursor: 'crosshair', touchAction: 'none' }}
             onClick={handleMeasureClick}
             onMouseMove={handleMeasureMouseMove}
+            onTouchMove={handleMeasureTouchMove}
+            onTouchEnd={handleMeasureTouchEnd}
           >
             {/* Instruction banner */}
             <Box sx={{
               position: 'absolute', top: 16, left: '50%', transform: 'translateX(-50%)',
               bgcolor: 'rgba(0,0,0,0.78)', color: '#fff',
-              px: 3, py: 1.25, borderRadius: 2,
-              fontSize: '0.875rem', pointerEvents: 'none', zIndex: 10,
-              display: 'flex', alignItems: 'center', gap: 2, whiteSpace: 'nowrap',
+              px: { xs: 2, sm: 3 }, py: 1.25, borderRadius: 2,
+              fontSize: { xs: '0.8rem', sm: '0.875rem' }, pointerEvents: 'none', zIndex: 10,
+              display: 'flex', alignItems: 'center', gap: { xs: 1, sm: 2 },
+              whiteSpace: 'normal', textAlign: 'center',
+              maxWidth: { xs: 'calc(100% - 32px)', sm: 'none' },
             }}>
               {measurePhase === 'first'
-                ? 'Click one edge of a representative cell'
-                : 'Click the opposite edge to complete measurement'}
-              <Box component="span" sx={{ fontSize: '0.75rem', opacity: 0.65 }}>Esc to cancel</Box>
+                ? 'Tap one edge of a representative cell'
+                : 'Tap the opposite edge to complete measurement'}
+              <Box component="span" sx={{ fontSize: '0.75rem', opacity: 0.65, display: { xs: 'none', sm: 'inline' } }}>Esc to cancel</Box>
             </Box>
 
             {/* SVG ruler line */}


### PR DESCRIPTION
## Summary

- **ToolBar**: Auto-collapses on phones/tablets (< 900px); all tap targets are 44px+ on mobile; expanded toolbar overlays the map on phones so the full viewport width is always available for annotations; keyboard shortcut badges hidden on mobile.
- **AnnotatePage**: Taller header (48px) on mobile; "Session overview" button shows only ← arrow on phones; label badge truncates on narrow screens. Diameter measurement overlay now handles `onTouchMove` / `onTouchEnd` so the cell measurement tool works on tablets and phones.
- **FloatingBanners**: Width adapts to near full-width on phones (was fixed 360px).

## Test plan

- [ ] Phone (< 600px): toolbar starts collapsed; expand shows overlay with backdrop; tapping backdrop collapses it
- [ ] Tablet (600–900px): toolbar starts collapsed, expands inline (not overlay)
- [ ] Desktop (≥ 900px): expanded by default, original behaviour unchanged
- [ ] All toolbar buttons are easily tappable (≥44px) on mobile
- [ ] "Measure in image" diameter tool works with touch (tap two points on a tablet/phone)
- [ ] Floating banners fit within screen width on narrow phones
- [ ] Header "Session overview" shows only ← on phone, full text on wider screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)