### PR TITLE
Invalidate inference cache when model-runner version changes

### DIFF
--- a/.github/workflows/model-inference.yml
+++ b/.github/workflows/model-inference.yml
@@ -102,6 +102,7 @@ jobs:
 
         if [ "$TOTAL_MODELS" -gt 0 ]; then
           echo "**Total models in scope:** $TOTAL_MODELS" >> $GITHUB_STEP_SUMMARY
+          echo "**Deployed model-runner version:** ${RUNNER_VERSION:-unknown}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           echo "| Inference Result | Count | Total | Rate |" >> $GITHUB_STEP_SUMMARY
@@ -112,6 +113,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Passed includes skipped models that were already previously passed." >> $GITHUB_STEP_SUMMARY
           echo "Timeouts are included in the failed count." >> $GITHUB_STEP_SUMMARY
+          echo "Cached results from a previous runner version are re-tested when the runner version is known and differs from the stored stamp; entries without a stored stamp are also re-tested once the current runner version is known so they pick one up." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Inference check completed at:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
         else

--- a/.github/workflows/model-testing.yml
+++ b/.github/workflows/model-testing.yml
@@ -109,6 +109,7 @@ jobs:
 
         if [ "$TOTAL_MODELS" -gt 0 ]; then
           echo "**Total models tested:** $TOTAL_MODELS" >> $GITHUB_STEP_SUMMARY
+          echo "**Deployed model-runner version:** ${RUNNER_VERSION:-unknown}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           echo "| Test Result | Count | Total | Rate |" >> $GITHUB_STEP_SUMMARY

--- a/scripts/bioengine_model_infer.py
+++ b/scripts/bioengine_model_infer.py
@@ -35,6 +35,7 @@ def print_inference_summary_for_ci(summary_file: str) -> None:
         print("PASSED_RATE=0.00")
         print("FAILED_RATE=0.00")
         print("TIMEOUT_RATE=0.00")
+        print("RUNNER_VERSION=")
         return
 
     summary = json.loads(summary_path.read_text(encoding="utf-8"))
@@ -43,6 +44,7 @@ def print_inference_summary_for_ci(summary_file: str) -> None:
     passed = int(summary.get("passed", 0))
     failed = int(summary.get("failed", 0))
     timeout = int(summary.get("timeout", 0))
+    runner_version = summary.get("runner_version") or ""
 
     def rate(value: int) -> str:
         if total_models == 0:
@@ -56,6 +58,7 @@ def print_inference_summary_for_ci(summary_file: str) -> None:
     print(f"PASSED_RATE={rate(passed)}")
     print(f"FAILED_RATE={rate(failed)}")
     print(f"TIMEOUT_RATE={rate(timeout)}")
+    print(f"RUNNER_VERSION='{runner_version.replace(chr(39), '')}'")
 
 
 async def fetch_previous_results(
@@ -64,6 +67,39 @@ async def fetch_previous_results(
     collection = await artifact_manager.read(f"{WORKSPACE}/{COLLECTION}")
 
     return collection["manifest"].get("bioengine_inference", {})
+
+
+async def fetch_runner_version(runner: ObjectProxy) -> Optional[str]:
+    """Ask the deployed model-runner which BioEngine artifact version it was built from.
+
+    Returns the version string when the runner exposes ``get_version()`` and the
+    response includes a non-empty ``version`` field. Returns ``None`` when the
+    method is missing, raises, or returns no version. A ``None`` result disables
+    runner-version cache invalidation for this run so the workflow still does
+    useful work during the rollout window before the runner exposes the field.
+    """
+    try:
+        info = await runner.get_version()
+    except Exception as exc:
+        print(
+            f"Note: runner.get_version() unavailable ({exc}); "
+            "runner-version cache invalidation disabled for this run"
+        )
+        return None
+
+    if isinstance(info, dict):
+        version = info.get("version")
+    else:
+        version = info
+
+    if not version:
+        print(
+            "Note: runner reported no version; "
+            "runner-version cache invalidation disabled for this run"
+        )
+        return None
+
+    return str(version)
 
 
 async def fetch_model_ids(artifact_manager: ObjectProxy) -> List[str]:
@@ -148,6 +184,12 @@ async def check_bmz_model_inference(
     )
     artifact_manager = await server.get_service("public/artifact-manager")
 
+    current_runner_version = await fetch_runner_version(runner)
+    if current_runner_version:
+        print(f"Deployed model-runner version: {current_runner_version}")
+    else:
+        print("Deployed model-runner version: unknown")
+
     # Fetch previous test results
     previous_results = await fetch_previous_results(artifact_manager)
 
@@ -159,19 +201,29 @@ async def check_bmz_model_inference(
     results = {}
     skipped_models = 0
     timeout_models = 0
+    runner_version_invalidations = 0
     for model_id in model_ids:
         model_start_time = time.time()
 
         try:
             print(f"\nMODEL: {model_id}\n{'-' * (7 + len(model_id))}")
 
-            last_test_at = previous_results.get(model_id, {}).get("tested_at", 0)
-            last_test_status = previous_results.get(model_id, {}).get(
-                "status", "never tested"
+            previous_entry = previous_results.get(model_id, {})
+            last_test_at = previous_entry.get("tested_at", 0)
+            last_test_status = previous_entry.get("status", "never tested")
+            stored_runner_version = previous_entry.get("runner_version")
+            # Only treat the runner version as a cache-invalidation signal when we
+            # actually know the current version. When the runner does not expose
+            # the field yet, leave older entries alone instead of forcing a
+            # workflow-wide re-run.
+            runner_version_changed = (
+                current_runner_version is not None
+                and stored_runner_version != current_runner_version
             )
             latest_change = await get_latest_change(artifact_manager, model_id)
             if (
                 not skip_cache
+                and not runner_version_changed
                 and latest_change <= last_test_at
                 and last_test_status == "passed"
             ):
@@ -180,6 +232,14 @@ async def check_bmz_model_inference(
                 )
                 skipped_models += 1
                 continue
+
+            if runner_version_changed:
+                print(
+                    f"-> Model '{model_id}' was last tested against runner "
+                    f"'{stored_runner_version or 'unknown'}', current is "
+                    f"'{current_runner_version}', re-running inference"
+                )
+                runner_version_invalidations += 1
 
             image = await fetch_sample_image(artifact_manager, model_id)
 
@@ -210,11 +270,19 @@ async def check_bmz_model_inference(
             "status": status,
             "message": message[:20] if message else None,
             "tested_at": model_start_time,
+            "runner_version": current_runner_version,
         }
 
     execution_time = time.time() - start_time
     print("\n============ All Models Tested ============\n")
-    print(f"Total execution time: {execution_time:.2f} seconds\n")
+    print(f"Total execution time: {execution_time:.2f} seconds")
+    if current_runner_version:
+        print(
+            f"Runner version stamped on new results: {current_runner_version} "
+            f"(invalidated {runner_version_invalidations} stale entry/entries)"
+        )
+    else:
+        print("Runner version unknown; results stamped with null runner_version")
     print(json.dumps(results, indent=2))
 
     summary = {
@@ -226,6 +294,8 @@ async def check_bmz_model_inference(
         + timeout_models,
         "timeout": timeout_models,
         "execution_time_seconds": round(execution_time, 2),
+        "runner_version": current_runner_version,
+        "runner_version_invalidations": runner_version_invalidations,
     }
     save_inference_summary(summary_file, summary)
 

--- a/scripts/bioengine_model_test.py
+++ b/scripts/bioengine_model_test.py
@@ -10,6 +10,36 @@ from typing import List, Optional
 
 import httpx
 from hypha_rpc import connect_to_server, login
+from hypha_rpc.utils import ObjectProxy
+
+
+async def fetch_runner_version(runner: ObjectProxy) -> Optional[str]:
+    """Ask the deployed model-runner which BioEngine artifact version it was built from.
+
+    Returns the version string when the runner exposes ``get_version()`` and the
+    response includes a non-empty ``version`` field. Returns ``None`` when the
+    method is missing, raises, or returns no version. The model-runner stamps
+    its own version onto every published ``test_report.json``; this script only
+    reads it for surfacing in the CI summary.
+    """
+    try:
+        info = await runner.get_version()
+    except Exception as exc:
+        print(
+            f"Note: runner.get_version() unavailable ({exc}); "
+            "runner version will not be reported in summary"
+        )
+        return None
+
+    if isinstance(info, dict):
+        version = info.get("version")
+    else:
+        version = info
+
+    if not version:
+        return None
+
+    return str(version)
 
 
 async def test_bmz_models(
@@ -43,6 +73,12 @@ async def test_bmz_models(
     model_runner = await server.get_service(
         "bioimage-io/model-runner", {"mode": "select:min:get_load"}
     )
+
+    current_runner_version = await fetch_runner_version(model_runner)
+    if current_runner_version:
+        print(f"Deployed model-runner version: {current_runner_version}")
+    else:
+        print("Deployed model-runner version: unknown")
 
     # Fetch all model IDs if not provided
     if model_ids is None:
@@ -193,6 +229,7 @@ def analyze_existing_test_reports(reports_dir: Path) -> None:
     failed = 0
     timeout = 0
     error = 0
+    runner_versions = set()
 
     for json_file in json_files:
         try:
@@ -211,6 +248,10 @@ def analyze_existing_test_reports(reports_dir: Path) -> None:
             elif status == "service-error":
                 error += 1
 
+            report_runner_version = test_report.get("runner_version")
+            if report_runner_version:
+                runner_versions.add(str(report_runner_version))
+
         except Exception as e:
             print(f"Error processing {json_file}: {e}", file=sys.stderr)
 
@@ -222,6 +263,13 @@ def analyze_existing_test_reports(reports_dir: Path) -> None:
     failed_rate = round((failed / total_models) * 100, 1) if total_models > 0 else 0
     timeout_rate = round((timeout / total_models) * 100, 1) if total_models > 0 else 0
     error_rate = round((error / total_models) * 100, 1) if total_models > 0 else 0
+
+    if len(runner_versions) == 0:
+        runner_version_display = ""
+    elif len(runner_versions) == 1:
+        runner_version_display = next(iter(runner_versions))
+    else:
+        runner_version_display = "mixed: " + ", ".join(sorted(runner_versions))
 
     # Output variables for GitHub Actions
     print(f"TOTAL_MODELS={total_models}")
@@ -235,6 +283,7 @@ def analyze_existing_test_reports(reports_dir: Path) -> None:
     print(f"FAILED_RATE={failed_rate}")
     print(f"TIMEOUT_RATE={timeout_rate}")
     print(f"ERROR_RATE={error_rate}")
+    print(f"RUNNER_VERSION='{runner_version_display.replace(chr(39), '')}'")
 
 
 def clear_existing_test_reports(reports_dir: Path) -> None:


### PR DESCRIPTION
## Motivation

`scripts/bioengine_model_infer.py` skips re-running inference for any model whose stored entry in `collection.manifest['bioengine_inference']` reports `status: passed` and a `tested_at` newer than the model's latest file change. That cache survives a new model-runner deployment, so when the runner's code or postprocessing changes, previously cached "passed" results may no longer be valid even though nothing about the model itself changed.

## Solution

Track the deployed model-runner artifact version on every cache entry and treat a version mismatch as a cache miss. The version is fetched once at the start of each run via `runner.get_version()` (a new method the bioengine repo will expose; see "Behaviour" for the rollout window).

`bioengine_model_test.py` does not maintain its own cache layer; the model-runner is the source of truth and stamps `runner_version` directly into the published `test_report.json`. This script's role is limited to fetching the current version for the CI summary and collapsing per-report versions when analyzing the saved test reports.

## Behaviour

Cache decisions in `bioengine_model_infer.py` now consider four pieces of state: `--skip-cache`, file mtime vs. stored `tested_at`, prior `status`, and the new `runner_version`. The new rule is:

| `current_runner_version` | `stored_runner_version` | Effect on cache |
|--------------------------|-------------------------|-----------------|
| known                    | matches current         | cache used (if existing rules pass) |
| known                    | differs / missing       | cache miss; result re-run and re-stamped |
| unknown                  | any                     | runner-version check disabled; existing rules apply |

The "unknown" branch handles the rollout window: while the deployed runner still lacks `get_version()`, the workflow falls back to the existing mtime + last-status rules instead of forcing a workflow-wide re-run. Once the runner exposes the field, entries that lack a stamp are re-tested once and then settle into the new equilibrium. Users running either workflow in the gap window see "Deployed model-runner version: unknown" in the GHA step summary and their cached results behave exactly as before.

`--skip-cache` still overrides all other signals on both sides.

## Migration

The manifest schema is purely additive: existing entries `{status, message, tested_at}` keep working. New entries also carry `runner_version`, which may be `null` while the runner does not expose the field. No backfill or one-time migration is required; entries pick up a stamp the first time they re-run under a known runner version.

## Test plan

- [x] Dry-run against the live worker with `--model-ids affable-shark --dry-run`: confirms `runner.get_version()` AttributeError is caught, the rollout-window fallback path is taken, and no collection edit is attempted.
- [x] `--analyze-results` against the resulting summary file: emits eval-safe shell variables including the new `RUNNER_VERSION=''` line.
- [x] `bioengine_model_test.py --analyze-reports` exercised with three fixtures (single version, mixed versions, no version): emits `RUNNER_VERSION='0.9.7'`, `RUNNER_VERSION='mixed: 0.9.6, 0.9.7'`, and `RUNNER_VERSION=''` respectively. All three eval cleanly into a bash variable and round-trip through `${RUNNER_VERSION:-unknown}` in the GHA summary.
- [ ] First post-merge scheduled run lands a runner_version-stamped entry once the bioengine side ships `get_version()`.

## Files

- `scripts/bioengine_model_infer.py`: add `fetch_runner_version`, extend the per-model cache check with a runner-version comparison, stamp every new result, include the version and invalidation count in the summary JSON, surface it through `--analyze-results`.
- `scripts/bioengine_model_test.py`: add `fetch_runner_version` and log it at start; extend `analyze_existing_test_reports` to surface the runner version observed across the per-model reports.
- `.github/workflows/model-inference.yml`: render the deployed runner version and a one-line note about rollout-window cache semantics in the GHA step summary.
- `.github/workflows/model-testing.yml`: render the deployed runner version in the GHA step summary.
