### PR TITLE
feat(bioengine): show all bioimage-io workers in dashboard, not just KTH

### DIFF
--- a/src/components/bioengine/BioEngineHome.tsx
+++ b/src/components/bioengine/BioEngineHome.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useHyphaStore } from '../../store/hyphaStore';
-import { BIOIMAGEIO_WORKER_SERVICE_ID } from '../../utils/bioengineService';
 import BioEngineGuide from './BioEngineGuide';
 
 const STORAGE_KEY = 'bioengine-observed-workspaces';
@@ -197,15 +196,13 @@ const BioEngineHome: React.FC = () => {
           description: s.description || '',
         }));
       } else {
-        // External workspace: probe with short service ID. For the public
-        // bioimage-io workspace, pin to the KTH pod glob so other workers
-        // sharing the workspace (e.g. deNBI onboarding instances) aren't
-        // picked up as production workers.
-        const probeId = workspace === DEFAULT_PUBLIC_WORKSPACE
-          ? BIOIMAGEIO_WORKER_SERVICE_ID
-          : `${workspace}/bioengine-worker`;
+        // External workspace: probe with short service ID. Multiple workers
+        // (KTH / deNBI / TUBITAK / Berzelius on bioimage-io) trigger the
+        // "Multiple services found" catch below, which parses every ID out
+        // and lists them all as cards. Production traffic (model-runner)
+        // is pinned to KTH separately via BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID.
         try {
-          const svc = await server.getService(probeId);
+          const svc = await server.getService(`${workspace}/bioengine-worker`);
           services = [{ id: svc.id, name: svc.name || svc.id, description: svc.description || '' }];
         } catch (err) {
           const errStr = String(err);


### PR DESCRIPTION
PR #44 pinned both the production model-runner traffic AND the BioEngine dashboard workspace browser to the KTH pod glob. With TUBITAK / deNBI / Berzelius now consolidated on the same bioimage-io workspace, the dashboard pin hides those alternatives.

Revert just the BioEngineHome.tsx workspace-browser probe: use the unconstrained `${workspace}/bioengine-worker` short ID again, which triggers the existing "Multiple services found" catch and lists every worker as a card. The model-runner pin (in modelRun.js, ModelRunner.tsx, ModelTester.tsx, ModelValidator.tsx) stays as-is, so production traffic continues to land on KTH.

Live verification (May 2026): the unconstrained probe error parses to KTH + deNBI + Berzelius (TUBITAK will appear once registered). The BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID glob still resolves to the KTH model-runner.