### PR TITLE
Read runner_version from test_report env list

### DIFF
--- a/scripts/bioengine_model_test.py
+++ b/scripts/bioengine_model_test.py
@@ -248,9 +248,19 @@ def analyze_existing_test_reports(reports_dir: Path) -> None:
             elif status == "service-error":
                 error += 1
 
-            report_runner_version = test_report.get("runner_version")
-            if report_runner_version:
-                runner_versions.add(str(report_runner_version))
+            # The runner records its own artifact version inside test_report["env"]
+            # as a row ["bioimage-io/model-runner", "<version>", "", ""], alongside
+            # rows for bioimageio.core, bioimageio.spec, and bioengine. Rows added
+            # before the runner started stamping itself do not contain that name.
+            for row in test_report.get("env", []) or []:
+                if (
+                    isinstance(row, (list, tuple))
+                    and len(row) >= 2
+                    and row[0] == "bioimage-io/model-runner"
+                    and row[1]
+                ):
+                    runner_versions.add(str(row[1]))
+                    break
 
         except Exception as e:
             print(f"Error processing {json_file}: {e}", file=sys.stderr)


### PR DESCRIPTION
## Motivation

PR #56 added a "Deployed model-runner version" line to the model-testing workflow summary, sourced from each per-model `test_report.json`. The lookup assumed the runner would stamp its version onto a top-level `runner_version` field. The deployed runner (`bioimage-io/model-runner` 1.0.7, BioEngine 0.10.8) instead stamps the version as a row inside `test_report["env"]`, alongside the rows for `bioimageio.core`, `bioimageio.spec`, and `bioengine`. The previous lookup never matched, so the summary line stayed empty even on reports produced by the new runner.

## Solution

Walk `test_report["env"]` looking for a row whose first element is `"bioimage-io/model-runner"` and take its version. The env row layout (`[name, version, "", ""]`) is the same shape as the other entries the runner already records, so this is a passive read against an existing convention.

## Behaviour

A report produced by runner 1.0.7+ contributes its version to the workflow summary. A report produced by an older runner has no such row and contributes nothing, identical to the rollout-window semantics from #56. The aggregation rules (single version, `mixed: ...`, empty) are unchanged.

## Migration

None. The change is read-only against `test_report.json`. Existing reports without the row keep producing the same empty result they produced before.

## Test plan

- [x] Three fixture reports exercised against `--analyze-reports`:
  - new runner row only -> `RUNNER_VERSION='1.0.7'`
  - mixed: one report at 1.0.6, one at 1.0.7 -> `RUNNER_VERSION='mixed: 1.0.6, 1.0.7'`
  - no model-runner row in env -> `RUNNER_VERSION=''`
- [x] Eval output stays single-quoted and safe to consume via `${RUNNER_VERSION:-unknown}` in the workflow.

## Files

- `scripts/bioengine_model_test.py`: replace the `test_report.get("runner_version")` lookup in `analyze_existing_test_reports` with an env-list scan for the `"bioimage-io/model-runner"` row.
