### PR TITLE
feat(bioengine): pin bioimage.io site to the KTH BioEngine worker only

### DIFF
--- a/src/components/ModelRunner.tsx
+++ b/src/components/ModelRunner.tsx
@@ -9,6 +9,7 @@ import {
 
 } from '../utils/modelRun';
 import { imjoyToTfjs, inferImgAxesViaSpec, mapAxes, parseAxes, isImg2Img, processForShow } from '../utils/imgProcess';
+import { BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID } from '../utils/bioengineService';
 import ModelTester from './ModelTester';
 
 // Extend the ModelRunnerEngine type to properly type the runTiles method
@@ -130,7 +131,7 @@ const ModelRunner: React.FC<ModelRunnerProps> = ({
   // Advanced settings
   const [tileSize, setTileSize] = useState<number>(512);
   const [serverUrl, setServerUrl] = useState<string>("https://hypha.aicell.io");
-  const [serviceId, setServiceId] = useState<string>("bioimage-io/model-runner");
+  const [serviceId, setServiceId] = useState<string>(BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID);
   const [token, setToken] = useState<string>("");
   
   // Button states
@@ -738,7 +739,7 @@ const ModelRunner: React.FC<ModelRunnerProps> = ({
                 type="text"
                 value={serviceId}
                 onChange={(e) => setServiceId(e.target.value)}
-                placeholder="bioimage-io/model-runner"
+                placeholder={BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-blue-500 focus:border-blue-500"
               />
             </div>

--- a/src/components/ModelTester.tsx
+++ b/src/components/ModelTester.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useHyphaStore } from '../store/hyphaStore';
+import { BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID } from '../utils/bioengineService';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Menu } from '@headlessui/react';
@@ -111,7 +112,7 @@ const ModelTester: React.FC<ModelTesterProps> = ({
     try {
       setLoadingStep('Connecting to model runner service...');
       // const runner = await server.getService('bioimage-io/bioimageio-model-runner', {mode: "last"});
-      const runner = await server.getService('bioimage-io/model-runner', {mode: "select:min:get_load"});
+      const runner = await server.getService(BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID, {mode: "select:min:get_load"});
       const modelId = artifactId.split('/').pop();
       
       setLoadingStep('Downloading and preparing model for testing...');

--- a/src/components/ModelValidator.tsx
+++ b/src/components/ModelValidator.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useHyphaStore } from '../store/hyphaStore';
+import { BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID } from '../utils/bioengineService';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Menu } from '@headlessui/react';
@@ -67,7 +68,7 @@ const ModelValidator: React.FC<ModelValidatorProps> = ({
     
     try {
       // const runner = await server.getService('bioimage-io/bioimageio-model-runner', {mode: "last"});
-      const runner = await server.getService('bioimage-io/model-runner', {mode: "select:min:get_load"});
+      const runner = await server.getService(BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID, {mode: "select:min:get_load"});
       // Parse the RDF content and assert its type
       let rdfDict = yaml.load(rdfContent) as RdfWithUploader | null;
       

--- a/src/components/bioengine/BioEngineHome.tsx
+++ b/src/components/bioengine/BioEngineHome.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useHyphaStore } from '../../store/hyphaStore';
+import { BIOIMAGEIO_WORKER_SERVICE_ID } from '../../utils/bioengineService';
 import BioEngineGuide from './BioEngineGuide';
 
 const STORAGE_KEY = 'bioengine-observed-workspaces';
@@ -196,9 +197,15 @@ const BioEngineHome: React.FC = () => {
           description: s.description || '',
         }));
       } else {
-        // External workspace: probe with short service ID
+        // External workspace: probe with short service ID. For the public
+        // bioimage-io workspace, pin to the KTH pod glob so other workers
+        // sharing the workspace (e.g. deNBI onboarding instances) aren't
+        // picked up as production workers.
+        const probeId = workspace === DEFAULT_PUBLIC_WORKSPACE
+          ? BIOIMAGEIO_WORKER_SERVICE_ID
+          : `${workspace}/bioengine-worker`;
         try {
-          const svc = await server.getService(`${workspace}/bioengine-worker`);
+          const svc = await server.getService(probeId);
           services = [{ id: svc.id, name: svc.name || svc.id, description: svc.description || '' }];
         } catch (err) {
           const errStr = String(err);

--- a/src/utils/bioengineService.ts
+++ b/src/utils/bioengineService.ts
@@ -1,0 +1,28 @@
+// Service-ID patterns used by the bioimage.io website to talk to the
+// production BioEngine workers hosted on the public `bioimage-io` Hypha
+// workspace.
+//
+// Multiple BioEngine workers can be registered on the workspace at the
+// same time (e.g. KTH for production, deNBI / TÜBİTAK during onboarding
+// or testing). The website pins itself to the KTH worker via a glob on
+// the pod client_id:
+//
+//     <pod-name>:<service-name>
+//     ^^^^^^^^^^
+//     this part is `bioengine-worker-kth-<replicaset>-<rand>` for KTH
+//     pods (and per-app sub-clients inherit the same prefix), so a
+//     `bioengine-worker-kth-*` glob on the client_id portion matches
+//     KTH and only KTH.
+//
+// Hypha resolves the glob server-side (verified live, May 2026), so
+// callers can pass these strings straight to `server.getService(...)`.
+// To re-pin to a different worker, change the prefix here and every
+// call site updates in lockstep.
+
+export const BIOIMAGEIO_WORKER_CLIENT_GLOB = 'bioengine-worker-kth-*';
+
+export const BIOIMAGEIO_WORKER_SERVICE_ID =
+  `bioimage-io/${BIOIMAGEIO_WORKER_CLIENT_GLOB}:bioengine-worker`;
+
+export const BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID =
+  `bioimage-io/${BIOIMAGEIO_WORKER_CLIENT_GLOB}:model-runner`;

--- a/src/utils/modelRun.js
+++ b/src/utils/modelRun.js
@@ -12,6 +12,7 @@ import {
   parseAxes,
   isImg2Img as checkImg2Img
 } from "./imgProcess";
+import { BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID } from "./bioengineService";
 
 // Base URL for accessing artifact files
 const ARTIFACT_BASE_URL = "https://hypha.aicell.io/bioimage-io/artifacts";
@@ -288,7 +289,7 @@ class BioEngineExecutor {
     this.serverUrl = serverUrl;
   }
 
-  async init(token = null, serviceId = 'bioimage-io/model-runner') {
+  async init(token = null, serviceId = BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID) {
     const connectOptions = {
       server_url: this.serverUrl,
       method_timeout: 360,
@@ -357,7 +358,7 @@ export class ModelRunnerEngine {
     this.modelId = null;
   }
 
-  async init(token = null, serviceId = 'bioimage-io/model-runner') {
+  async init(token = null, serviceId = BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID) {
     await this.bioengineExecutor.init(token, serviceId);
   }
 


### PR DESCRIPTION
Multiple BioEngine workers can register on the public bioimage-io Hypha workspace at once (e.g. deNBI onboarding alongside production KTH). The website was resolving the worker via a fuzzy short ID — any matching pod could be picked up.

Constrain every lookup to the KTH pod glob:

  bioimage-io/bioengine-worker-kth-*:bioengine-worker
  bioimage-io/bioengine-worker-kth-*:model-runner

Hypha resolves the * in the client_id server-side (verified live), so no list+filter dance is needed. Centralised in
src/utils/bioengineService.ts so the prefix can be re-pinned in one place when production traffic moves.

Call sites updated:
- src/utils/modelRun.js (BioEngineExecutor + ModelRunnerEngine inits)
- src/components/ModelRunner.tsx (state default + input placeholder)
- src/components/ModelTester.tsx
- src/components/ModelValidator.tsx
- src/components/bioengine/BioEngineHome.tsx (workspace browser probe for bioimage-io only; other workspaces keep the unconstrained `${workspace}/bioengine-worker` probe).

Live verification (May 2026):
- KTH worker resolves: bioengine-worker-kth-69895c7496-z8vxl:bioengine-worker bioengine-worker-kth-69895c7496-z8vxl-jn0qx9yq:model-runner
- bioengine-worker-denbi-*  rejected
- bioengine-worker-tubitak-* rejected