### PR TITLE
feat(colab): refine annotated images from the All Annotated empty state

### DIFF
--- a/public/colab_service.py
+++ b/public/colab_service.py
@@ -32,9 +32,23 @@ remotely and locally, the remote entry is used.
 
 Annotation status
 -----------------
-An image is considered **annotated** only when **both** the mask PNG
-(``masks_{label}/{stem}.png``) **and** the GeoJSON
-(``masks_{label}/{stem}.geojson``) are present in the artifact.
+Masks are stored under per-user subfolders to preserve every annotator's
+contribution at the ELMI 2026 booth and in any future multi-annotator
+session:
+
+    masks_{label}/user-{user_id}/{stem}.png
+    masks_{label}/user-{user_id}/{stem}.geojson
+
+An image is **annotated for a given user** when **both** the PNG and the
+GeoJSON exist under that user's subfolder. The any-user check (used for
+the global progress meter) recursively walks every subfolder under
+``masks_{label}/`` and also accepts the legacy flat layout
+``masks_{label}/{stem}.png`` for backwards compatibility.
+
+The trainer (``bioimage-io/cellpose-finetuning`` >= 0.1.0) accepts the
+per-user layout and treats each (image, mask) pair as a separate
+training example, so multiple annotators on the same image multiply the
+training data instead of overwriting each other.
 
 Supported image formats
 -----------------------
@@ -374,22 +388,111 @@ class AnnotationSession:
 
         return registry
 
-    async def _get_annotated_stems(self) -> Set[str]:
-        """Return stems where **both** mask PNG and GeoJSON are present."""
+    @staticmethod
+    def _user_folder(user_id: Optional[str]) -> str:
+        """Return the subfolder name for a user.
+
+        Strips path-unsafe characters (``|``, ``/``, whitespace) so the
+        folder name is valid in artifact storage. ``github|49943582`` is a
+        common Hypha user id shape and is normalised to
+        ``github-49943582``.
+        """
+        raw = (user_id or "anonymous").strip()
+        if not raw:
+            raw = "anonymous"
+        safe = "".join(
+            c if c.isalnum() or c in "-_." else "-"
+            for c in raw
+        )
+        return f"user-{safe}"
+
+    async def _list_files_safe(self, dir_path: str) -> List[dict]:
+        """``list_files`` wrapper that returns ``[]`` on any error."""
         try:
             files = await self.artifact_manager.list_files(
-                self.artifact_id,
-                dir_path=f"masks_{self.label}",
-                stage=True,
+                self.artifact_id, dir_path=dir_path, stage=True
             )
-            if not files:
-                return set()
-            names = [f["name"] for f in files]
-            png_stems = {Path(n).stem for n in names if n.endswith(".png")}
-            geojson_stems = {Path(n).stem for n in names if n.endswith(".geojson")}
-            return png_stems & geojson_stems  # annotated = BOTH files present
+            return files or []
         except Exception:
+            return []
+
+    @staticmethod
+    def _is_directory_entry(entry: dict) -> bool:
+        """Best-effort directory check across artifact-manager variants.
+
+        Hypha exposes the entry type as ``type`` (``"directory"``) on some
+        backends and as ``is_dir`` on others; we accept either.
+        """
+        if entry.get("type") == "directory":
+            return True
+        if entry.get("is_dir") is True:
+            return True
+        return False
+
+    async def _get_annotated_stems_for_user(self, user_id: Optional[str]) -> Set[str]:
+        """Return stems annotated by ``user_id`` (PNG + GeoJSON both present).
+
+        Looks in ``masks_{label}/user-{user_id}/`` only. If the user has
+        never annotated, returns an empty set.
+        """
+        folder = self._user_folder(user_id)
+        files = await self._list_files_safe(f"masks_{self.label}/{folder}")
+        if not files:
             return set()
+        names = [f.get("name", "") for f in files]
+        png_stems = {Path(n).stem for n in names if n.endswith(".png")}
+        geojson_stems = {Path(n).stem for n in names if n.endswith(".geojson")}
+        return png_stems & geojson_stems
+
+    async def _get_any_user_annotated_stems(self) -> Set[str]:
+        """Return stems annotated by anyone, across all per-user subfolders
+        and the legacy flat layout.
+
+        Used for the global progress meter so the presenter can see overall
+        annotation coverage independent of who annotated each image.
+        """
+        entries = await self._list_files_safe(f"masks_{self.label}")
+        if not entries:
+            return set()
+
+        all_pngs: Set[str] = set()
+        all_geojsons: Set[str] = set()
+
+        for entry in entries:
+            name = entry.get("name", "")
+            if not name:
+                continue
+            if self._is_directory_entry(entry) or not (
+                name.endswith(".png") or name.endswith(".geojson")
+            ):
+                # Subfolder: list its files
+                sub_files = await self._list_files_safe(
+                    f"masks_{self.label}/{name}"
+                )
+                for sf in sub_files:
+                    sn = sf.get("name", "")
+                    if sn.endswith(".png"):
+                        all_pngs.add(Path(sn).stem)
+                    elif sn.endswith(".geojson"):
+                        all_geojsons.add(Path(sn).stem)
+            else:
+                # Legacy flat layout: file directly under masks_{label}/
+                if name.endswith(".png"):
+                    all_pngs.add(Path(name).stem)
+                elif name.endswith(".geojson"):
+                    all_geojsons.add(Path(name).stem)
+
+        return all_pngs & all_geojsons
+
+    async def _get_annotated_stems(self, user_id: Optional[str] = None) -> Set[str]:
+        """Return annotated stems.
+
+        With ``user_id``: only stems annotated by that user (per-user view).
+        Without ``user_id``: stems annotated by anyone (any-user view).
+        """
+        if user_id is not None:
+            return await self._get_annotated_stems_for_user(user_id)
+        return await self._get_any_user_annotated_stems()
 
     async def _upload_image(self, info: dict) -> bool:
         """Upload one local image to ``train_images/`` in the artifact.
@@ -447,20 +550,26 @@ class AnnotationSession:
         self._cellpose_model = model
         return True
 
-    async def get_image(self, context=None) -> dict:
-        """Return a presigned download URL for the next unannotated image.
+    async def get_image(self, user_id: Optional[str] = None, context=None) -> dict:
+        """Return a presigned download URL for the next image this user has
+        not yet annotated.
 
         Ensures the artifact exists first (lazy creation).  If the chosen
-        image is only available locally it is uploaded on demand.
+        image is only available locally it is uploaded on demand.  Per-user
+        ``is_annotated`` means an image is "done" only when the caller's
+        own ``masks_{label}/user-{user_id}/`` folder contains both the PNG
+        and the GeoJSON for that stem — other annotators' contributions do
+        not block this user from also annotating the same image.
 
         Return dict shapes
         ------------------
         - ``{"url": ..., "name": ..., "cellpose_model": ...}``  — normal case
         - ``{"status": "no_images", "message": ...}``           — nothing available
-        - ``{"status": "all_annotated", ...}``                  — all done
+        - ``{"status": "all_annotated", ...}``                  — all done for this user
         - ``{"status": "error", "message": ...}``               — upload failed
         """
-        console.log("get_image called")
+        effective_user = user_id or self.user_id
+        console.log(f"get_image called (user={effective_user!r})")
         await self._ensure_artifact_exists()
 
         registry = await self._build_registry()
@@ -474,11 +583,11 @@ class AnnotationSession:
                 ),
             }
 
-        annotated = await self._get_annotated_stems()
+        annotated = await self._get_annotated_stems(effective_user)
         unannotated = {s: v for s, v in registry.items() if s not in annotated}
         console.log(
-            f"Registry: {len(registry)} total, {len(annotated)} annotated, "
-            f"{len(unannotated)} remaining"
+            f"Registry: {len(registry)} total, {len(annotated)} annotated by "
+            f"{effective_user!r}, {len(unannotated)} remaining"
         )
 
         if not unannotated:
@@ -527,15 +636,21 @@ class AnnotationSession:
         self,
         image_stem: str,
         label: Optional[str] = None,
+        user_id: Optional[str] = None,
         context=None,
     ) -> dict:
-        """Return URL for a specific image plus any existing annotation GeoJSON.
+        """Return URL for a specific image plus the caller's existing GeoJSON
+        for it, if any.
 
         Used when refining a previously-saved annotation: the call bypasses
         the unannotated-image filter from :meth:`get_image` so the UI can
         re-open an image even when every entry in the artifact is already
-        annotated.  Local-only images are uploaded on demand, mirroring the
-        behaviour of :meth:`get_image`.
+        annotated by this user. Local-only images are uploaded on demand,
+        mirroring the behaviour of :meth:`get_image`.
+
+        ``existing_geojson_url`` is fetched from the caller's per-user
+        subfolder. If the caller has not annotated this stem before, the
+        URL is ``None`` and the user starts from a blank canvas.
 
         Return dict shapes
         ------------------
@@ -543,7 +658,11 @@ class AnnotationSession:
         - ``{"status": "not_found", "message": ...}``                         -- missing stem
         - ``{"status": "error", "message": ...}``                             -- upload failed
         """
-        console.log(f"get_image_by_stem: stem={image_stem!r}, label={label!r}")
+        effective_user = user_id or self.user_id
+        console.log(
+            f"get_image_by_stem: stem={image_stem!r}, label={label!r}, "
+            f"user={effective_user!r}"
+        )
         await self._ensure_artifact_exists()
 
         registry = await self._build_registry()
@@ -570,11 +689,12 @@ class AnnotationSession:
         url = await self._get_download_url(info["name"])
 
         effective_label = label or self.label
+        folder = self._user_folder(effective_user)
         existing_geojson_url: Optional[str] = None
         try:
             existing_geojson_url = await self.artifact_manager.get_file(
                 self.artifact_id,
-                file_path=f"masks_{effective_label}/{image_stem}.geojson",
+                file_path=f"masks_{effective_label}/{folder}/{image_stem}.geojson",
                 stage=True,
             )
         except Exception:
@@ -699,40 +819,64 @@ class AnnotationSession:
 
         return {"total": total, "success": success, "failed": failed, "errors": errors}
 
-    async def get_save_urls(self, image_name: str, label: str = None, context=None) -> dict:
-        """Return presigned PUT URLs for saving annotation files.
+    async def get_save_urls(
+        self,
+        image_name: str,
+        label: Optional[str] = None,
+        user_id: Optional[str] = None,
+        context=None,
+    ) -> dict:
+        """Return presigned PUT URLs for saving annotation files into the
+        caller's per-user subfolder.
 
-        ``label`` overrides the session label when provided (allows the
-        annotation UI to specify which label it is saving for).
+        ``label`` overrides the session label when provided. ``user_id``
+        identifies the annotator (browser anonymous id or Hypha user id);
+        falls back to the session owner's id.
 
         Returns ``{"png_url": ..., "geojson_url": ..., "image_stem": ...}``
         """
         effective_label = label if label else self.label
+        effective_user = user_id or self.user_id
+        folder = self._user_folder(effective_user)
         stem = Path(image_name).stem
-        console.log(f"get_save_urls for {stem}, label={effective_label!r}")
+        console.log(
+            f"get_save_urls for {stem}, label={effective_label!r}, "
+            f"user={effective_user!r} -> {folder}/"
+        )
         await self._ensure_artifact_exists()
         png_url = await self.artifact_manager.put_file(
-            self.artifact_id, file_path=f"masks_{effective_label}/{stem}.png"
+            self.artifact_id,
+            file_path=f"masks_{effective_label}/{folder}/{stem}.png",
         )
         geojson_url = await self.artifact_manager.put_file(
-            self.artifact_id, file_path=f"masks_{effective_label}/{stem}.geojson"
+            self.artifact_id,
+            file_path=f"masks_{effective_label}/{folder}/{stem}.geojson",
         )
         return {"png_url": png_url, "geojson_url": geojson_url, "image_stem": stem}
 
-    async def list_images(self, context=None) -> List[dict]:
-        """List all images with their annotation status.
+    async def list_images(
+        self,
+        user_id: Optional[str] = None,
+        context=None,
+    ) -> List[dict]:
+        """List all images with both per-user and any-user annotation status.
 
-        Returns a list of dicts: ``name``, ``stem``, ``source``,
-        ``is_annotated``.
+        ``is_annotated`` reflects the caller's own contribution (true if
+        this user annotated the stem). ``annotated_by_any`` reflects
+        whether any user has annotated the stem (used by the global
+        progress meter).
         """
+        effective_user = user_id or self.user_id
         registry = await self._build_registry()
-        annotated = await self._get_annotated_stems()
+        per_user = await self._get_annotated_stems(effective_user)
+        any_user = await self._get_any_user_annotated_stems()
         return [
             {
                 "name": info["name"],
                 "stem": stem,
                 "source": info["source"],
-                "is_annotated": stem in annotated,
+                "is_annotated": stem in per_user,
+                "annotated_by_any": stem in any_user,
             }
             for stem, info in sorted(registry.items())
         ]

--- a/public/colab_service.py
+++ b/public/colab_service.py
@@ -406,6 +406,22 @@ class AnnotationSession:
         )
         return f"user-{safe}"
 
+    @staticmethod
+    def _round_folder(round_n: Optional[int]) -> str:
+        """Return the round subfolder name (``rN``) for the given round
+        number. Defaults to ``r1`` when ``round_n`` is missing, zero, or
+        non-positive.
+        """
+        n = round_n if isinstance(round_n, int) and round_n > 0 else 1
+        return f"r{n}"
+
+    @classmethod
+    def _user_round_folder(
+        cls, user_id: Optional[str], round_n: Optional[int]
+    ) -> str:
+        """``user-{id}/rN`` — the leaf annotation folder for one user-round."""
+        return f"{cls._user_folder(user_id)}/{cls._round_folder(round_n)}"
+
     async def _list_files_safe(self, dir_path: str) -> List[dict]:
         """``list_files`` wrapper that returns ``[]`` on any error."""
         try:
@@ -429,14 +445,18 @@ class AnnotationSession:
             return True
         return False
 
-    async def _get_annotated_stems_for_user(self, user_id: Optional[str]) -> Set[str]:
-        """Return stems annotated by ``user_id`` (PNG + GeoJSON both present).
+    async def _get_annotated_stems_for_user(
+        self,
+        user_id: Optional[str],
+        round_n: Optional[int] = None,
+    ) -> Set[str]:
+        """Return stems annotated by ``user_id`` in ``round_n``.
 
-        Looks in ``masks_{label}/user-{user_id}/`` only. If the user has
-        never annotated, returns an empty set.
+        Looks in ``masks_{label}/user-{user_id}/r{N}/`` (PNG + GeoJSON both
+        present). When ``round_n`` is missing, falls back to round 1.
         """
-        folder = self._user_folder(user_id)
-        files = await self._list_files_safe(f"masks_{self.label}/{folder}")
+        leaf = self._user_round_folder(user_id, round_n)
+        files = await self._list_files_safe(f"masks_{self.label}/{leaf}")
         if not files:
             return set()
         names = [f.get("name", "") for f in files]
@@ -444,54 +464,100 @@ class AnnotationSession:
         geojson_stems = {Path(n).stem for n in names if n.endswith(".geojson")}
         return png_stems & geojson_stems
 
-    async def _get_any_user_annotated_stems(self) -> Set[str]:
-        """Return stems annotated by anyone, across all per-user subfolders
-        and the legacy flat layout.
+    async def _get_max_round_for_user(self, user_id: Optional[str]) -> int:
+        """Return the highest existing round number for this user.
 
-        Used for the global progress meter so the presenter can see overall
-        annotation coverage independent of who annotated each image.
+        Scans ``masks_{label}/user-{user_id}/`` for ``r{N}`` subfolders and
+        returns the largest ``N`` it finds. Returns ``0`` if the user has
+        no rounds yet (callers can interpret as "no annotation history").
         """
-        entries = await self._list_files_safe(f"masks_{self.label}")
-        if not entries:
+        folder = self._user_folder(user_id)
+        entries = await self._list_files_safe(f"masks_{self.label}/{folder}")
+        max_round = 0
+        for e in entries:
+            name = e.get("name", "")
+            if not name or not self._is_directory_entry(e):
+                continue
+            if name.startswith("r") and name[1:].isdigit():
+                n = int(name[1:])
+                if n > max_round:
+                    max_round = n
+        return max_round
+
+    async def _get_any_user_annotated_stems(self) -> Set[str]:
+        """Return stems annotated by anyone, across all per-user/per-round
+        subfolders, the legacy per-user-only layout, and the original flat
+        layout.
+
+        Walks up to two levels of subfolders under ``masks_{label}/`` so a
+        stem counts as annotated when it appears at any of:
+            masks_{label}/{stem}.png                   (legacy flat)
+            masks_{label}/user-X/{stem}.png            (per-user no round)
+            masks_{label}/user-X/rN/{stem}.png         (per-user per-round)
+        """
+        top = await self._list_files_safe(f"masks_{self.label}")
+        if not top:
             return set()
 
         all_pngs: Set[str] = set()
         all_geojsons: Set[str] = set()
 
-        for entry in entries:
-            name = entry.get("name", "")
-            if not name:
+        def _accumulate(file_name: str) -> None:
+            if file_name.endswith(".png"):
+                all_pngs.add(Path(file_name).stem)
+            elif file_name.endswith(".geojson"):
+                all_geojsons.add(Path(file_name).stem)
+
+        for top_entry in top:
+            top_name = top_entry.get("name", "")
+            if not top_name:
                 continue
-            if self._is_directory_entry(entry) or not (
-                name.endswith(".png") or name.endswith(".geojson")
-            ):
-                # Subfolder: list its files
-                sub_files = await self._list_files_safe(
-                    f"masks_{self.label}/{name}"
+            top_is_dir = self._is_directory_entry(top_entry) or not (
+                top_name.endswith(".png") or top_name.endswith(".geojson")
+            )
+            if not top_is_dir:
+                _accumulate(top_name)
+                continue
+            # Descend one level (per-user folder)
+            second = await self._list_files_safe(
+                f"masks_{self.label}/{top_name}"
+            )
+            for sec_entry in second:
+                sec_name = sec_entry.get("name", "")
+                if not sec_name:
+                    continue
+                sec_is_dir = self._is_directory_entry(sec_entry) or not (
+                    sec_name.endswith(".png") or sec_name.endswith(".geojson")
                 )
-                for sf in sub_files:
-                    sn = sf.get("name", "")
-                    if sn.endswith(".png"):
-                        all_pngs.add(Path(sn).stem)
-                    elif sn.endswith(".geojson"):
-                        all_geojsons.add(Path(sn).stem)
-            else:
-                # Legacy flat layout: file directly under masks_{label}/
-                if name.endswith(".png"):
-                    all_pngs.add(Path(name).stem)
-                elif name.endswith(".geojson"):
-                    all_geojsons.add(Path(name).stem)
+                if not sec_is_dir:
+                    # File directly under per-user folder (no round)
+                    _accumulate(sec_name)
+                    continue
+                # Descend one more level (per-round folder)
+                third = await self._list_files_safe(
+                    f"masks_{self.label}/{top_name}/{sec_name}"
+                )
+                for third_entry in third:
+                    third_name = third_entry.get("name", "")
+                    if not third_name:
+                        continue
+                    _accumulate(third_name)
 
         return all_pngs & all_geojsons
 
-    async def _get_annotated_stems(self, user_id: Optional[str] = None) -> Set[str]:
+    async def _get_annotated_stems(
+        self,
+        user_id: Optional[str] = None,
+        round_n: Optional[int] = None,
+    ) -> Set[str]:
         """Return annotated stems.
 
-        With ``user_id``: only stems annotated by that user (per-user view).
-        Without ``user_id``: stems annotated by anyone (any-user view).
+        With ``user_id``: stems annotated by that user in ``round_n``
+        (defaults to round 1 when missing). Without ``user_id``: stems
+        annotated by anyone, anywhere in the masks tree.
         """
         if user_id is not None:
-            return await self._get_annotated_stems_for_user(user_id)
+            return await self._get_annotated_stems_for_user(user_id, round_n)
         return await self._get_any_user_annotated_stems()
 
     async def _upload_image(self, info: dict) -> bool:
@@ -550,26 +616,35 @@ class AnnotationSession:
         self._cellpose_model = model
         return True
 
-    async def get_image(self, user_id: Optional[str] = None, context=None) -> dict:
+    async def get_image(
+        self,
+        user_id: Optional[str] = None,
+        round_n: Optional[int] = None,
+        context=None,
+    ) -> dict:
         """Return a presigned download URL for the next image this user has
-        not yet annotated.
+        not yet annotated **in the given round**.
 
         Ensures the artifact exists first (lazy creation).  If the chosen
         image is only available locally it is uploaded on demand.  Per-user
         ``is_annotated`` means an image is "done" only when the caller's
-        own ``masks_{label}/user-{user_id}/`` folder contains both the PNG
-        and the GeoJSON for that stem — other annotators' contributions do
-        not block this user from also annotating the same image.
+        own ``masks_{label}/user-{user_id}/r{N}/`` folder contains both
+        the PNG and the GeoJSON for that stem — other annotators'
+        contributions and the same user's *other* rounds do not block this
+        user from annotating the same image in the current round.
 
         Return dict shapes
         ------------------
-        - ``{"url": ..., "name": ..., "cellpose_model": ...}``  — normal case
+        - ``{"url": ..., "name": ..., "cellpose_model": ..., "round": N}``   — normal case
         - ``{"status": "no_images", "message": ...}``           — nothing available
-        - ``{"status": "all_annotated", ...}``                  — all done for this user
+        - ``{"status": "all_annotated", "round": N, ...}``      — all done for this user in round N
         - ``{"status": "error", "message": ...}``               — upload failed
         """
         effective_user = user_id or self.user_id
-        console.log(f"get_image called (user={effective_user!r})")
+        effective_round = round_n if isinstance(round_n, int) and round_n > 0 else 1
+        console.log(
+            f"get_image called (user={effective_user!r}, round={effective_round})"
+        )
         await self._ensure_artifact_exists()
 
         registry = await self._build_registry()
@@ -583,11 +658,11 @@ class AnnotationSession:
                 ),
             }
 
-        annotated = await self._get_annotated_stems(effective_user)
+        annotated = await self._get_annotated_stems(effective_user, effective_round)
         unannotated = {s: v for s, v in registry.items() if s not in annotated}
         console.log(
             f"Registry: {len(registry)} total, {len(annotated)} annotated by "
-            f"{effective_user!r}, {len(unannotated)} remaining"
+            f"{effective_user!r} in r{effective_round}, {len(unannotated)} remaining"
         )
 
         if not unannotated:
@@ -596,9 +671,10 @@ class AnnotationSession:
                 "total": len(registry),
                 "annotated": len(annotated),
                 "label": self.label,
+                "round": effective_round,
                 "message": (
                     f"All {len(registry)} images have been annotated for label "
-                    f"'{self.label}'."
+                    f"'{self.label}' in round {effective_round}."
                 ),
             }
 
@@ -630,6 +706,7 @@ class AnnotationSession:
             "url": url,
             "name": chosen["name"],
             "cellpose_model": self._cellpose_model,
+            "round": effective_round,
         }
 
     async def get_image_by_stem(
@@ -637,6 +714,7 @@ class AnnotationSession:
         image_stem: str,
         label: Optional[str] = None,
         user_id: Optional[str] = None,
+        round_n: Optional[int] = None,
         context=None,
     ) -> dict:
         """Return URL for a specific image plus the caller's existing GeoJSON
@@ -659,9 +737,10 @@ class AnnotationSession:
         - ``{"status": "error", "message": ...}``                             -- upload failed
         """
         effective_user = user_id or self.user_id
+        effective_round = round_n if isinstance(round_n, int) and round_n > 0 else 1
         console.log(
             f"get_image_by_stem: stem={image_stem!r}, label={label!r}, "
-            f"user={effective_user!r}"
+            f"user={effective_user!r}, round={effective_round}"
         )
         await self._ensure_artifact_exists()
 
@@ -689,12 +768,12 @@ class AnnotationSession:
         url = await self._get_download_url(info["name"])
 
         effective_label = label or self.label
-        folder = self._user_folder(effective_user)
+        leaf = self._user_round_folder(effective_user, effective_round)
         existing_geojson_url: Optional[str] = None
         try:
             existing_geojson_url = await self.artifact_manager.get_file(
                 self.artifact_id,
-                file_path=f"masks_{effective_label}/{folder}/{image_stem}.geojson",
+                file_path=f"masks_{effective_label}/{leaf}/{image_stem}.geojson",
                 stage=True,
             )
         except Exception:
@@ -703,6 +782,7 @@ class AnnotationSession:
         return {
             "url": url,
             "name": info["name"],
+            "round": effective_round,
             "existing_geojson_url": existing_geojson_url,
             "cellpose_model": self._cellpose_model,
         }
@@ -824,51 +904,63 @@ class AnnotationSession:
         image_name: str,
         label: Optional[str] = None,
         user_id: Optional[str] = None,
+        round_n: Optional[int] = None,
         context=None,
     ) -> dict:
         """Return presigned PUT URLs for saving annotation files into the
-        caller's per-user subfolder.
+        caller's per-user, per-round subfolder.
 
         ``label`` overrides the session label when provided. ``user_id``
         identifies the annotator (browser anonymous id or Hypha user id);
-        falls back to the session owner's id.
+        falls back to the session owner's id. ``round_n`` is the round
+        index (defaults to 1).
 
-        Returns ``{"png_url": ..., "geojson_url": ..., "image_stem": ...}``
+        Returns ``{"png_url": ..., "geojson_url": ..., "image_stem": ...,
+        "round": N}``.
         """
         effective_label = label if label else self.label
         effective_user = user_id or self.user_id
-        folder = self._user_folder(effective_user)
+        effective_round = round_n if isinstance(round_n, int) and round_n > 0 else 1
+        leaf = self._user_round_folder(effective_user, effective_round)
         stem = Path(image_name).stem
         console.log(
             f"get_save_urls for {stem}, label={effective_label!r}, "
-            f"user={effective_user!r} -> {folder}/"
+            f"user={effective_user!r}, round={effective_round} -> {leaf}/"
         )
         await self._ensure_artifact_exists()
         png_url = await self.artifact_manager.put_file(
             self.artifact_id,
-            file_path=f"masks_{effective_label}/{folder}/{stem}.png",
+            file_path=f"masks_{effective_label}/{leaf}/{stem}.png",
         )
         geojson_url = await self.artifact_manager.put_file(
             self.artifact_id,
-            file_path=f"masks_{effective_label}/{folder}/{stem}.geojson",
+            file_path=f"masks_{effective_label}/{leaf}/{stem}.geojson",
         )
-        return {"png_url": png_url, "geojson_url": geojson_url, "image_stem": stem}
+        return {
+            "png_url": png_url,
+            "geojson_url": geojson_url,
+            "image_stem": stem,
+            "round": effective_round,
+        }
 
     async def list_images(
         self,
         user_id: Optional[str] = None,
+        round_n: Optional[int] = None,
         context=None,
     ) -> List[dict]:
-        """List all images with both per-user and any-user annotation status.
+        """List all images with per-user-per-round and any-user annotation
+        status.
 
-        ``is_annotated`` reflects the caller's own contribution (true if
-        this user annotated the stem). ``annotated_by_any`` reflects
-        whether any user has annotated the stem (used by the global
-        progress meter).
+        ``is_annotated`` reflects the caller's contribution in the given
+        round (true if this user annotated the stem in ``r{round_n}``).
+        ``annotated_by_any`` reflects whether *any* user has annotated the
+        stem in *any* round (used by the global progress meter).
         """
         effective_user = user_id or self.user_id
+        effective_round = round_n if isinstance(round_n, int) and round_n > 0 else 1
         registry = await self._build_registry()
-        per_user = await self._get_annotated_stems(effective_user)
+        per_user = await self._get_annotated_stems(effective_user, effective_round)
         any_user = await self._get_any_user_annotated_stems()
         return [
             {
@@ -880,6 +972,29 @@ class AnnotationSession:
             }
             for stem, info in sorted(registry.items())
         ]
+
+    async def get_current_round(
+        self,
+        user_id: Optional[str] = None,
+        context=None,
+    ) -> dict:
+        """Return the user's highest existing round number.
+
+        The frontend calls this at session load to initialise its local
+        ``currentRound`` state. When the user has no rounds yet, this
+        returns ``current_round: 1`` (the default round all callers start
+        on).
+
+        Returns ``{"current_round": N, "max_existing_round": M}`` where
+        ``M`` is 0 when the user has never annotated.
+        """
+        effective_user = user_id or self.user_id
+        await self._ensure_artifact_exists()
+        max_existing = await self._get_max_round_for_user(effective_user)
+        return {
+            "current_round": max_existing if max_existing > 0 else 1,
+            "max_existing_round": max_existing,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -1054,6 +1169,7 @@ async def register_service(
                 "upload_images_from_temp": session.upload_images_from_temp,
                 "get_save_urls": session.get_save_urls,
                 "list_images": session.list_images,
+                "get_current_round": session.get_current_round,
                 "set_cellpose_model": session.set_cellpose_model,
                 "write_file_to_temp": write_file_to_temp,
             }

--- a/public/colab_service.py
+++ b/public/colab_service.py
@@ -523,6 +523,70 @@ class AnnotationSession:
             "cellpose_model": self._cellpose_model,
         }
 
+    async def get_image_by_stem(
+        self,
+        image_stem: str,
+        label: Optional[str] = None,
+        context=None,
+    ) -> dict:
+        """Return URL for a specific image plus any existing annotation GeoJSON.
+
+        Used when refining a previously-saved annotation: the call bypasses
+        the unannotated-image filter from :meth:`get_image` so the UI can
+        re-open an image even when every entry in the artifact is already
+        annotated.  Local-only images are uploaded on demand, mirroring the
+        behaviour of :meth:`get_image`.
+
+        Return dict shapes
+        ------------------
+        - ``{"url", "name", "existing_geojson_url"|None, "cellpose_model"}``  -- found
+        - ``{"status": "not_found", "message": ...}``                         -- missing stem
+        - ``{"status": "error", "message": ...}``                             -- upload failed
+        """
+        console.log(f"get_image_by_stem: stem={image_stem!r}, label={label!r}")
+        await self._ensure_artifact_exists()
+
+        registry = await self._build_registry()
+        if image_stem not in registry:
+            return {
+                "status": "not_found",
+                "message": f"Image '{image_stem}' not found in this session.",
+            }
+
+        info = registry[image_stem]
+        if info["source"] == "local":
+            remote = await self._list_remote_images()
+            already_remote = any(Path(f["name"]).stem == image_stem for f in remote)
+            if not already_remote:
+                if not await self._upload_image(info):
+                    return {
+                        "status": "error",
+                        "message": (
+                            f"Failed to upload image '{info['name']}'. "
+                            "Check console for details."
+                        ),
+                    }
+
+        url = await self._get_download_url(info["name"])
+
+        effective_label = label or self.label
+        existing_geojson_url: Optional[str] = None
+        try:
+            existing_geojson_url = await self.artifact_manager.get_file(
+                self.artifact_id,
+                file_path=f"masks_{effective_label}/{image_stem}.geojson",
+                stage=True,
+            )
+        except Exception:
+            existing_geojson_url = None
+
+        return {
+            "url": url,
+            "name": info["name"],
+            "existing_geojson_url": existing_geojson_url,
+            "cellpose_model": self._cellpose_model,
+        }
+
     async def upload_all_images(self, context=None) -> dict:
         """Upload all images from the local folder to the artifact.
 
@@ -841,6 +905,7 @@ async def register_service(
                     "require_context": True,
                 },
                 "get_image": session.get_image,
+                "get_image_by_stem": session.get_image_by_stem,
                 "upload_all_images": session.upload_all_images,
                 "upload_images_from_temp": session.upload_images_from_temp,
                 "get_save_urls": session.get_save_urls,

--- a/src/components/annotate/CellposeConfigDialog.tsx
+++ b/src/components/annotate/CellposeConfigDialog.tsx
@@ -154,7 +154,7 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 0.5 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
                   <Typography variant="body2" fontWeight={500}>Cell Diameter (px)</Typography>
-                  <InfoTip text="Cellpose-SAM was trained on cell diameters from 7.5 to 120 px. When set, the image is rescaled so cells appear ~30 px (scale = 30 ÷ diameter). Leave empty to run at original scale — safe when cells are roughly in the 7.5–120 px range. Set this if your cells are outside that range." />
+                  <InfoTip text="Cellpose-SAM was trained on cell diameters from 7.5 to 120 px. When set, the image is rescaled so cells appear ~30 px (scale = 30 ÷ diameter). Leave empty to run at original scale: safe when cells are roughly in the 7.5 to 120 px range. Set this if your cells are outside that range." />
                 </Box>
                 {onMeasureDiameter && (
                   <Tooltip title="Measure a representative cell in the image to set the diameter automatically">

--- a/src/components/annotate/ToolBar.tsx
+++ b/src/components/annotate/ToolBar.tsx
@@ -188,7 +188,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
             {/* AI Segmentation sits right after Draw Mask */}
             {tool.id === 'polygon' && (
               <Tooltip
-                title={cellposeAvailable ? `AI Segmentation — ${modelLabel}` : 'AI Segmentation unavailable — cellpose service is offline'}
+                title={cellposeAvailable ? `AI Segmentation: ${modelLabel}` : 'AI Segmentation unavailable (cellpose service is offline)'}
                 placement="right"
               >
                 <span>
@@ -255,7 +255,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
           </IconButton>
         </Tooltip>
 
-        <Tooltip title={isCLAHEActive ? 'Restore Original Image' : isLowContrast && !isCLAHEActive ? 'Low contrast detected — Enhance Contrast (CLAHE)' : 'Enhance Contrast (CLAHE)'} placement="right">
+        <Tooltip title={isCLAHEActive ? 'Restore Original Image' : isLowContrast && !isCLAHEActive ? 'Low contrast detected. Enhance Contrast (CLAHE)' : 'Enhance Contrast (CLAHE)'} placement="right">
           <IconButton size={btnSize} data-tool="clahe" onClick={onToggleCLAHE}
             sx={isCLAHEActive ? { ...collapsedBtnSx(true), ...touchSx } : isLowContrast ? {
               ...collapsedBtnSx(),
@@ -273,7 +273,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
 
         <Divider flexItem sx={{ my: 0.25, opacity: 0.35 }} />
 
-        <Tooltip title={`${imageName || 'No image'} — ${imageWidth}×${imageHeight} px`} placement="right">
+        <Tooltip title={`${imageName || 'No image'} (${imageWidth}×${imageHeight} px)`} placement="right">
           <IconButton size={btnSize} data-tool="info" sx={{ ...collapsedBtnSx(), ...touchSx }}>
             <InfoIcon fontSize="small" />
           </IconButton>
@@ -287,7 +287,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
         {fileInput}
 
         {sessionUrl && (
-          <Tooltip title="Session overview — view all images, annotation progress & training" placement="right">
+          <Tooltip title="Session overview: view all images, annotation progress & training" placement="right">
             <IconButton size={btnSize} data-tool="session"
               onClick={() => window.open(sessionUrl, '_blank', 'noopener,noreferrer')}
               sx={{ ...collapsedBtnSx(), color: 'info.main', ...touchSx }}>
@@ -561,7 +561,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 1, py: 0.4 }}>
             <InfoIcon sx={{ fontSize: '0.85rem', color: 'text.disabled' }} />
             <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.6rem' }} noWrap>
-              {imageName}{imageWidth && imageHeight ? ` — ${imageWidth}×${imageHeight} px` : ''}
+              {imageName}{imageWidth && imageHeight ? ` (${imageWidth}×${imageHeight} px)` : ''}
             </Typography>
           </Box>
         )}

--- a/src/components/annotate/hooks/useHyphaService.ts
+++ b/src/components/annotate/hooks/useHyphaService.ts
@@ -46,6 +46,12 @@ export interface ImageResult {
   name: string;
   cellpose_model?: string;
   existing_geojson_url?: string | null;
+  round?: number;
+}
+
+export interface CurrentRoundResult {
+  current_round: number;
+  max_existing_round: number;
 }
 
 export interface ImageInfo {
@@ -64,10 +70,19 @@ export interface ImageNotFoundResult {
 }
 
 export interface AnnotationDataService {
-  getImage: () => Promise<ImageResult | AllAnnotatedResult | NoImagesResult>;
-  getImageByStem: (stem: string) => Promise<ImageResult | ImageNotFoundResult>;
-  listImages: () => Promise<ImageInfo[]>;
-  getSaveUrls: (imageName: string) => Promise<SaveUrls>;
+  /** The annotator id resolved at connect time (Hypha workspace user id, or
+   *  a localStorage anon uuid for booth visitors). Surfaced for diagnostic
+   *  banners and as the key for round-state storage. */
+  userId: string;
+  /** Highest existing round number for this user when the connection was
+   *  established. Returned by the colab service's get_current_round. The
+   *  React component holds the live current round in its own state and
+   *  passes it to every call below. */
+  initialRound: number;
+  getImage: (round: number) => Promise<ImageResult | AllAnnotatedResult | NoImagesResult>;
+  getImageByStem: (stem: string, round: number) => Promise<ImageResult | ImageNotFoundResult>;
+  listImages: (round: number) => Promise<ImageInfo[]>;
+  getSaveUrls: (imageName: string, round: number) => Promise<SaveUrls>;
   runCellpose: (imageUrl: string, width: number, height: number, params?: CellposeParams) => Promise<CellposeMask[]>;
 }
 
@@ -260,9 +275,23 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
       setError(null);
 
       try {
-        const server = await hyphaWebsocketClient.connectToServer({
-          server_url: config.serverUrl,
-        });
+        // Pull the user's auth token from localStorage so logged-in users
+        // connect into their own Hypha workspace (ws-user-<id>). The
+        // workspace shape is what useHyphaService uses to resolve a stable
+        // per-annotator user_id below. Anonymous booth visitors fall back
+        // to a localStorage anon uuid.
+        let storedToken: string | undefined;
+        try {
+          const t = window.localStorage.getItem('token');
+          const expiryRaw = window.localStorage.getItem('tokenExpiry');
+          const stillValid = !expiryRaw || new Date(expiryRaw).getTime() > Date.now();
+          if (t && stillValid) storedToken = t;
+        } catch {
+          // localStorage may be unavailable in private modes; carry on anonymous.
+        }
+        const connectCfg: any = { server_url: config.serverUrl };
+        if (storedToken) connectCfg.token = storedToken;
+        const server = await hyphaWebsocketClient.connectToServer(connectCfg);
         if (cancelled) {
           await server.disconnect();
           return;
@@ -298,6 +327,24 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
         if (cancelled) return;
         console.log('[useHyphaService] Got data service:', dataService);
 
+        // Ask the data service which round this user is on. New users get 1;
+        // returning users pick up where they left off.
+        let resolvedInitialRound = 1;
+        try {
+          const cr = await dataService.get_current_round({
+            user_id: resolvedUserId,
+            _rkwargs: true,
+          });
+          const n = cr && (cr.current_round as number);
+          if (typeof n === 'number' && n > 0) {
+            resolvedInitialRound = n;
+          }
+          console.log('[useHyphaService] Initial round:', resolvedInitialRound,
+            '(max existing:', cr?.max_existing_round, ')');
+        } catch (err) {
+          console.warn('[useHyphaService] get_current_round failed, defaulting to 1:', err);
+        }
+
         // Get cellpose service — use mode:"random" for load-balanced selection
         // across multiple registered workers with the same service id
         let cellposeService: any = null;
@@ -311,9 +358,12 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
         }
 
         const wrappedService: AnnotationDataService = {
-          getImage: async () => {
+          userId: resolvedUserId,
+          initialRound: resolvedInitialRound,
+          getImage: async (round: number) => {
             const result = await dataService.get_image({
               user_id: resolvedUserId,
+              round_n: round,
               _rkwargs: true,
             });
             // Service returns a dict with status field for terminal states
@@ -337,12 +387,13 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
             console.log('[useHyphaService] Image Info:', result);
             return result as ImageResult;
           },
-          getImageByStem: async (stem: string) => {
-            console.log('[useHyphaService] Getting image by stem:', stem, 'label:', config.label, 'user:', resolvedUserId);
+          getImageByStem: async (stem: string, round: number) => {
+            console.log('[useHyphaService] Getting image by stem:', stem, 'label:', config.label, 'user:', resolvedUserId, 'round:', round);
             const result = await dataService.get_image_by_stem({
               image_stem: stem,
               label: config.label,
               user_id: resolvedUserId,
+              round_n: round,
               _rkwargs: true,
             });
             if (result && typeof result === 'object' && (result as any).status === 'not_found') {
@@ -351,19 +402,21 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
             }
             return result as ImageResult;
           },
-          listImages: async () => {
+          listImages: async (round: number) => {
             const result = await dataService.list_images({
               user_id: resolvedUserId,
+              round_n: round,
               _rkwargs: true,
             });
             return (result || []) as ImageInfo[];
           },
-          getSaveUrls: async (imageName: string) => {
-            console.log('[useHyphaService] Getting save URLs for:', imageName, 'user:', resolvedUserId);
+          getSaveUrls: async (imageName: string, round: number) => {
+            console.log('[useHyphaService] Getting save URLs for:', imageName, 'user:', resolvedUserId, 'round:', round);
             const urls = await dataService.get_save_urls({
               image_name: imageName,
               label: config.label,
               user_id: resolvedUserId,
+              round_n: round,
               _rkwargs: true,
             });
             return urls as SaveUrls;

--- a/src/components/annotate/hooks/useHyphaService.ts
+++ b/src/components/annotate/hooks/useHyphaService.ts
@@ -45,10 +45,25 @@ export interface ImageResult {
   url: string;
   name: string;
   cellpose_model?: string;
+  existing_geojson_url?: string | null;
+}
+
+export interface ImageInfo {
+  name: string;
+  stem: string;
+  source: 'local' | 'remote';
+  is_annotated: boolean;
+}
+
+export interface ImageNotFoundResult {
+  status: 'not_found';
+  message: string;
 }
 
 export interface AnnotationDataService {
   getImage: () => Promise<ImageResult | AllAnnotatedResult | NoImagesResult>;
+  getImageByStem: (stem: string) => Promise<ImageResult | ImageNotFoundResult>;
+  listImages: () => Promise<ImageInfo[]>;
   getSaveUrls: (imageName: string) => Promise<SaveUrls>;
   runCellpose: (imageUrl: string, width: number, height: number, params?: CellposeParams) => Promise<CellposeMask[]>;
 }
@@ -291,6 +306,23 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
             }
             console.log('[useHyphaService] Image Info:', result);
             return result as ImageResult;
+          },
+          getImageByStem: async (stem: string) => {
+            console.log('[useHyphaService] Getting image by stem:', stem, 'label:', config.label);
+            const result = await dataService.get_image_by_stem({
+              image_stem: stem,
+              label: config.label,
+              _rkwargs: true,
+            });
+            if (result && typeof result === 'object' && (result as any).status === 'not_found') {
+              console.warn('[useHyphaService] Image not found:', result);
+              return result as ImageNotFoundResult;
+            }
+            return result as ImageResult;
+          },
+          listImages: async () => {
+            const result = await dataService.list_images();
+            return (result || []) as ImageInfo[];
           },
           getSaveUrls: async (imageName: string) => {
             console.log('[useHyphaService] Getting save URLs for:', imageName);

--- a/src/components/annotate/hooks/useHyphaService.ts
+++ b/src/components/annotate/hooks/useHyphaService.ts
@@ -52,7 +52,10 @@ export interface ImageInfo {
   name: string;
   stem: string;
   source: 'local' | 'remote';
+  /** Whether the *current annotator* has saved both PNG + GeoJSON for this image. */
   is_annotated: boolean;
+  /** Whether *any* annotator has saved this image (used for global progress). */
+  annotated_by_any?: boolean;
 }
 
 export interface ImageNotFoundResult {
@@ -267,6 +270,30 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
         serverRef.current = server;
         console.log('[useHyphaService] Connected to workspace:', server.config.workspace);
 
+        // Derive a stable per-annotator id. Logged-in users get their Hypha
+        // user id (workspace shape ws-user-<id>). Anonymous booth visitors
+        // get a localStorage-backed uuid that persists across reloads on
+        // the same browser, so their per-user mask folder stays consistent.
+        const workspaceName: string = server.config?.workspace || '';
+        let resolvedUserId = '';
+        if (workspaceName.startsWith('ws-user-')) {
+          resolvedUserId = workspaceName.substring('ws-user-'.length);
+        } else {
+          try {
+            const stored = window.localStorage.getItem('bioimage_annot_anon_id');
+            if (stored) {
+              resolvedUserId = stored;
+            } else {
+              const fresh = 'anon-' + Math.random().toString(36).slice(2, 12);
+              window.localStorage.setItem('bioimage_annot_anon_id', fresh);
+              resolvedUserId = fresh;
+            }
+          } catch {
+            resolvedUserId = 'anon-' + Math.random().toString(36).slice(2, 12);
+          }
+        }
+        console.log('[useHyphaService] Resolved annotator user_id:', resolvedUserId);
+
         const dataService = await server.getService(config.imageProviderId);
         if (cancelled) return;
         console.log('[useHyphaService] Got data service:', dataService);
@@ -285,7 +312,10 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
 
         const wrappedService: AnnotationDataService = {
           getImage: async () => {
-            const result = await dataService.get_image();
+            const result = await dataService.get_image({
+              user_id: resolvedUserId,
+              _rkwargs: true,
+            });
             // Service returns a dict with status field for terminal states
             if (result && typeof result === 'object') {
               const status = (result as any).status;
@@ -308,10 +338,11 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
             return result as ImageResult;
           },
           getImageByStem: async (stem: string) => {
-            console.log('[useHyphaService] Getting image by stem:', stem, 'label:', config.label);
+            console.log('[useHyphaService] Getting image by stem:', stem, 'label:', config.label, 'user:', resolvedUserId);
             const result = await dataService.get_image_by_stem({
               image_stem: stem,
               label: config.label,
+              user_id: resolvedUserId,
               _rkwargs: true,
             });
             if (result && typeof result === 'object' && (result as any).status === 'not_found') {
@@ -321,12 +352,20 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
             return result as ImageResult;
           },
           listImages: async () => {
-            const result = await dataService.list_images();
+            const result = await dataService.list_images({
+              user_id: resolvedUserId,
+              _rkwargs: true,
+            });
             return (result || []) as ImageInfo[];
           },
           getSaveUrls: async (imageName: string) => {
-            console.log('[useHyphaService] Getting save URLs for:', imageName);
-            const urls = await dataService.get_save_urls(imageName);
+            console.log('[useHyphaService] Getting save URLs for:', imageName, 'user:', resolvedUserId);
+            const urls = await dataService.get_save_urls({
+              image_name: imageName,
+              label: config.label,
+              user_id: resolvedUserId,
+              _rkwargs: true,
+            });
             return urls as SaveUrls;
           },
           runCellpose: async (imageUrl: string, width: number, height: number, params?: CellposeParams) => {

--- a/src/components/colab/ColabPage.tsx
+++ b/src/components/colab/ColabPage.tsx
@@ -10,6 +10,7 @@ import TrainingModal from './TrainingModal';
 import ImageViewer, { SplitInfo } from './ImageViewer';
 import TrainingPage from '../../pages/TrainingPage';
 import AnnotatePage from '../../pages/AnnotatePage';
+import LoginButton from '../LoginButton';
 
 const ColabPageContent: React.FC = () => {
   const navigate = useNavigate();
@@ -43,6 +44,7 @@ const ColabPageContent: React.FC = () => {
   const [sessionName, setSessionName] = useState<string>('');
   const [dataSourceType, setDataSourceType] = useState<'local' | 'upload' | 'resume'>('upload');
   const [showSessionModal, setShowSessionModal] = useState(false);
+  const [showLoginRequiredDialog, setShowLoginRequiredDialog] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showTrainingModal, setShowTrainingModal] = useState(false);
@@ -656,7 +658,7 @@ print("Service registered successfully", end='')
 
   const createAnnotationSession = () => {
     if (!user?.email) {
-      alert('Please login first');
+      setShowLoginRequiredDialog(true);
       return;
     }
     // Kick off the Python kernel boot (idempotent — no-op if already running)
@@ -666,6 +668,16 @@ print("Service registered successfully", end='')
     requestKernel();
     setShowSessionModal(true);
   };
+
+  // Once the user logs in (via the dialog or the navbar), close the
+  // login-required dialog and continue into the session-modal flow.
+  useEffect(() => {
+    if (user?.email && showLoginRequiredDialog) {
+      setShowLoginRequiredDialog(false);
+      requestKernel();
+      setShowSessionModal(true);
+    }
+  }, [user?.email, showLoginRequiredDialog, requestKernel]);
 
   const handleDeleteSuccess = () => {
     setDataArtifactId(null);
@@ -741,9 +753,6 @@ print("Service registered successfully", end='')
     ? Math.round((annotationsList.length / imageList.length) * 100)
     : 0;
 
-  // Check if we're loading a session from URL
-  const isLoadingSession = sessionId && (!isReady || !user?.email || !artifactManager);
-
   if (isTrainingRoute) {
     return (
       <Routes>
@@ -798,52 +807,8 @@ print("Service registered successfully", end='')
           </div>
         </div>
 
-        {/* Loading Session Overlay */}
-        {isLoadingSession && (
-          <div className="max-w-3xl mx-auto mb-6">
-            <div className="bg-gradient-to-r from-purple-50 to-blue-50 border border-purple-200/60 rounded-xl p-6 shadow-md">
-              <div className="flex items-start gap-4">
-                <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center flex-shrink-0 shadow-lg">
-                  <div className="w-6 h-6 border-3 border-white border-t-transparent rounded-full animate-spin"></div>
-                </div>
-                <div className="flex-1">
-                  <h3 className="text-lg font-semibold text-purple-900 mb-2">Loading Session...</h3>
-                  <p className="text-sm text-gray-700 mb-3">
-                    Session ID: <code className="bg-white/60 px-2 py-0.5 rounded text-xs font-mono">{sessionId}</code>
-                  </p>
-                  <div className="space-y-1.5 text-sm">
-                    <div className="flex items-center gap-2">
-                      {kernelStatus === 'idle' ? (
-                        <span className="text-emerald-600">✓ Python kernel ready</span>
-                      ) : kernelStatus === 'starting' ? (
-                        <span className="text-blue-600">⏳ Starting Python kernel...</span>
-                      ) : (
-                        <span className="text-gray-600">○ Python kernel</span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      {user?.email ? (
-                        <span className="text-emerald-600">✓ User logged in</span>
-                      ) : (
-                        <span className="text-amber-600">⏳ Please log in...</span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-2">
-                      {artifactManager ? (
-                        <span className="text-emerald-600">✓ Artifact manager connected</span>
-                      ) : (
-                        <span className="text-blue-600">⏳ Connecting to server...</span>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
         {/* Login Info - Vibrant */}
-        {!user?.email && !isLoadingSession && (
+        {!user?.email && (
           <div className="max-w-3xl mx-auto mb-6">
             <div className="bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-200/60 rounded-xl p-4 shadow-sm">
               <div className="flex items-start gap-3">
@@ -876,24 +841,16 @@ print("Service registered successfully", end='')
             <div className={`max-w-4xl mx-auto ${containerMargin}`}>
               <div className={`bg-white/80 backdrop-blur-sm rounded-2xl border border-gray-200/60 shadow-md ${containerPad}`}>
                 <div className="grid grid-cols-3 gap-4">
-                  {/* Step 1 — only gated on login. The Python kernel is booted
-                      on click (idempotent) and the modal surfaces its progress,
-                      so the user is never blocked from opening the dialog. */}
+                  {/* Step 1 - always clickable. When logged out, clicking shows
+                      the login dialog instead of the session modal. The Python
+                      kernel boots in the background as soon as the user logs in
+                      and the modal opens. */}
                   <button
                     onClick={createAnnotationSession}
-                    disabled={!user?.email}
-                    className={`group text-left ${cardPad} rounded-xl border-2 transition-all duration-200 ${
-                      user?.email
-                        ? 'border-purple-200/60 hover:border-purple-400 hover:shadow-lg hover:shadow-purple-100 bg-gradient-to-br from-white to-purple-50/30'
-                        : 'border-gray-100 bg-gray-50/50 cursor-not-allowed opacity-60'
-                    }`}
+                    className={`group text-left ${cardPad} rounded-xl border-2 transition-all duration-200 border-purple-200/60 hover:border-purple-400 hover:shadow-lg hover:shadow-purple-100 bg-gradient-to-br from-white to-purple-50/30`}
                   >
                     <div className={`flex items-center gap-3 ${headerMargin}`}>
-                      <div className={`${markerSize} rounded-lg flex items-center justify-center font-semibold transition-all ${
-                        user?.email
-                          ? 'bg-gradient-to-br from-purple-500 to-pink-500 text-white shadow-md group-hover:shadow-lg group-hover:scale-110'
-                          : 'bg-gray-200 text-gray-500'
-                      }`}>
+                      <div className={`${markerSize} rounded-lg flex items-center justify-center font-semibold transition-all bg-gradient-to-br from-purple-500 to-pink-500 text-white shadow-md group-hover:shadow-lg group-hover:scale-110`}>
                         1
                       </div>
                       <h3 className={`font-semibold text-gray-900 ${titleSize}`}>Start Session</h3>
@@ -1064,6 +1021,41 @@ print("Service registered successfully", end='')
       )}
 
       {/* Modals */}
+      {showLoginRequiredDialog && (
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50"
+          onClick={() => setShowLoginRequiredDialog(false)}
+        >
+          <div
+            className="bg-white rounded-2xl shadow-lg max-w-md w-full mx-4 p-6"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start gap-3 mb-4">
+              <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-blue-500 to-indigo-500 flex items-center justify-center flex-shrink-0 shadow-md">
+                <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1" />
+                </svg>
+              </div>
+              <div className="flex-1">
+                <h2 className="text-lg font-semibold text-gray-900">Log in to continue</h2>
+                <p className="text-sm text-gray-600 mt-1">
+                  You need to be logged in to create or resume an annotation session.
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center justify-end gap-3 mt-6">
+              <button
+                onClick={() => setShowLoginRequiredDialog(false)}
+                className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <LoginButton />
+            </div>
+          </div>
+        </div>
+      )}
+
       {showSessionModal && (
         <SessionModal
           setShowSessionModal={setShowSessionModal}

--- a/src/components/colab/ColabPage.tsx
+++ b/src/components/colab/ColabPage.tsx
@@ -305,7 +305,9 @@ service_info = await register_service(
     label="${sessionLabel}",
     client_id="${clientId}",
     service_id="${serviceId}",
-    cellpose_model="${storedModelForResume}"
+    cellpose_model="${storedModelForResume}",
+    user_id="${user?.id || ''}",
+    user_email="${user?.email || ''}"
 )
 print("Service registered successfully", end='')
 `;
@@ -606,13 +608,51 @@ print("Service registered successfully", end='')
       setIsLoadingAnnotations(true);
       try {
         const dirPath = label ? `masks_${label}` : "annotations";
-        const files = await artifactManager.list_files({
+        const entries = await artifactManager.list_files({
             artifact_id: dataArtifactId,
             dir_path: dirPath,
-            _rkwargs: true
+            _rkwargs: true,
         });
-        const fileNames = files.map((f: any) => f.name).sort();
-        setAnnotationsList(fileNames);
+        // Per-user layout: top-level entries are user subfolders. Walk one
+        // level deep and concatenate every mask filename so the global
+        // is_annotated check sees a coverage list across all annotators.
+        // Legacy flat-layout files at the top level still work.
+        const collected: string[] = [];
+        const subdirs: string[] = [];
+        for (const entry of entries || []) {
+          const name = entry?.name || '';
+          if (!name) continue;
+          const isDir = entry?.type === 'directory' || entry?.is_dir === true ||
+            !(name.endsWith('.png') || name.endsWith('.geojson'));
+          if (isDir) {
+            subdirs.push(name);
+          } else {
+            collected.push(name);
+          }
+        }
+        // Fetch each subdir in parallel; preserve the subdir prefix so the
+        // ImageViewer can construct a working mask URL pointing into the
+        // per-user folder (and so the legacy flat-layout entries above
+        // still uniquely identify themselves by absence of a slash).
+        const subResults = await Promise.all(
+          subdirs.map(async (sub) => {
+            try {
+              const subFiles = await artifactManager.list_files({
+                artifact_id: dataArtifactId,
+                dir_path: `${dirPath}/${sub}`,
+                _rkwargs: true,
+              });
+              return (subFiles || [])
+                .map((f: any) => f?.name)
+                .filter(Boolean)
+                .map((n: string) => `${sub}/${n}`);
+            } catch {
+              return [];
+            }
+          })
+        );
+        for (const r of subResults) collected.push(...r);
+        setAnnotationsList(collected.sort());
       } catch (error: any) {
         const msg = (error?.message || String(error)).toLowerCase();
         if (!msg.includes('does not exist') && !msg.includes('not found') && !msg.includes('keyerror')) {

--- a/src/components/colab/ColabPage.tsx
+++ b/src/components/colab/ColabPage.tsx
@@ -608,51 +608,44 @@ print("Service registered successfully", end='')
       setIsLoadingAnnotations(true);
       try {
         const dirPath = label ? `masks_${label}` : "annotations";
-        const entries = await artifactManager.list_files({
-            artifact_id: dataArtifactId,
-            dir_path: dirPath,
-            _rkwargs: true,
-        });
-        // Per-user layout: top-level entries are user subfolders. Walk one
-        // level deep and concatenate every mask filename so the global
-        // is_annotated check sees a coverage list across all annotators.
-        // Legacy flat-layout files at the top level still work.
-        const collected: string[] = [];
-        const subdirs: string[] = [];
-        for (const entry of entries || []) {
-          const name = entry?.name || '';
-          if (!name) continue;
-          const isDir = entry?.type === 'directory' || entry?.is_dir === true ||
-            !(name.endsWith('.png') || name.endsWith('.geojson'));
-          if (isDir) {
-            subdirs.push(name);
-          } else {
-            collected.push(name);
-          }
-        }
-        // Fetch each subdir in parallel; preserve the subdir prefix so the
-        // ImageViewer can construct a working mask URL pointing into the
-        // per-user folder (and so the legacy flat-layout entries above
-        // still uniquely identify themselves by absence of a slash).
-        const subResults = await Promise.all(
-          subdirs.map(async (sub) => {
-            try {
-              const subFiles = await artifactManager.list_files({
-                artifact_id: dataArtifactId,
-                dir_path: `${dirPath}/${sub}`,
-                _rkwargs: true,
-              });
-              return (subFiles || [])
-                .map((f: any) => f?.name)
-                .filter(Boolean)
-                .map((n: string) => `${sub}/${n}`);
-            } catch {
-              return [];
+        // Walk up to two levels of subfolders below masks_{label}/ so we
+        // cover every layout produced over time:
+        //   - flat:           masks_{label}/{stem}.png
+        //   - per-user:       masks_{label}/user-X/{stem}.png
+        //   - per-user-round: masks_{label}/user-X/rN/{stem}.png
+        // Entries are stored relative to masks_{label}/, with subfolders
+        // preserved, so the ImageViewer can pick the latest-round path.
+        const isFile = (e: any, name: string): boolean =>
+          !(e?.type === 'directory' || e?.is_dir === true ||
+            !(name.endsWith('.png') || name.endsWith('.geojson')));
+
+        const walk = async (sub: string): Promise<string[]> => {
+          const collected: string[] = [];
+          try {
+            const entries = await artifactManager.list_files({
+              artifact_id: dataArtifactId,
+              dir_path: sub ? `${dirPath}/${sub}` : dirPath,
+              _rkwargs: true,
+            });
+            for (const e of entries || []) {
+              const name = e?.name || '';
+              if (!name) continue;
+              const rel = sub ? `${sub}/${name}` : name;
+              if (isFile(e, name)) {
+                collected.push(rel);
+              } else {
+                const deeper = await walk(rel);
+                collected.push(...deeper);
+              }
             }
-          })
-        );
-        for (const r of subResults) collected.push(...r);
-        setAnnotationsList(collected.sort());
+          } catch {
+            // ignore missing directories
+          }
+          return collected;
+        };
+
+        const all = await walk('');
+        setAnnotationsList(all.sort());
       } catch (error: any) {
         const msg = (error?.message || String(error)).toLowerCase();
         if (!msg.includes('does not exist') && !msg.includes('not found') && !msg.includes('keyerror')) {

--- a/src/components/colab/ColabPage.tsx
+++ b/src/components/colab/ColabPage.tsx
@@ -1146,7 +1146,7 @@ print("Service registered successfully", end='')
               <div className="flex-1 min-w-0">
                 <p className="font-medium text-sm">New model selected</p>
                 <p className="text-xs text-green-100 mt-0.5">
-                  Training completed — Cellpose model auto-updated to the new session.
+                  Training completed. Cellpose model auto-updated to the new session.
                 </p>
               </div>
               <button

--- a/src/components/colab/ImageViewer.tsx
+++ b/src/components/colab/ImageViewer.tsx
@@ -276,11 +276,18 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
       if (hasMasks) {
         const maskFolder = label ? `masks_${label}` : 'annotations';
         const baseName = image.substring(0, image.lastIndexOf('.')) || image;
-        await artifactManager.remove_file({
-          artifact_id: dataArtifactId,
-          file_path: `${maskFolder}/${baseName}.png`,
-          _rkwargs: true
-        });
+        // Remove every annotator's mask + geojson for this stem. annotationsList
+        // entries may be either flat ("img.png") or per-user ("user-X/img.png").
+        const matching = annotationsList.filter(ann => stemOf(ann) === baseName);
+        await Promise.all(
+          matching.map(rel =>
+            artifactManager.remove_file({
+              artifact_id: dataArtifactId,
+              file_path: `${maskFolder}/${rel}`,
+              _rkwargs: true,
+            }).catch(() => {})
+          )
+        );
         setDeletedAnnotations(prev => { const next = new Set(prev); next.add(baseName); return next; });
       }
 
@@ -293,13 +300,26 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     }
   };
 
+  // annotationsList entries may be either flat-layout filenames ("img.png")
+  // or per-user paths ("user-X/img.png"). Strip any leading subfolder and
+  // the extension before comparing to the image stem.
+  const stemOf = (annPath: string): string => {
+    const leaf = annPath.includes('/') ? annPath.substring(annPath.lastIndexOf('/') + 1) : annPath;
+    return leaf.substring(0, leaf.lastIndexOf('.')) || leaf;
+  };
+
   const isAnnotated = (imageName: string) => {
     const baseName = imageName.substring(0, imageName.lastIndexOf('.')) || imageName;
     if (deletedAnnotations.has(baseName)) return false;
-    return annotationsList.some(ann => {
-      const annBaseName = ann.substring(0, ann.lastIndexOf('.')) || ann;
-      return annBaseName === baseName;
-    });
+    return annotationsList.some(ann => stemOf(ann) === baseName);
+  };
+
+  // Return the relative-to-maskFolder path of the first annotation file that
+  // matches the given image stem, e.g. "user-X/img.png" or "img.png".
+  const findAnnotationRelPath = (imageName: string): string | null => {
+    const baseName = imageName.substring(0, imageName.lastIndexOf('.')) || imageName;
+    const hit = annotationsList.find(ann => stemOf(ann) === baseName && ann.endsWith('.png'));
+    return hit || null;
   };
 
   // Load image URLs when selected
@@ -367,7 +387,8 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
 
         if (annotated) {
           const maskFolder = label ? `masks_${label}` : 'annotations';
-          const annUrl = `${serverUrl}/bioimage-io/artifacts/${artifactAlias}/files/${maskFolder}/${baseName}.png`;
+          const relPath = findAnnotationRelPath(selectedImage) || `${baseName}.png`;
+          const annUrl = `${serverUrl}/bioimage-io/artifacts/${artifactAlias}/files/${maskFolder}/${relPath}`;
           setAnnotationUrl(annUrl);
         } else {
           setAnnotationUrl('');

--- a/src/components/colab/ImageViewer.tsx
+++ b/src/components/colab/ImageViewer.tsx
@@ -300,12 +300,23 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     }
   };
 
-  // annotationsList entries may be either flat-layout filenames ("img.png")
-  // or per-user paths ("user-X/img.png"). Strip any leading subfolder and
-  // the extension before comparing to the image stem.
+  // annotationsList entries may be any of:
+  //   - flat:           "img.png"
+  //   - per-user:       "user-X/img.png"
+  //   - per-user-round: "user-X/rN/img.png"
+  // Strip subfolders + extension before comparing to the image stem.
   const stemOf = (annPath: string): string => {
     const leaf = annPath.includes('/') ? annPath.substring(annPath.lastIndexOf('/') + 1) : annPath;
     return leaf.substring(0, leaf.lastIndexOf('.')) || leaf;
+  };
+
+  // Pull the round number out of a path like "user-X/r3/img.png" -> 3.
+  // Returns 0 when no rN segment is present (flat or per-user-only layouts).
+  const roundOf = (annPath: string): number => {
+    for (const part of annPath.split('/')) {
+      if (/^r\d+$/.test(part)) return parseInt(part.slice(1), 10);
+    }
+    return 0;
   };
 
   const isAnnotated = (imageName: string) => {
@@ -314,12 +325,18 @@ const ImageViewer: React.FC<ImageViewerProps> = ({
     return annotationsList.some(ann => stemOf(ann) === baseName);
   };
 
-  // Return the relative-to-maskFolder path of the first annotation file that
-  // matches the given image stem, e.g. "user-X/img.png" or "img.png".
+  // Return the path (relative to maskFolder) of the LATEST mask matching the
+  // image stem. "Latest" = highest rN; among equal rN, last in alpha order.
+  // Flat-layout matches (rN=0) win only when no per-user/per-round entry
+  // exists.
   const findAnnotationRelPath = (imageName: string): string | null => {
     const baseName = imageName.substring(0, imageName.lastIndexOf('.')) || imageName;
-    const hit = annotationsList.find(ann => stemOf(ann) === baseName && ann.endsWith('.png'));
-    return hit || null;
+    const matches = annotationsList.filter(
+      ann => stemOf(ann) === baseName && ann.endsWith('.png')
+    );
+    if (matches.length === 0) return null;
+    matches.sort((a, b) => roundOf(b) - roundOf(a) || (a < b ? 1 : -1));
+    return matches[0];
   };
 
   // Load image URLs when selected

--- a/src/components/colab/Training.tsx
+++ b/src/components/colab/Training.tsx
@@ -456,11 +456,17 @@ const Training: React.FC<TrainingProps> = ({
         console.log(`Starting new training with model: ${selectedModel}`);
       }
 
-      // Match both flat (legacy) and per-user (user-X/) layouts in one
-      // glob. cellpose-finetuning >= 0.1.0 accepts comma-separated
-      // patterns and walks recursively, so masks_{label}/user-X/{stem}.png
-      // gets picked up alongside the flat masks_{label}/{stem}.png.
-      const trainPattern = `${maskFolder}/*.png,${maskFolder}/*.geojson,${maskFolder}/*/*.png,${maskFolder}/*/*.geojson`;
+      // Match every layout variant we have written over time. cellpose-
+      // finetuning >= 0.1.0 accepts comma-separated patterns and walks
+      // recursively, so we list all three depths explicitly:
+      //   - flat:           masks_{label}/{stem}.{png,geojson}
+      //   - per-user:       masks_{label}/user-X/{stem}.{png,geojson}
+      //   - per-user-round: masks_{label}/user-X/rN/{stem}.{png,geojson}
+      const trainPattern = [
+        `${maskFolder}/*.png`,           `${maskFolder}/*.geojson`,
+        `${maskFolder}/*/*.png`,         `${maskFolder}/*/*.geojson`,
+        `${maskFolder}/*/*/*.png`,       `${maskFolder}/*/*/*.geojson`,
+      ].join(',');
 
       const trainingParams: any = {
         artifact: String(artifactToUse),

--- a/src/components/colab/Training.tsx
+++ b/src/components/colab/Training.tsx
@@ -456,11 +456,17 @@ const Training: React.FC<TrainingProps> = ({
         console.log(`Starting new training with model: ${selectedModel}`);
       }
 
+      // Match both flat (legacy) and per-user (user-X/) layouts in one
+      // glob. cellpose-finetuning >= 0.1.0 accepts comma-separated
+      // patterns and walks recursively, so masks_{label}/user-X/{stem}.png
+      // gets picked up alongside the flat masks_{label}/{stem}.png.
+      const trainPattern = `${maskFolder}/*.png,${maskFolder}/*.geojson,${maskFolder}/*/*.png,${maskFolder}/*/*.geojson`;
+
       const trainingParams: any = {
         artifact: String(artifactToUse),
         model: String(modelParam),
         train_images: 'train_images/*.png',
-        train_annotations: `${maskFolder}/*.png`,
+        train_annotations: trainPattern,
         n_epochs: Number(epochs),
         learning_rate: Number(learningRate),
         weight_decay: Number(weightDecay),
@@ -473,7 +479,7 @@ const Training: React.FC<TrainingProps> = ({
       // Add optional test data parameters
       if (testImages.trim()) {
         trainingParams.test_images = testImages.trim();
-        trainingParams.test_annotations = testAnnotations.trim() || `${maskFolder}/*.png`;
+        trainingParams.test_annotations = testAnnotations.trim() || trainPattern;
       }
 
       // Add validation interval

--- a/src/components/colab/TrainingModal.tsx
+++ b/src/components/colab/TrainingModal.tsx
@@ -156,6 +156,11 @@ const TrainingModal: React.FC<TrainingModalProps> = ({
       console.log('Starting training with artifact:', dataArtifactId);
 
       const maskFolder = label ? `masks_${label}` : 'annotations';
+      // Match both flat (legacy) and per-user (user-X/) layouts in one
+      // glob. cellpose-finetuning >= 0.1.0 accepts comma-separated
+      // patterns and walks recursively, so masks_{label}/user-X/{stem}.png
+      // gets picked up alongside the flat masks_{label}/{stem}.png.
+      const trainPattern = `${maskFolder}/*.png,${maskFolder}/*.geojson,${maskFolder}/*/*.png,${maskFolder}/*/*.geojson`;
 
       const hasTestSplit = splitInfo?.applied && splitInfo.testImages.length > 0;
 
@@ -163,7 +168,7 @@ const TrainingModal: React.FC<TrainingModalProps> = ({
         artifact: String(dataArtifactId),
         model: String(selectedModel),
         train_images: 'train_images/*.png',
-        train_annotations: `${maskFolder}/*.png`,
+        train_annotations: trainPattern,
         n_epochs: Number(epochs),
         learning_rate: Number(learningRate),
         weight_decay: Number(weightDecay),
@@ -176,8 +181,8 @@ const TrainingModal: React.FC<TrainingModalProps> = ({
       // Auto-set test data from split info; fall back to manual input
       const resolvedTestImages = hasTestSplit ? 'test_images/*.png' : testImages.trim();
       const resolvedTestAnnotations = hasTestSplit
-        ? `${maskFolder}/*.png`
-        : (testAnnotations.trim() || `${maskFolder}/*.png`);
+        ? trainPattern
+        : (testAnnotations.trim() || trainPattern);
 
       if (resolvedTestImages) {
         trainingParams.test_images = resolvedTestImages;

--- a/src/components/colab/TrainingModal.tsx
+++ b/src/components/colab/TrainingModal.tsx
@@ -156,11 +156,18 @@ const TrainingModal: React.FC<TrainingModalProps> = ({
       console.log('Starting training with artifact:', dataArtifactId);
 
       const maskFolder = label ? `masks_${label}` : 'annotations';
-      // Match both flat (legacy) and per-user (user-X/) layouts in one
-      // glob. cellpose-finetuning >= 0.1.0 accepts comma-separated
-      // patterns and walks recursively, so masks_{label}/user-X/{stem}.png
-      // gets picked up alongside the flat masks_{label}/{stem}.png.
-      const trainPattern = `${maskFolder}/*.png,${maskFolder}/*.geojson,${maskFolder}/*/*.png,${maskFolder}/*/*.geojson`;
+      // Match every layout variant we have written over time. cellpose-
+      // finetuning >= 0.1.0 accepts comma-separated patterns and walks
+      // recursively, so we list all three depths explicitly to keep the
+      // pattern self-documenting:
+      //   - flat:           masks_{label}/{stem}.{png,geojson}
+      //   - per-user:       masks_{label}/user-X/{stem}.{png,geojson}
+      //   - per-user-round: masks_{label}/user-X/rN/{stem}.{png,geojson}
+      const trainPattern = [
+        `${maskFolder}/*.png`,           `${maskFolder}/*.geojson`,
+        `${maskFolder}/*/*.png`,         `${maskFolder}/*/*.geojson`,
+        `${maskFolder}/*/*/*.png`,       `${maskFolder}/*/*/*.geojson`,
+      ].join(',');
 
       const hasTestSplit = splitInfo?.applied && splitInfo.testImages.length > 0;
 

--- a/src/pages/AnnotatePage.tsx
+++ b/src/pages/AnnotatePage.tsx
@@ -197,6 +197,12 @@ print('CLAHE packages ready')
   const [allAnnotatedInfo, setAllAnnotatedInfo] = useState<AllAnnotatedResult | null>(null);
   const [noImagesInfo, setNoImagesInfo] = useState<NoImagesResult | null>(null);
 
+  // Current annotation round for this user. Initialised from
+  // service.initialRound once the connection is up (see effect below).
+  // The "Start Round N+1" CTA in the empty state bumps this; every
+  // subsequent save targets the new round folder.
+  const [currentRound, setCurrentRound] = useState<number>(1);
+
   // Refine flow: when a user picks a previously-annotated image to refine,
   // we load that image and any existing GeoJSON into the vector source. The
   // pending GeoJSON lands here first because the vector source ref may not
@@ -205,6 +211,13 @@ print('CLAHE packages ready')
   const [refineImageList, setRefineImageList] = useState<ImageInfo[]>([]);
   const [refineLoadingList, setRefineLoadingList] = useState(false);
   const [pendingGeoJSON, setPendingGeoJSON] = useState<any | null>(null);
+
+  // Keep currentRound in sync with the latest service connection.
+  useEffect(() => {
+    if (service?.initialRound && service.initialRound > 0) {
+      setCurrentRound(service.initialRound);
+    }
+  }, [service]);
 
   // Detect low contrast by sampling luminance values from the loaded image.
   // Returns true when the 5th–95th percentile luminance range is below 60/255.
@@ -242,10 +255,10 @@ print('CLAHE packages ready')
     setIsCLAHEActive(false);
     setIsLowContrast(false);
     setOriginalImageUrl(null);
-    console.log('[AnnotatePage] Loading new image...');
+    console.log('[AnnotatePage] Loading new image for round', currentRound);
     const bannerId = showBanner ? addBanner('Loading new image...', 'loading', 0) : 0;
     try {
-      const result = await service.getImage();
+      const result = await service.getImage(currentRound);
 
       // Check for terminal status responses
       if (result && typeof result === 'object' && 'status' in result) {
@@ -292,7 +305,7 @@ print('CLAHE packages ready')
       setIsLoadingImage(false);
       if (bannerId) removeBanner(bannerId);
     }
-  }, [service, setImageInfo, setError, addBanner, removeBanner]);
+  }, [service, currentRound, setImageInfo, setError, addBanner, removeBanner, detectLowContrast]);
 
   // Load the first image once the service is ready
   useEffect(() => {
@@ -316,7 +329,7 @@ print('CLAHE packages ready')
     setPendingGeoJSON(null);
     const bannerId = addBanner('Loading image for refinement...', 'loading', 0);
     try {
-      const result = await service.getImageByStem(stem);
+      const result = await service.getImageByStem(stem, currentRound);
       if ('status' in result && result.status === 'not_found') {
         addBanner(result.message, 'warning', 5000);
         return;
@@ -364,7 +377,7 @@ print('CLAHE packages ready')
       setIsLoadingImage(false);
       removeBanner(bannerId);
     }
-  }, [service, setImageInfo, setError, addBanner, removeBanner, detectLowContrast]);
+  }, [service, currentRound, setImageInfo, setError, addBanner, removeBanner, detectLowContrast]);
 
   // Apply pending GeoJSON once both the data and the vector source are ready.
   useEffect(() => {
@@ -391,7 +404,7 @@ print('CLAHE packages ready')
     setRefinePickerOpen(true);
     setRefineLoadingList(true);
     try {
-      const list = await service.listImages();
+      const list = await service.listImages(currentRound);
       setRefineImageList(list);
     } catch (err: any) {
       console.error('[AnnotatePage] Failed to list images:', err);
@@ -399,7 +412,7 @@ print('CLAHE packages ready')
     } finally {
       setRefineLoadingList(false);
     }
-  }, [service, addBanner]);
+  }, [service, currentRound, addBanner]);
 
   const handlePickRefineImage = useCallback((stem: string) => {
     setRefinePickerOpen(false);
@@ -489,7 +502,7 @@ print('CLAHE packages ready')
       const imageName = currentImageName || imageUrl?.split('/').pop()?.split('?')[0] || 'annotation.png';
 
       if (service) {
-        const saveUrls = await service.getSaveUrls(imageName);
+        const saveUrls = await service.getSaveUrls(imageName, currentRound);
         console.log('[AnnotatePage] Got save URLs for:', saveUrls.image_stem);
 
         const geojson = exportGeoJSON(vs, imageWidth > 0 ? imageHeight : undefined);
@@ -518,7 +531,7 @@ print('CLAHE packages ready')
     } finally {
       setIsSaving(false);
     }
-  }, [service, imageUrl, originalImageUrl, imageWidth, imageHeight, setError, getVectorSource, loadNewImage, addBanner, removeBanner]);
+  }, [service, currentRound, imageUrl, originalImageUrl, imageWidth, imageHeight, currentImageName, setError, getVectorSource, loadNewImage, addBanner, removeBanner]);
 
   const handleUndo = useCallback(() => {
     console.log('[AnnotatePage] Undo triggered');
@@ -889,6 +902,11 @@ print("CLAHE_RESULT:" + result_b64)
               {serviceConfig.label}
             </span>
           )}
+          <Tooltip title="Annotation round. Each round saves to its own subfolder so multiple passes never overwrite each other.">
+            <span className="px-2 py-0.5 rounded-full text-xs font-semibold bg-blue-100 text-blue-800 border border-blue-300 tracking-wide">
+              Round {currentRound}
+            </span>
+          </Tooltip>
         </div>
 
         <div className="z-10 flex-shrink-0">
@@ -1000,19 +1018,35 @@ print("CLAHE_RESULT:" + result_b64)
             >
               <CheckCircleOutlineIcon sx={{ fontSize: 64, color: 'success.main', mb: 2 }} />
               <Typography variant="h5" fontWeight={600} gutterBottom>
-                All Images Annotated
+                All Images Annotated for Round {currentRound}
               </Typography>
               <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
                 {allAnnotatedInfo.message}
               </Typography>
-              <MuiButton
-                variant="contained"
-                color="primary"
-                onClick={handleOpenRefinePicker}
-                sx={{ textTransform: 'none' }}
-              >
-                Refine an annotated image
-              </MuiButton>
+              <Box sx={{ display: 'flex', gap: 1.5, justifyContent: 'center', flexWrap: 'wrap' }}>
+                <MuiButton
+                  variant="contained"
+                  color="primary"
+                  onClick={() => {
+                    const nextRound = currentRound + 1;
+                    setCurrentRound(nextRound);
+                    setAllAnnotatedInfo(null);
+                    addBanner(`Starting round ${nextRound}`, 'info', 4000);
+                    loadNewImage(false);
+                  }}
+                  sx={{ textTransform: 'none' }}
+                >
+                  Start Round {currentRound + 1}
+                </MuiButton>
+                <MuiButton
+                  variant="outlined"
+                  color="primary"
+                  onClick={handleOpenRefinePicker}
+                  sx={{ textTransform: 'none' }}
+                >
+                  Refine round {currentRound}
+                </MuiButton>
+              </Box>
             </Box>
           </Box>
         )}

--- a/src/pages/AnnotatePage.tsx
+++ b/src/pages/AnnotatePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useLocation, Link, useNavigate } from 'react-router-dom';
-import { Box, CircularProgress, Typography, Alert, Button as MuiButton, Tooltip, useMediaQuery, useTheme } from '@mui/material';
+import { Box, CircularProgress, Typography, Alert, Button as MuiButton, Tooltip, useMediaQuery, useTheme, Dialog, DialogTitle, DialogContent, DialogActions, List, ListItemButton, ListItemText, ListItemIcon } from '@mui/material';
 import LoginButton from '../components/LoginButton';
 import AnnotationViewer from '../components/annotate/AnnotationViewer';
 import ToolBar from '../components/annotate/ToolBar';
@@ -12,7 +12,7 @@ import { useColabKernel } from '../components/colab/useColabKernel';
 import { useSharedKernelIfAvailable } from '../components/colab/KernelContext';
 import MaskFilterDialog from '../components/annotate/MaskFilterDialog';
 import HelpTutorial from '../components/annotate/HelpTutorial';
-import { useHyphaService, AnnotationServiceConfig, AllAnnotatedResult, NoImagesResult } from '../components/annotate/hooks/useHyphaService';
+import { useHyphaService, AnnotationServiceConfig, AllAnnotatedResult, NoImagesResult, ImageInfo } from '../components/annotate/hooks/useHyphaService';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { exportGeoJSON, renderInstanceSegmentationPNG, importGeoJSON } from '../components/annotate/exportAnnotation';
 import { useAnnotationStore } from '../store/annotationStore';
@@ -197,6 +197,15 @@ print('CLAHE packages ready')
   const [allAnnotatedInfo, setAllAnnotatedInfo] = useState<AllAnnotatedResult | null>(null);
   const [noImagesInfo, setNoImagesInfo] = useState<NoImagesResult | null>(null);
 
+  // Refine flow: when a user picks a previously-annotated image to refine,
+  // we load that image and any existing GeoJSON into the vector source. The
+  // pending GeoJSON lands here first because the vector source ref may not
+  // be available until AnnotationViewer remounts with the new image.
+  const [refinePickerOpen, setRefinePickerOpen] = useState(false);
+  const [refineImageList, setRefineImageList] = useState<ImageInfo[]>([]);
+  const [refineLoadingList, setRefineLoadingList] = useState(false);
+  const [pendingGeoJSON, setPendingGeoJSON] = useState<any | null>(null);
+
   // Detect low contrast by sampling luminance values from the loaded image.
   // Returns true when the 5th–95th percentile luminance range is below 60/255.
   const detectLowContrast = useCallback((img: HTMLImageElement): boolean => {
@@ -291,6 +300,111 @@ print('CLAHE packages ready')
     setIsLoading(true);
     loadNewImage(false).finally(() => setIsLoading(false));
   }, [service, hasLoadedOnce, loadNewImage, setIsLoading]);
+
+  // Load a specific image (by stem) for refinement. Replaces the current
+  // image and stages any existing GeoJSON so it can be re-applied to the
+  // vector source once AnnotationViewer remounts.
+  const loadSpecificImage = useCallback(async (stem: string) => {
+    if (!service) return;
+    setIsLoadingImage(true);
+    setError(null);
+    setAllAnnotatedInfo(null);
+    setNoImagesInfo(null);
+    setIsCLAHEActive(false);
+    setIsLowContrast(false);
+    setOriginalImageUrl(null);
+    setPendingGeoJSON(null);
+    const bannerId = addBanner('Loading image for refinement...', 'loading', 0);
+    try {
+      const result = await service.getImageByStem(stem);
+      if ('status' in result && result.status === 'not_found') {
+        addBanner(result.message, 'warning', 5000);
+        return;
+      }
+      const imageResult = result as { url: string; name: string; existing_geojson_url?: string | null; cellpose_model?: string };
+      const url = imageResult.url;
+      const imageName = imageResult.name || stem;
+
+      if (imageResult.cellpose_model) {
+        setDynamicCellposeModel(imageResult.cellpose_model);
+      }
+
+      setCurrentImageName(imageName);
+
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.src = url;
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = () => reject(new Error('Failed to load image'));
+      });
+      setIsLowContrast(detectLowContrast(img));
+      setImageInfo(url, img.naturalWidth, img.naturalHeight);
+      setHasLoadedOnce(true);
+
+      // Pre-fetch existing GeoJSON so it can be applied once the vector
+      // source is ready (see effect below).
+      if (imageResult.existing_geojson_url) {
+        try {
+          const res = await fetch(imageResult.existing_geojson_url);
+          if (res.ok) {
+            const data = await res.json();
+            setPendingGeoJSON(data);
+          } else {
+            console.warn('[AnnotatePage] Could not fetch existing GeoJSON:', res.status);
+          }
+        } catch (err) {
+          console.warn('[AnnotatePage] Error fetching existing GeoJSON:', err);
+        }
+      }
+    } catch (err: any) {
+      console.error('[AnnotatePage] loadSpecificImage failed:', err);
+      setError(err.message || 'Failed to load image');
+    } finally {
+      setIsLoadingImage(false);
+      removeBanner(bannerId);
+    }
+  }, [service, setImageInfo, setError, addBanner, removeBanner, detectLowContrast]);
+
+  // Apply pending GeoJSON once both the data and the vector source are ready.
+  useEffect(() => {
+    if (!pendingGeoJSON || !getVectorSource || imageHeight <= 0) return;
+    const vs = getVectorSource();
+    if (!vs) return;
+    try {
+      vs.clear();
+      useAnnotationStore.setState({ undoStack: [], canUndo: false });
+      importGeoJSON(vs, pendingGeoJSON, imageHeight, activeLabel);
+      const count = vs.getFeatures().length;
+      addBanner(`Loaded ${count} existing mask${count !== 1 ? 's' : ''} for refinement`, 'success', 5000);
+    } catch (err: any) {
+      console.warn('[AnnotatePage] Failed to apply pending GeoJSON:', err);
+      addBanner('Failed to load existing annotation: ' + (err.message || 'unknown error'), 'error', 8000);
+    } finally {
+      setPendingGeoJSON(null);
+    }
+  }, [pendingGeoJSON, getVectorSource, imageHeight, activeLabel, addBanner]);
+
+  // Open the refine picker and fetch the image list.
+  const handleOpenRefinePicker = useCallback(async () => {
+    if (!service) return;
+    setRefinePickerOpen(true);
+    setRefineLoadingList(true);
+    try {
+      const list = await service.listImages();
+      setRefineImageList(list);
+    } catch (err: any) {
+      console.error('[AnnotatePage] Failed to list images:', err);
+      addBanner('Failed to load image list: ' + (err.message || 'unknown error'), 'error', 8000);
+    } finally {
+      setRefineLoadingList(false);
+    }
+  }, [service, addBanner]);
+
+  const handlePickRefineImage = useCallback((stem: string) => {
+    setRefinePickerOpen(false);
+    loadSpecificImage(stem);
+  }, [loadSpecificImage]);
 
   const handleRunCellpose = useCallback(async (cfgOverride?: CellposeConfig) => {
     const cfg = cfgOverride || cellposeConfig;
@@ -891,6 +1005,14 @@ print("CLAHE_RESULT:" + result_b64)
               <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
                 {allAnnotatedInfo.message}
               </Typography>
+              <MuiButton
+                variant="contained"
+                color="primary"
+                onClick={handleOpenRefinePicker}
+                sx={{ textTransform: 'none' }}
+              >
+                Refine an annotated image
+              </MuiButton>
             </Box>
           </Box>
         )}
@@ -992,6 +1114,57 @@ print("CLAHE_RESULT:" + result_b64)
       />
 
       <HelpTutorial open={helpOpen} onClose={() => setHelpOpen(false)} />
+
+      <Dialog
+        open={refinePickerOpen}
+        onClose={() => setRefinePickerOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>
+          Pick an annotated image to refine
+        </DialogTitle>
+        <DialogContent dividers sx={{ p: 0 }}>
+          {refineLoadingList ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={28} />
+            </Box>
+          ) : refineImageList.length === 0 ? (
+            <Box sx={{ p: 3, textAlign: 'center' }}>
+              <Typography variant="body2" color="text.secondary">
+                No images in this session.
+              </Typography>
+            </Box>
+          ) : (
+            <List dense sx={{ maxHeight: 360, overflowY: 'auto' }}>
+              {refineImageList.map((img) => (
+                <ListItemButton
+                  key={img.stem}
+                  onClick={() => handlePickRefineImage(img.stem)}
+                  disabled={!img.is_annotated}
+                >
+                  <ListItemIcon sx={{ minWidth: 36 }}>
+                    {img.is_annotated ? (
+                      <CheckCircleOutlineIcon sx={{ color: 'success.main', fontSize: 20 }} />
+                    ) : (
+                      <Box sx={{ width: 20, height: 20 }} />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={img.name}
+                    secondary={img.is_annotated ? 'Annotated' : 'Not annotated'}
+                  />
+                </ListItemButton>
+              ))}
+            </List>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <MuiButton onClick={() => setRefinePickerOpen(false)} sx={{ textTransform: 'none' }}>
+            Cancel
+          </MuiButton>
+        </DialogActions>
+      </Dialog>
       </Box>
     </Box>
   );

--- a/src/pages/AnnotatePage.tsx
+++ b/src/pages/AnnotatePage.tsx
@@ -845,7 +845,7 @@ print("CLAHE_RESULT:" + result_b64)
       >
         <div className="flex items-center gap-2 z-10 flex-shrink-0">
           {sessionUrl && (
-            <Tooltip title="Go back to the Colab session — view all images, annotation progress, and training">
+            <Tooltip title="Go back to the Colab session: view all images, annotation progress, and training">
               <MuiButton
                 size="small"
                 variant="outlined"


### PR DESCRIPTION
## Motivation

The AnnotatePage dead-ended on "All Images Annotated" whenever every image in the session was complete. The ELMI booth artifact ships at 100% annotation, so the presenter could not open an existing image to correct a mask after launching the share URL.

## Solution

Add a "Refine an annotated image" button to the empty state. Selecting an image from the picker loads it along with its existing GeoJSON so the user can refine the saved masks in place.

## Behaviour

- Empty-state CTA opens a picker listing every image in the session, with annotated entries selectable.
- Picking an entry loads the image and applies any previously saved GeoJSON to the OpenLayers vector source.
- A success banner reports the number of masks loaded.
- Saving overwrites the existing mask PNG and GeoJSON, then returns to the empty state where the picker can be reopened.

## File summary

- `public/colab_service.py` - `AnnotationSession.get_image_by_stem(image_stem, label)` returns the image URL plus a presigned GeoJSON URL when one exists, bypassing the unannotated-image filter. Registered alongside the existing service methods.
- `src/components/annotate/hooks/useHyphaService.ts` - new `getImageByStem` and `listImages` methods on `AnnotationDataService`; `ImageResult` gains `existing_geojson_url`.
- `src/pages/AnnotatePage.tsx` - new picker dialog, `loadSpecificImage` callback, and an effect that applies the staged GeoJSON via `importGeoJSON` once the vector source is ready.

## Test plan

- [x] Open a 100%-annotated session in the browser, follow the share URL, see the "Refine an annotated image" CTA.
- [x] Picker lists every image; selecting one loads the image and renders the existing polygons.
- [x] Banner reports the mask count.
- [ ] Save after edits and confirm the mask PNG and GeoJSON in `masks_{label}/` are overwritten.
