### PR TITLE
feat(skills): sync bioimageio-models skill to spec 0.5.10 — custom processing

### DIFF
--- a/public/skills/bioimageio-models/SKILL.md
+++ b/public/skills/bioimageio-models/SKILL.md
@@ -4,7 +4,7 @@ description: Packages, validates, and submits deep learning models to the BioIma
 compatibility: Designed for Claude Code, Gemini CLI, or any agentic AI assistant with file system and bash access. Requires Python 3.8+ and internet access for submission.
 metadata:
   author: bioimage-io
-  version: "1.7"
+  version: "1.8"
 ---
 
 # BioImage Model Zoo — Model Contribution Agent
@@ -36,8 +36,10 @@ Required:
 [ ] Model architecture code — for pytorch_state_dict (the Python class)
 [ ] Input tensor: shape, dtype, axes, channel names, expected value range
 [ ] Output tensor: shape, dtype, axes, channel names, value range
-[ ] Preprocessing — zero_mean_unit_variance / scale_range / none
-[ ] Postprocessing — sigmoid or none (note: `softmax` is NOT supported — embed it in `forward()` instead)
+[ ] Preprocessing — zero_mean_unit_variance / scale_range / custom / none
+[ ] Postprocessing — sigmoid / cellpose_flow_dynamics / stardist_postprocessing / custom / none
+      (note: `softmax` is NOT a valid built-in op — embed it in `forward()` instead)
+      (for Cellpose or StarDist models, ask if the model outputs raw flows/distances that need decoding)
 [ ] Representative test input image (any format; will be converted to .npy)
 [ ] Model name — specific, human-readable (e.g. "cFOS Segmentation 2D UNet - Mouse Hippocampus")
 [ ] Description — 2-4 sentences: what it does, modality, organism/tissue, training data
@@ -114,6 +116,8 @@ mkdir -p model_package
      --class MyModel --skip-normalize --input-shape "1,1,256,256" --output model_package/
    ```
 5. Write `model_package/rdf.yaml` — see [references/model-spec-reference.md](https://bioimage.io/skills/bioimageio-models/references/model-spec-reference.md)
+   - Use `format_version: 0.5.10`
+   - If the model needs Cellpose/StarDist decoding or custom logic, see [references/custom-processing.md](https://bioimage.io/skills/bioimageio-models/references/custom-processing.md)
 6. Write `model_package/README.md` — must contain these sections:
    - `## Description` — what the model does, modality, organism
    - `## Intended Use` — what tasks it is suitable for, known limitations
@@ -180,7 +184,7 @@ print('✓ Static validation passed:', type(desc).__name__)
 
 Fix errors and retry. Common issues:
 - Missing `sha256` for a referenced file — run `compute_sha256.py` and update the YAML
-- Wrong `format_version` — use `0.5.4`
+- Wrong `format_version` — use `0.5.10`
 - Duplicate axis `id` values **within** a single tensor (same IDs across input/output tensors is fine)
 - `pytorch_state_dict` must NOT have a `parent` field
 - `softmax` is NOT a valid postprocessing operation — embed it inside the model's `forward()`
@@ -191,11 +195,14 @@ Fix errors and retry. Common issues:
 
 ## Phase 4 — Dynamic Testing
 
-> **Python version requirement:** `bioimageio.core >= 0.8` requires **Python 3.10+** for `pytorch_state_dict` models (uses `TemporaryDirectory(ignore_cleanup_errors=True)`). For `torchscript` and `onnx` models, `bioimageio.core==0.9.0` works on Python 3.8/3.9 without downgrading. On Python 3.8/3.9 with `pytorch_state_dict`, pin to an older version: `pip install "bioimageio.core==0.6.9" "bioimageio.spec==0.5.3.2"`. On Python 3.10+, the latest versions work for all formats: `pip install "bioimageio.spec==0.5.4.3" "bioimageio.core==0.9.0"`.
+> **Python version requirement:** `bioimageio.core >= 0.8` requires **Python 3.10+** for `pytorch_state_dict` models (uses `TemporaryDirectory(ignore_cleanup_errors=True)`). For `torchscript` and `onnx` models, Python 3.8/3.9 works. On Python 3.10+, use the latest versions.
 
 ```bash
-pip install -q "bioimageio.spec==0.5.4.3" "bioimageio.core==0.9.0"
+pip install -q "bioimageio.spec>=0.5.10" "bioimageio.core>=0.10"
 bioimageio test model_package/rdf.yaml
+
+# For models with custom pre/postprocessing, add the flag:
+bioimageio test model_package/rdf.yaml --allow-custom-postprocessing
 ```
 
 Or with conda (handles Python version automatically):
@@ -510,10 +517,11 @@ EOF
 | File | When to Read |
 |------|-------------|
 | [references/model-spec-reference.md](https://bioimage.io/skills/bioimageio-models/references/model-spec-reference.md) | Writing `rdf.yaml` — all fields explained |
+| [references/custom-processing.md](https://bioimage.io/skills/bioimageio-models/references/custom-processing.md) | Custom pre/postprocessing ops, Cellpose/StarDist built-ins, security model |
 | [references/example-rdf.yaml](https://bioimage.io/skills/bioimageio-models/references/example-rdf.yaml) | Annotated example to copy from |
 | [references/submission-guide.md](https://bioimage.io/skills/bioimageio-models/references/submission-guide.md) | Hypha API calls for submission |
 | [references/success-examples.md](https://bioimage.io/skills/bioimageio-models/references/success-examples.md) | Real worked examples from past submissions |
 | [scripts/hypha_login.py](https://bioimage.io/skills/bioimageio-models/scripts/hypha_login.py) | Log in to Hypha and save token to `.env` |
-| [scripts/compute_sha256.py](https://bioimage.io/skills/bioimageio-models/scripts/compute_sha256.py) | SHA256 hash utility |
+| [scripts/compute_sha256.py](https://bioimage.io/skills/bioimageio-models/scripts/compute_sha256.py) | SHA256 hash utility (also hashes custom processing `.py` files) |
 | [scripts/generate_test_tensors.py](https://bioimage.io/skills/bioimageio-models/scripts/generate_test_tensors.py) | Generate test_input/output .npy files |
 | [scripts/validate_package.sh](https://bioimage.io/skills/bioimageio-models/scripts/validate_package.sh) | One-shot validation runner |

--- a/public/skills/bioimageio-models/references/custom-processing.md
+++ b/public/skills/bioimageio-models/references/custom-processing.md
@@ -1,0 +1,382 @@
+# Custom Pre/Postprocessing Operations
+
+Introduced in **spec 0.5.10** / **bioimageio.core 0.10+**
+
+Custom processing lets you ship arbitrary Python callables alongside your model weights to handle
+pre/postprocessing that cannot be expressed by the built-in operations. This makes it possible to
+contribute models with complex decoding logic (e.g., Cellpose flow dynamics, StarDist NMS, custom
+normalizers) while keeping the package fully self-contained and reproducible.
+
+---
+
+## Two Modes
+
+### Inline (development / submission)
+
+Ship a `.py` source file inside the model package. The file is SHA256-verified before execution.
+
+```yaml
+postprocessing:
+  - id: custom
+    callable: my_postprocess      # class or factory function name in the source file
+    source: my_postprocess.py     # path relative to rdf.yaml
+    sha256: <64-char-sha256>      # required — computed from the .py file
+    kwargs:
+      threshold: 0.5              # forwarded to the callable
+```
+
+### Built-in (for established algorithms)
+
+Reference a named operation from the standard library — no source file needed. Currently available
+built-ins are listed in the [Postprocessing Operations](#built-in-specialized-postprocessing) section below.
+
+---
+
+## Writing a Custom Callable
+
+There are two equivalent styles. Pick whichever fits your use case.
+
+### Style 1 — Callable class
+
+```python
+# my_postprocess.py
+import numpy as np
+
+class my_postprocess:
+    def __init__(self, threshold: float = 0.5) -> None:
+        self.threshold = threshold
+
+    def __call__(self, *arrays: np.ndarray) -> np.ndarray:
+        """Apply threshold to first array and return uint8 mask."""
+        return (arrays[0] > self.threshold).astype(np.uint8)
+```
+
+### Style 2 — Factory function (closure)
+
+```python
+# my_postprocess.py
+import numpy as np
+
+def my_postprocess(threshold: float = 0.5):
+    def run(*arrays: np.ndarray) -> np.ndarray:
+        return (arrays[0] > threshold).astype(np.uint8)
+    return run
+```
+
+**Both styles are called identically at runtime:**
+1. `op = my_postprocess(**kwargs)` — instantiated once per model load
+2. `result = op(*tensors)` — called once per sample
+
+**Constraints:**
+- The callable **must not change the shape** of the input tensor(s).
+- Only import packages from the BioEngine fixed runtime (see below).
+- The source file must be self-contained — no relative imports, no local helpers.
+
+### Allowed imports
+
+Only packages pre-installed in the BioEngine runtime may be imported:
+
+```
+numpy==1.26.4         scipy                 scikit-image
+torch==2.5.1          torchvision           tensorflow==2.16.1
+onnxruntime==1.20.1   bioimageio.core       xarray
+```
+
+Do **not** import `cellpose`, `stardist`, or any package not in this list. If you need Cellpose or
+StarDist decoding, use the dedicated built-in ops described below instead.
+
+---
+
+## Security Model
+
+Custom processing source files are security-reviewed before a model is accepted into the public Zoo:
+
+1. **SHA256 verification** — the `.py` file hash is checked on every load; tampered files are rejected.
+2. **Explicit opt-in** — `bioimageio.core` requires `allow_custom_postprocessing=True` to execute custom ops; the default is `False`.
+3. **Curator gate** — models with custom processing receive additional scrutiny before publication.
+4. **Import sandbox** — only pre-installed packages may be imported (no `subprocess`, `os.system`, network calls, etc.).
+
+### Running locally with allow_custom_postprocessing
+
+```python
+from bioimageio.core import load_model_description, create_prediction_pipeline
+
+model = load_model_description("model_package/rdf.yaml")
+pipeline = create_prediction_pipeline(
+    model,
+    allow_custom_postprocessing=True,   # required — explicit opt-in
+)
+```
+
+---
+
+## Built-in Specialized Postprocessing
+
+These operations are part of the standard spec; no source file is needed.
+
+### CellposeFlowDynamics
+
+Decodes Cellpose flow fields and cell probability into integer instance labels.
+
+**Expected input:** 3-channel tensor `[flow_y, flow_x, cellprob]`  
+**Output:** integer instance label tensor (uint16, 0 = background)
+
+```yaml
+postprocessing:
+  - id: cellpose_flow_dynamics
+    kwargs:
+      cellprob_threshold: 0.0    # cell probability threshold (default 0.0)
+      flow_threshold: 0.4        # flow field threshold (default 0.4)
+      do_3D: false               # enable 3D processing (default false)
+      min_size: 15               # minimum object size in pixels (default 15)
+      output_dtype: uint16       # output dtype (default uint16)
+```
+
+### StarDist2DPostprocessing
+
+Decodes StarDist probability and distance predictions into instance labels via NMS.
+
+```yaml
+postprocessing:
+  - id: stardist_postprocessing
+    kwargs:
+      grid: [2, 2]               # grid size of the network predictions
+      prob_threshold: 0.5        # object probability threshold for NMS
+      nms_threshold: 0.4         # IoU threshold for non-maximum suppression
+      n_rays: 32                 # number of radial lines (must match model output)
+```
+
+---
+
+## Input Padding
+
+Spec 0.5.10 adds an optional `pad` field to input tensor descriptors. This lets the spec declare
+how the runner should pad inputs that are smaller than the model's minimum tile size.
+
+```yaml
+inputs:
+  - id: raw
+    axes:
+      - type: space
+        id: y
+        size: 256
+      - type: space
+        id: x
+        size: 256
+    pad:
+      mode: reflect    # constant | edge | reflect | symmetric
+      # For constant mode, also set:
+      # value: 0.0
+```
+
+| Mode | Description |
+|------|-------------|
+| `constant` | Fill with a constant value (default 0) |
+| `edge` | Repeat edge values |
+| `reflect` | Mirror around the edge (edge pixel not duplicated) |
+| `symmetric` | Mirror around the edge (edge pixel is duplicated) |
+
+### Halo / output cropping
+
+Models that use padding internally may produce unreliable border pixels. Declare a `halo` on output
+spatial axes so tiling pipelines know how many pixels to discard:
+
+```yaml
+outputs:
+  - id: labels
+    axes:
+      - type: space
+        id: y
+        size:
+          tensor_id: raw
+          axis_id: y
+        halo: 32        # crop 32px from each side before assembling tiles
+      - type: space
+        id: x
+        size:
+          tensor_id: raw
+          axis_id: x
+        halo: 32
+```
+
+Use `get_halos()` from `bioimageio.core` to compute the required input padding from the output halos:
+
+```python
+from bioimageio.core import load_model_description
+from bioimageio.spec.model.v0_5 import get_halos
+
+model = load_model_description("model_package/rdf.yaml")
+halos = get_halos(model.inputs, model.outputs)
+```
+
+---
+
+## Complete Example — Cellpose Model Export
+
+This shows a minimal but complete `rdf.yaml` for a Cellpose model that uses `CellposeFlowDynamics`
+as a built-in postprocessing step.
+
+```yaml
+format_version: 0.5.10
+type: model
+name: Cellpose Nucleus Segmentation 2D
+
+description: >
+  2D Cellpose model for nucleus instance segmentation in fluorescence microscopy.
+  Outputs flow fields decoded via CellposeFlowDynamics into instance labels.
+
+license: BSD-3-Clause
+
+authors:
+  - name: Carsen Stringer
+    github_user: carsen-stringer
+
+tags:
+  - cellpose
+  - instance-segmentation
+  - nucleus
+  - 2D
+  - fluorescence
+
+inputs:
+  - id: raw
+    axes:
+      - type: batch
+        size: 1
+      - type: channel
+        channel_names: [nucleus]
+      - type: space
+        id: y
+        size: 256
+      - type: space
+        id: x
+        size: 256
+    preprocessing:
+      - id: scale_range
+        kwargs:
+          axes: [y, x]
+          min_percentile: 1.0
+          max_percentile: 99.0
+    test_tensor:
+      source: test_input.npy
+      sha256: <hash>
+
+outputs:
+  - id: flows
+    description: "3-channel output: [flow_y, flow_x, cellprob]"
+    axes:
+      - type: batch
+      - type: channel
+        channel_names: [flow_y, flow_x, cellprob]
+      - type: space
+        id: y
+        size:
+          tensor_id: raw
+          axis_id: y
+      - type: space
+        id: x
+        size:
+          tensor_id: raw
+          axis_id: x
+    postprocessing:
+      - id: cellpose_flow_dynamics
+        kwargs:
+          cellprob_threshold: 0.0
+          flow_threshold: 0.4
+          min_size: 15
+          output_dtype: uint16
+    test_tensor:
+      source: test_output.npy
+      sha256: <hash>
+
+weights:
+  pytorch_state_dict:
+    source: cellpose_weights.pt
+    sha256: <hash>
+    architecture:
+      source: cellpose_model.py
+      callable: CellposeModel
+      sha256: <hash>
+```
+
+---
+
+## Complete Example — Fully Custom Postprocessing
+
+For a model whose decoding logic is not covered by any built-in op:
+
+```yaml
+format_version: 0.5.10
+type: model
+name: Custom Decoder Model
+
+# ... (other fields) ...
+
+outputs:
+  - id: labels
+    axes:
+      - type: batch
+      - type: channel
+        channel_names: [label]
+      - type: space
+        id: y
+        size:
+          tensor_id: raw
+          axis_id: y
+      - type: space
+        id: x
+        size:
+          tensor_id: raw
+          axis_id: x
+    postprocessing:
+      - id: custom
+        callable: decode_predictions
+        source: decode_predictions.py
+        sha256: <sha256-of-decode_predictions.py>
+        kwargs:
+          threshold: 0.4
+          min_size: 20
+    test_tensor:
+      source: test_output.npy
+      sha256: <hash>
+```
+
+With `decode_predictions.py`:
+
+```python
+import numpy as np
+
+class decode_predictions:
+    def __init__(self, threshold: float = 0.4, min_size: int = 20) -> None:
+        self.threshold = threshold
+        self.min_size = min_size
+
+    def __call__(self, *arrays: np.ndarray) -> np.ndarray:
+        from skimage.measure import label
+        from skimage.morphology import remove_small_objects
+        binary = arrays[0] > self.threshold
+        labeled = label(binary)
+        labeled = remove_small_objects(labeled, min_size=self.min_size)
+        return labeled.astype(np.uint16)
+```
+
+Compute SHA256 for the source file and add it to rdf.yaml:
+
+```bash
+python public/skills/bioimageio-models/scripts/compute_sha256.py model_package/
+```
+
+---
+
+## Checklist for Custom Processing Models
+
+```
+[ ] Source file is self-contained (no local imports, no forbidden packages)
+[ ] SHA256 hash computed for source file and added to rdf.yaml
+[ ] Callable does not change tensor shape
+[ ] Tested locally with allow_custom_postprocessing=True
+[ ] Noted in README that model uses custom postprocessing
+[ ] Verified with bioimageio test:
+      pip install "bioimageio.spec>=0.5.10" "bioimageio.core>=0.10"
+      bioimageio test model_package/rdf.yaml --allow-custom-postprocessing
+```

--- a/public/skills/bioimageio-models/references/example-rdf.yaml
+++ b/public/skills/bioimageio-models/references/example-rdf.yaml
@@ -6,7 +6,7 @@
 ---
 
 # ---- IDENTITY ----
-format_version: 0.5.4     # Always 0.5.4 (current stable)
+format_version: 0.5.10    # Current stable (spec 0.5.10+ required for custom pre/postprocessing)
 type: model                # Always "model" for ML models
 
 name: UNet 2D Nuclei Broad              # 5-128 chars, human-readable, specific

--- a/public/skills/bioimageio-models/references/model-spec-reference.md
+++ b/public/skills/bioimageio-models/references/model-spec-reference.md
@@ -1,6 +1,6 @@
 # BioImage.IO Model RDF — Field Reference
 
-Format version: **0.5.4** (always use this or latest)  
+Format version: **0.5.10** (always use this or latest)  
 Spec source: https://github.com/bioimage-io/spec-bioimage-io  
 Full interactive docs: https://bioimage-io.github.io/spec-bioimage-io/interactive_docs_v0-5.html
 
@@ -11,7 +11,7 @@ Full interactive docs: https://bioimage-io.github.io/spec-bioimage-io/interactiv
 ```yaml
 %YAML 1.2
 ---
-format_version: 0.5.4
+format_version: 0.5.10
 type: model
 name: "Your Model Name Here"
 description: "One or two sentences describing what this model does."
@@ -69,7 +69,7 @@ weights:
 
 | Field | Required | Type | Notes |
 |-------|----------|------|-------|
-| `format_version` | YES | string | Always `"0.5.4"` |
+| `format_version` | YES | string | Always `"0.5.10"` (current stable) |
 | `type` | YES | string | Always `"model"` |
 | `name` | YES | string | 5–128 chars. Human-readable, descriptive. No "model" suffix needed. |
 | `description` | YES | string | Max 1024 chars. What it does, what data it handles. |
@@ -133,6 +133,8 @@ inputs:
       - id: ensure_dtype
         kwargs:
           dtype: float32
+    pad:                          # optional (spec 0.5.10+): how to pad undersized inputs
+      mode: reflect               # constant | edge | reflect | symmetric
 ```
 
 ### Axis Types
@@ -140,7 +142,7 @@ inputs:
 | Type | Description | Required subfields |
 |------|-------------|-------------------|
 | `batch` | Batch dimension | none (size defaults to inferred) |
-| `channel` | Channel dimension | `channel_names` (list of strings) |
+| `channel` | Channel dimension | `channel_names` (list of strings — arbitrary names allowed) |
 | `space` | Spatial (x, y, z) | `id` (x/y/z), `size` |
 | `time` | Time | `id`, `size` |
 | `index` | General index | `id`, `size` |
@@ -191,31 +193,41 @@ Applied to input tensors before inference:
 | Operation | kwargs | Description |
 |-----------|--------|-------------|
 | `zero_mean_unit_variance` | `axes: [y, x]` or `[c, y, x]` | Subtract mean, divide by std |
-| `scale_range` | `axes`, `min_percentile`, `max_percentile` | Percentile-based scaling |
+| `fixed_zero_mean_unit_variance` | `axes`, `mean`, `std` | Use pre-computed statistics |
+| `scale_range` | `axes`, `min_percentile`, `max_percentile`, `eps` | Percentile-based scaling |
 | `scale_linear` | `gain`, `offset` | `x = x * gain + offset` |
 | `ensure_dtype` | `dtype: float32` | Cast to dtype |
 | `binarize` | `threshold: 0.5` | Binary threshold |
 | `clip` | `min: 0.0, max: 1.0` | Clip values |
+| `custom` | `callable`, `source`, `sha256`, `kwargs` | User-supplied Python callable (spec 0.5.10+) |
 
 ## Postprocessing Operations
 
 Applied to output tensors after inference:
 
-| Operation | kwargs |
-|-----------|--------|
-| `sigmoid` | none |
-| `scale_linear` | `gain`, `offset` |
-| `ensure_dtype` | `dtype: float32` |
-| `binarize` | `threshold: 0.5` |
-| `clip` | `min`, `max` |
-| `zero_mean_unit_variance` | `axes` |
-| `scale_range` | `axes`, `min_percentile`, `max_percentile` |
-| `scale_mean_variance` | `axes` |
+| Operation | kwargs | Description |
+|-----------|--------|-------------|
+| `sigmoid` | none | Logits → probabilities |
+| `scale_linear` | `gain`, `offset` | Linear rescale |
+| `ensure_dtype` | `dtype: float32` | Cast to dtype |
+| `binarize` | `threshold: 0.5` | Binary threshold |
+| `clip` | `min`, `max` | Clip values |
+| `zero_mean_unit_variance` | `axes` | Subtract mean, divide by std |
+| `scale_range` | `axes`, `min_percentile`, `max_percentile` | Percentile-based scaling |
+| `scale_mean_variance` | `axes` | Match mean and variance to reference |
+| `cellpose_flow_dynamics` | `cellprob_threshold`, `flow_threshold`, `do_3D`, `min_size`, `output_dtype` | Cellpose flow → instance labels (spec 0.5.10+) |
+| `stardist_postprocessing` | `grid`, `prob_threshold`, `nms_threshold`, `n_rays` | StarDist probability+distance → instance labels (spec 0.5.10+) |
+| `custom` | `callable`, `source`, `sha256`, `kwargs` | User-supplied Python callable (spec 0.5.10+) |
 
 > **Note:** `softmax` is NOT a valid postprocessing operation in `bioimageio.spec` 0.5.x.
 > For multi-class models that need softmax, embed it inside the model's `forward()` method
 > so the output tensor is already a probability map. This keeps the model self-contained
 > and compatible with all runtimes.
+
+> **Custom processing:** For models that require arbitrary decoding logic (flow fields,
+> radial distance maps, etc.), use `id: custom` with an inline `.py` source file.
+> See [custom-processing.md](https://bioimage.io/skills/bioimageio-models/references/custom-processing.md)
+> for full documentation, security model, and worked examples.
 
 ---
 
@@ -369,8 +381,10 @@ Or use the helper script: `scripts/compute_sha256.py model_package/`
 | `sha256 mismatch for ...` | Recompute SHA256 and update in YAML |
 | `axis id 'x' not unique` | Axis `id` values must be unique **within** each tensor (not globally across tensors) |
 | `pytorch_state_dict cannot have parent` | Remove `parent` from `pytorch_state_dict` block |
-| `format_version not supported` | Change to `"0.5.4"` |
+| `format_version not supported` | Change to `"0.5.10"` |
 | `channel_names length != axis size` | Ensure `channel_names` list length matches number of channels |
 | `test output does not match` | Regenerate `test_output.npy` by running the model on `test_input.npy` |
 | `documentation must end in .md` | Rename doc file or fix path in YAML |
 | `name too short` | Name must be 5–128 characters |
+| `custom processing not allowed` | Pass `allow_custom_postprocessing=True` to `create_prediction_pipeline()` |
+| `source sha256 required` | Add `sha256` for every `source:` field including custom processing `.py` files |


### PR DESCRIPTION
## Summary

- **New file** `references/custom-processing.md` — comprehensive guide to the custom pre/postprocessing feature introduced in spec 0.5.10, including inline source-file mode, built-in ops (Cellpose, StarDist), security model, input padding, halos, and complete worked examples
- **Updated** `format_version` throughout: `0.5.4` → `0.5.10`
- **Updated** preprocessing/postprocessing tables in `model-spec-reference.md` to list `custom`, `cellpose_flow_dynamics`, and `stardist_postprocessing` ops
- **Updated** `SKILL.md` v1.7 → v1.8: new reference in key files table, updated package version pins, `--allow-custom-postprocessing` flag in test commands, Phase 1 checklist extended for Cellpose/StarDist models
- **Updated** `example-rdf.yaml` format_version

## Motivation

Fynn merged [spec-bioimage-io#752](https://github.com/bioimage-io/spec-bioimage-io/pull/752) which advanced the format to 0.5.10 and introduced:
- `id: custom` preprocessing/postprocessing with inline `.py` source + SHA256 verification
- Built-in `cellpose_flow_dynamics` and `stardist_postprocessing` ops
- Input tensor `pad` field
- Arbitrary channel names
- `get_halos()` helper

These changes make it possible to contribute **any** AI model to the Zoo, including those with complex decoding pipelines. The skill needed a dedicated reference file and updated documentation to guide contributors through these new options.

## Test plan

- [ ] Static validation: `bioimageio.spec>=0.5.10` accepts `format_version: 0.5.10`
- [ ] Dynamic test with custom op: `bioimageio test rdf.yaml --allow-custom-postprocessing`
- [ ] Skill loads correctly at `https://bioimage.io/skills/bioimageio-models/SKILL.md`
- [ ] New reference file reachable at `https://bioimage.io/skills/bioimageio-models/references/custom-processing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

cc @FynnBe 