### PR TITLE
feat(bioengine-worker): cache + scaling controls and dashboard UX rework

### DIFF
--- a/src/components/bioengine/AppDeploymentsStatusDialog.tsx
+++ b/src/components/bioengine/AppDeploymentsStatusDialog.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import ErrorDialog from './ErrorDialog';
 
 interface AppDeploymentsStatusDialogProps {
   isOpen: boolean;
@@ -24,6 +25,14 @@ interface AppDeploymentsStatusDialogProps {
     scaling: Record<string, any>;
   }) => Promise<void>;
   bioengineVersion?: string;
+  // Worker undeploy / cancel-deployment handler. When present the dialog
+  // renders an Undeploy button in the header (with an inline confirm step
+  // to avoid accidental deletion). When omitted, undeploy is disabled —
+  // e.g. for read-only viewers.
+  onUndeploy?: (applicationId: string) => void;
+  // True while the parent has a stop_app call in flight for this app —
+  // used to show a spinner on the undeploy button and prevent re-clicks.
+  isUndeploying?: boolean;
 }
 
 // Per-deployment form state. Two mutually-exclusive modes mirror the
@@ -129,6 +138,8 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
   nodeLabels,
   updateAppScaling,
   bioengineVersion,
+  onUndeploy,
+  isUndeploying,
 }) => {
   // Format a replica's node placement using the cluster-view-consistent
   // role label, plus the replica's own node_instance_id when available
@@ -168,12 +179,28 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
         return 'bg-gray-50 text-gray-600 border-gray-200';
     }
   };
-  const [logsTail, setLogsTail] = useState<number>(30);
-  const [nPreviousReplica, setNPreviousReplica] = useState<number>(0);
+
+  // Top-level status state. The dialog seeds from `initialStatus` (the app
+  // status snapshot the parent already loaded), then refreshes on demand.
+  // Per-deployment log refetches mutate the `deployments` slice of this
+  // object so other deployments retain their last-loaded log buffer.
   const [status, setStatus] = useState<any>(initialStatus || null);
   const [loading, setLoading] = useState(false);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Per-deployment "Log Lines" / "Previous Replicas" form values + an
+  // in-flight refresh marker, keyed by deployment name. The dialog seeds
+  // each block with the default (30 lines, 0 previous) on open. Each
+  // block has its own Refresh button so users can drill into one
+  // deployment's logs without disturbing the others' last-loaded buffer.
+  // See the feature request to bioengine session 96b34abe for the
+  // native per-deployment API ask that would let us drop the interim
+  // "fetch-all-then-merge-one" workaround.
+  type LogControls = { logsTail: number; nPrevious: number };
+  const DEFAULT_LOG_CONTROLS: LogControls = { logsTail: 30, nPrevious: 0 };
+  const [logControls, setLogControls] = useState<Record<string, LogControls>>({});
+  const [refreshingDeployment, setRefreshingDeployment] = useState<string | null>(null);
 
   // Scaling form state: keyed by user @bioengine.app class name (i.e. the
   // keys of get_app_status().deployments minus ProxyDeployment). Persists
@@ -186,9 +213,20 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
   const [scalingSubmitOk, setScalingSubmitOk] = useState<boolean>(false);
   const [advancedOpen, setAdvancedOpen] = useState<Record<string, boolean>>({});
 
+  // Two-step undeploy confirm state. First click flips the button into
+  // "Confirm undeploy" + a Cancel; second click fires the callback. The
+  // confirm state auto-resets after a few seconds so the destructive
+  // affordance doesn't sit armed indefinitely.
+  const [undeployConfirm, setUndeployConfirm] = useState<boolean>(false);
+  const undeployConfirmTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     setStatus(initialStatus || null);
   }, [initialStatus]);
+
+  useEffect(() => () => {
+    if (undeployConfirmTimer.current) clearTimeout(undeployConfirmTimer.current);
+  }, []);
 
   const loadStatus = async () => {
     if (!applicationId) return;
@@ -197,10 +235,13 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
     setError(null);
 
     try {
+      // Top-level Refresh uses the lowest-cost defaults (30 lines, 0
+      // previous replicas). Per-deployment Refresh buttons handle the
+      // high-volume cases independently below.
       const result = await fetchApplicationStatus({
         application_ids: [applicationId],
-        logs_tail: logsTail,
-        n_previous_replica: nPreviousReplica,
+        logs_tail: DEFAULT_LOG_CONTROLS.logsTail,
+        n_previous_replica: DEFAULT_LOG_CONTROLS.nPrevious,
       });
       setStatus(result);
     } catch (err) {
@@ -215,8 +256,10 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
   useEffect(() => {
     if (isOpen) {
       setHasLoaded(false);
+      setUndeployConfirm(false);
       loadStatus();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
   const deployments = useMemo(() => {
@@ -238,6 +281,23 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
     () => deployments.filter(d => d.name !== 'ProxyDeployment'),
     [deployments],
   );
+
+  // Seed the log-controls form with defaults the first time we see each
+  // deployment name; preserve any values the user already typed.
+  useEffect(() => {
+    setLogControls(prev => {
+      const next = { ...prev };
+      let changed = false;
+      for (const { name } of deployments) {
+        if (!next[name]) {
+          next[name] = { ...DEFAULT_LOG_CONTROLS };
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deployments]);
 
   // Pending-replica detector. Either deployment status DEPLOYING (Ray
   // Serve is still reconciling) or a replica stuck in PENDING_ALLOCATION
@@ -358,59 +418,170 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
     setScalingSubmitOk(false);
   };
 
+  // Refresh logs for a single deployment. Until the worker accepts
+  // per-deployment log params (see feature request to bioengine session
+  // 96b34abe), we call get_app_status with this block's params and merge
+  // only the matching deployment's data back into state — leaving other
+  // deployments' last-loaded buffers untouched. Slightly wasteful at the
+  // backend (full fan-out) but right at the UI level.
+  const refreshDeploymentLogs = async (depName: string) => {
+    const cfg = logControls[depName] ?? DEFAULT_LOG_CONTROLS;
+    setRefreshingDeployment(depName);
+    setError(null);
+    try {
+      const result = await fetchApplicationStatus({
+        application_ids: [applicationId],
+        logs_tail: cfg.logsTail,
+        n_previous_replica: cfg.nPrevious,
+      });
+      const newDeployment = result?.deployments?.[depName];
+      if (!newDeployment) {
+        setError(`Deployment "${depName}" not present in refreshed status.`);
+        return;
+      }
+      // Merge only the refreshed deployment back into state; leave the
+      // rest of the dialog's snapshot untouched (the user might be
+      // mid-edit on the scaling form etc).
+      setStatus((prev: any) => {
+        if (!prev || typeof prev !== 'object') return result;
+        return {
+          ...prev,
+          deployments: { ...(prev.deployments ?? {}), [depName]: newDeployment },
+        };
+      });
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setError(`Refresh failed for ${depName}: ${errorMessage}`);
+    } finally {
+      setRefreshingDeployment(null);
+    }
+  };
+
+  const updateLogControl = (depName: string, patch: Partial<LogControls>) => {
+    setLogControls(prev => ({
+      ...prev,
+      [depName]: { ...(prev[depName] ?? DEFAULT_LOG_CONTROLS), ...patch },
+    }));
+  };
+
+  // Undeploy button label depends on the app's lifecycle phase: while
+  // the worker is still bringing the app up, "stop" means "cancel the
+  // deploy"; once it's running it's a proper undeploy.
+  const undeployLabel = useMemo(() => {
+    const appStatus = String(status?.status ?? '').toUpperCase();
+    return appStatus === 'DEPLOYING' ? 'Cancel deployment' : 'Undeploy';
+  }, [status]);
+
+  const handleUndeployClick = () => {
+    if (!onUndeploy) return;
+    if (!undeployConfirm) {
+      // First click: arm the confirm state. Auto-disarm after 6s so the
+      // destructive affordance doesn't sit hot indefinitely.
+      setUndeployConfirm(true);
+      if (undeployConfirmTimer.current) clearTimeout(undeployConfirmTimer.current);
+      undeployConfirmTimer.current = setTimeout(() => setUndeployConfirm(false), 6000);
+      return;
+    }
+    // Second click: fire.
+    if (undeployConfirmTimer.current) clearTimeout(undeployConfirmTimer.current);
+    setUndeployConfirm(false);
+    onUndeploy(applicationId);
+  };
+
+  const cancelUndeployConfirm = () => {
+    if (undeployConfirmTimer.current) clearTimeout(undeployConfirmTimer.current);
+    setUndeployConfirm(false);
+  };
+
   if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <style>{`
+        .mm-press { transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1); }
+        .mm-press:active:not(:disabled) { transform: scale(0.97); }
+      `}</style>
       <div className="bg-white rounded-xl shadow-xl w-full max-w-6xl max-h-[90vh] overflow-y-auto">
-        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center sticky top-0 bg-white z-10">
-          <div>
-            <h3 className="text-xl font-semibold text-gray-800">Application Deployment Status</h3>
-            <p className="text-sm text-gray-500 mt-1">Application ID: {applicationId}</p>
+        <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center gap-4 sticky top-0 bg-white z-10">
+          <div className="min-w-0">
+            <h3 className="text-xl font-semibold text-gray-800">Monitor & Manage app</h3>
+            <p className="text-sm text-gray-500 mt-1 break-all">Application ID: {applicationId}</p>
           </div>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors" aria-label="Close dialog">
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <button
+              type="button"
+              onClick={loadStatus}
+              disabled={loading}
+              className="mm-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-60 disabled:cursor-not-allowed"
+              title="Reload app status from the worker"
+            >
+              <svg className={`w-4 h-4 mr-1.5 ${loading ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v6h6M20 20v-6h-6M5.07 9A8 8 0 0119 9M19 15a8 8 0 01-13.93 0" />
+              </svg>
+              {loading ? 'Refreshing' : 'Refresh'}
+            </button>
+            {/* Destructive action sits at the right edge so it isn't
+                adjacent to Refresh; two-step confirm guards against
+                accidental clicks. */}
+            {onUndeploy && (
+              undeployConfirm ? (
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={cancelUndeployConfirm}
+                    disabled={isUndeploying}
+                    className="mm-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleUndeployClick}
+                    disabled={isUndeploying}
+                    className="mm-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:bg-red-400"
+                    autoFocus
+                  >
+                    Confirm {undeployLabel.toLowerCase()}
+                  </button>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleUndeployClick}
+                  disabled={isUndeploying}
+                  className="mm-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border border-red-200 bg-white text-red-700 hover:bg-red-50 disabled:opacity-60 disabled:cursor-not-allowed"
+                  title={undeployLabel === 'Cancel deployment'
+                    ? 'Stop the in-progress deployment'
+                    : 'Stop this app and free its replicas'}
+                >
+                  {isUndeploying ? (
+                    <>
+                      <svg className="w-4 h-4 mr-1.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                      </svg>
+                      {undeployLabel === 'Cancel deployment' ? 'Canceling' : 'Undeploying'}
+                    </>
+                  ) : (
+                    <>
+                      <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" />
+                      </svg>
+                      {undeployLabel}
+                    </>
+                  )}
+                </button>
+              )
+            )}
+            <button onClick={onClose} className="text-gray-400 hover:text-gray-600 transition-colors p-1" aria-label="Close dialog">
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
         </div>
 
         <div className="p-6 space-y-6">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 bg-gray-50 border border-gray-200 rounded-lg items-end">
-            <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-gray-700">Log Lines</span>
-              <input
-                type="number"
-                value={logsTail}
-                onChange={(e) => setLogsTail(parseInt(e.target.value || '0', 10))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
-              />
-              <span className="text-xs text-gray-500">-1 to retrieve all available logs</span>
-            </label>
-
-            <label className="flex flex-col gap-1">
-              <span className="text-sm font-medium text-gray-700">Previous Replicas</span>
-              <input
-                type="number"
-                value={nPreviousReplica}
-                onChange={(e) => setNPreviousReplica(parseInt(e.target.value || '0', 10))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm"
-              />
-              <span className="text-xs text-gray-500">-1 to include all previous replicas</span>
-            </label>
-
-            <div className="flex items-end h-full">
-              <button
-                type="button"
-                onClick={loadStatus}
-                disabled={loading}
-                className="w-full px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:bg-gray-400 h-10"
-              >
-                {loading ? 'Refreshing...' : 'Refresh Status'}
-              </button>
-            </div>
-          </div>
-
           {error && (
             <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg text-sm">
               {error}
@@ -435,7 +606,7 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
             </div>
           )}
 
-          {(!hasLoaded || loading) ? (
+          {(!hasLoaded || (loading && !hasLoaded)) ? (
             <div className="flex flex-col items-center justify-center py-16 text-gray-600">
               <div className="w-10 h-10 border-4 border-gray-200 border-t-blue-600 rounded-full animate-spin mb-4" />
               <p className="text-sm font-medium">Loading app status...</p>
@@ -443,14 +614,16 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
             </div>
           ) : null}
 
-          <div className="p-4 rounded-lg border border-gray-200 bg-gray-50">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
-              <div><span className="font-medium text-gray-700">Status:</span> <span className="text-gray-900">{status?.status || 'UNKNOWN'}</span></div>
-              <div><span className="font-medium text-gray-700">Version:</span> <span className="text-gray-900">{status?.version || 'N/A'}</span></div>
-              <div><span className="font-medium text-gray-700">Message:</span> <span className="text-gray-900">{status?.message || '-'}</span></div>
-              <div><span className="font-medium text-gray-700">Last Updated By:</span> <span className="text-gray-900">{status?.last_updated_by || '-'}</span></div>
+          {hasLoaded && (
+            <div className="p-4 rounded-lg border border-gray-200 bg-gray-50">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+                <div><span className="font-medium text-gray-700">Status:</span> <span className="text-gray-900">{status?.status || 'UNKNOWN'}</span></div>
+                <div><span className="font-medium text-gray-700">Version:</span> <span className="text-gray-900">{status?.version || 'N/A'}</span></div>
+                <div><span className="font-medium text-gray-700">Message:</span> <span className="text-gray-900">{status?.message || '-'}</span></div>
+                <div><span className="font-medium text-gray-700">Last Updated By:</span> <span className="text-gray-900">{status?.last_updated_by || '-'}</span></div>
+              </div>
             </div>
-          </div>
+          )}
 
           {loading && hasLoaded ? (
             <div className="flex items-center justify-center py-4 text-sm text-gray-600">
@@ -459,6 +632,10 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
             </div>
           ) : null}
 
+          {/* Replica scaling moves to the top of the editing surface
+              (above per-deployment cards) — it's the main lever for
+              operating an app at scale, and pushing it below a deck of
+              log panes made it easy to miss. */}
           {scalingEnabled && hasLoaded && (
             <ScalingSection
               userDeployments={userDeployments}
@@ -487,10 +664,12 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
 
           {hasLoaded && !loading && deployments.length === 0 ? (
             <p className="text-sm text-gray-500">No deployment entries found for this application.</p>
-          ) : (
+          ) : hasLoaded ? (
             <div className="space-y-4">
               {deployments.map(({ name, data }) => {
                 const logs = data?.logs && typeof data.logs === 'object' ? Object.entries(data.logs) : [];
+                const cfg = logControls[name] ?? DEFAULT_LOG_CONTROLS;
+                const isRefreshing = refreshingDeployment === name;
 
                 return (
                   <div key={name} className="border border-gray-200 rounded-xl overflow-hidden">
@@ -559,6 +738,63 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
                         </div>
                       )}
 
+                      {/* Per-deployment log controls. Replaces the dialog-
+                          level "Log Lines" / "Previous Replicas" inputs
+                          so an operator can drill into one deployment
+                          without bumping log fetches for the others.
+                          Until the worker supports per-deployment params
+                          natively (see bioengine feature request) we
+                          fetch the full app status and merge only this
+                          deployment's slice back into state. */}
+                      <div className="rounded-lg border border-gray-200 bg-white px-3 py-2.5">
+                        <div className="flex flex-wrap items-end gap-3">
+                          <label className="flex flex-col gap-1 min-w-0">
+                            <span className="text-xs font-medium text-gray-700">Log Lines</span>
+                            <input
+                              type="number"
+                              value={cfg.logsTail}
+                              onChange={(e) => updateLogControl(name, { logsTail: parseInt(e.target.value || '0', 10) })}
+                              className="w-28 px-2.5 py-1.5 border border-gray-300 rounded-md text-sm tabular-nums"
+                            />
+                          </label>
+                          <label className="flex flex-col gap-1 min-w-0">
+                            <span className="text-xs font-medium text-gray-700">Previous Replicas</span>
+                            <input
+                              type="number"
+                              value={cfg.nPrevious}
+                              onChange={(e) => updateLogControl(name, { nPrevious: parseInt(e.target.value || '0', 10) })}
+                              className="w-28 px-2.5 py-1.5 border border-gray-300 rounded-md text-sm tabular-nums"
+                            />
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() => refreshDeploymentLogs(name)}
+                            disabled={isRefreshing || loading}
+                            className="mm-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-60 disabled:cursor-not-allowed h-[34px]"
+                          >
+                            {isRefreshing ? (
+                              <>
+                                <svg className="w-3.5 h-3.5 mr-1.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                </svg>
+                                Refreshing
+                              </>
+                            ) : (
+                              <>
+                                <svg className="w-3.5 h-3.5 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v6h6M20 20v-6h-6M5.07 9A8 8 0 0119 9M19 15a8 8 0 01-13.93 0" />
+                                </svg>
+                                Refresh logs
+                              </>
+                            )}
+                          </button>
+                          <span className="text-xs text-gray-500 ml-1">
+                            Use -1 for all available logs or all previous replicas.
+                          </span>
+                        </div>
+                      </div>
+
                       {logs.length > 0 ? (
                         <div className="space-y-3">
                           <p className="text-sm font-medium text-gray-700">Logs</p>
@@ -582,16 +818,27 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
                           ))}
                         </div>
                       ) : (
-                        <p className="text-xs text-gray-500">No logs returned for this deployment.</p>
+                        <p className="text-xs text-gray-500">No logs returned for this deployment. Click Refresh logs to fetch.</p>
                       )}
                     </div>
                   </div>
                 );
               })}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
+      {/* Scaling save errors render in a top-layer ErrorDialog (z-60) on
+          top of this dialog (z-50) so deploy_app stack traces stay readable.
+          The inline status row above just acknowledges that the save failed
+          and points at the dialog. */}
+      <ErrorDialog
+        open={!!scalingSubmitError}
+        title="Scaling update failed"
+        subtitle={applicationId}
+        message={scalingSubmitError ?? ''}
+        onClose={() => setScalingSubmitError(null)}
+      />
     </div>
   );
 };
@@ -798,7 +1045,7 @@ const ScalingSection: React.FC<ScalingSectionProps> = ({
         <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
           <div className="text-xs text-gray-500 min-h-[1.25rem]">
             {submitError ? (
-              <span className="text-red-600">{submitError}</span>
+              <span className="text-red-600">Save failed. See the error dialog for details.</span>
             ) : submitOk ? (
               <span className="text-green-700">Scaling updated. Ray Serve is rolling the change.</span>
             ) : isDirty ? (

--- a/src/components/bioengine/AppDeploymentsStatusDialog.tsx
+++ b/src/components/bioengine/AppDeploymentsStatusDialog.tsx
@@ -14,7 +14,111 @@ interface AppDeploymentsStatusDialogProps {
   // {"__role__:<node_id>" -> "Head Node" | "Worker Node N"}.
   // Numbering matches the cluster-resources view's worker numbering.
   nodeLabels?: Record<string, string>;
+  // When present + bioengine_version >= 0.11.6 the dialog renders an inline
+  // scaling editor that calls deploy_app({application_id, artifact_id,
+  // scaling}) to roll new replica counts. Omitted when the parent doesn't
+  // know how to perform the update (read-only contexts).
+  updateAppScaling?: (params: {
+    application_id: string;
+    artifact_id: string;
+    scaling: Record<string, any>;
+  }) => Promise<void>;
+  bioengineVersion?: string;
 }
+
+// Per-deployment form state. Two mutually-exclusive modes mirror the
+// worker's scaling validator (manager.py:2086-2097): either a fixed
+// num_replicas, or an autoscaling_config bag with min/max + the (optional)
+// Ray Serve tuning knobs we expose. Storing both inactive sides lets the
+// user toggle the switch without losing partially-entered values.
+type DeploymentScalingState = {
+  mode: 'fixed' | 'autoscale';
+  num_replicas: number;
+  min_replicas: number;
+  max_replicas: number;
+  target: number;
+  upscale_delay_s: number | null;
+  downscale_delay_s: number | null;
+};
+
+const DEFAULT_AUTOSCALE: Pick<
+  DeploymentScalingState,
+  'min_replicas' | 'max_replicas' | 'target' | 'upscale_delay_s' | 'downscale_delay_s'
+> = {
+  min_replicas: 1,
+  max_replicas: 2,
+  target: 2,
+  upscale_delay_s: null,
+  downscale_delay_s: null,
+};
+
+// Translate a scaling-map entry into the form's state shape. Missing
+// entries default to a fixed 1 replica (matches Ray Serve's default and
+// the worker's "classes not in the map run at 1 fixed replica" contract).
+const entryToState = (entry?: any): DeploymentScalingState => {
+  if (entry && typeof entry === 'object') {
+    const ascRaw = entry.autoscaling_config;
+    if (ascRaw && typeof ascRaw === 'object') {
+      return {
+        mode: 'autoscale',
+        num_replicas: 1,
+        min_replicas: typeof ascRaw.min_replicas === 'number' ? ascRaw.min_replicas : DEFAULT_AUTOSCALE.min_replicas,
+        max_replicas: typeof ascRaw.max_replicas === 'number' ? ascRaw.max_replicas : DEFAULT_AUTOSCALE.max_replicas,
+        target: typeof ascRaw.target_num_ongoing_requests_per_replica === 'number'
+          ? ascRaw.target_num_ongoing_requests_per_replica
+          : DEFAULT_AUTOSCALE.target,
+        upscale_delay_s: typeof ascRaw.upscale_delay_s === 'number' ? ascRaw.upscale_delay_s : null,
+        downscale_delay_s: typeof ascRaw.downscale_delay_s === 'number' ? ascRaw.downscale_delay_s : null,
+      };
+    }
+    if (typeof entry.num_replicas === 'number') {
+      return {
+        mode: 'fixed',
+        num_replicas: entry.num_replicas,
+        ...DEFAULT_AUTOSCALE,
+      };
+    }
+  }
+  return { mode: 'fixed', num_replicas: 1, ...DEFAULT_AUTOSCALE };
+};
+
+// Translate a form state back into the wire shape the worker validates.
+const stateToEntry = (state: DeploymentScalingState): Record<string, any> => {
+  if (state.mode === 'fixed') {
+    return { num_replicas: state.num_replicas };
+  }
+  const asc: Record<string, any> = {
+    min_replicas: state.min_replicas,
+    max_replicas: state.max_replicas,
+    target_num_ongoing_requests_per_replica: state.target,
+  };
+  if (state.upscale_delay_s !== null && state.upscale_delay_s !== undefined) {
+    asc.upscale_delay_s = state.upscale_delay_s;
+  }
+  if (state.downscale_delay_s !== null && state.downscale_delay_s !== undefined) {
+    asc.downscale_delay_s = state.downscale_delay_s;
+  }
+  return { autoscaling_config: asc };
+};
+
+const meetsVersion = (actual: string | undefined, required: string): boolean => {
+  if (!actual) return false;
+  const parse = (v: string): number[] =>
+    v
+      .split('.')
+      .map(part => parseInt(part.replace(/[^0-9].*$/, ''), 10))
+      .map(n => (Number.isFinite(n) ? n : 0));
+  const a = parse(actual);
+  const r = parse(required);
+  const len = Math.max(a.length, r.length);
+  for (let i = 0; i < len; i += 1) {
+    const av = a[i] ?? 0;
+    const rv = r[i] ?? 0;
+    if (av > rv) return true;
+    if (av < rv) return false;
+  }
+  return true;
+};
 
 const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
   isOpen,
@@ -23,6 +127,8 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
   initialStatus,
   fetchApplicationStatus,
   nodeLabels,
+  updateAppScaling,
+  bioengineVersion,
 }) => {
   // Format a replica's node placement using the cluster-view-consistent
   // role label, plus the replica's own node_instance_id when available
@@ -69,6 +175,17 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
   const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Scaling form state: keyed by user @bioengine.app class name (i.e. the
+  // keys of get_app_status().deployments minus ProxyDeployment). Persists
+  // across status refreshes; resets when the dialog opens or the live
+  // scaling map changes due to a successful Save.
+  const [scalingForm, setScalingForm] = useState<Record<string, DeploymentScalingState>>({});
+  const [scalingInitial, setScalingInitial] = useState<string>('{}');
+  const [savingScaling, setSavingScaling] = useState<boolean>(false);
+  const [scalingSubmitError, setScalingSubmitError] = useState<string | null>(null);
+  const [scalingSubmitOk, setScalingSubmitOk] = useState<boolean>(false);
+  const [advancedOpen, setAdvancedOpen] = useState<Record<string, boolean>>({});
+
   useEffect(() => {
     setStatus(initialStatus || null);
   }, [initialStatus]);
@@ -113,6 +230,133 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
       data,
     }));
   }, [status]);
+
+  // User-facing deployments (excludes ProxyDeployment, which always runs at
+  // one fixed replica per app and is intentionally not addressable by the
+  // scaling map — see bioengine/apps/manager.py:749-754 + 2068).
+  const userDeployments = useMemo(
+    () => deployments.filter(d => d.name !== 'ProxyDeployment'),
+    [deployments],
+  );
+
+  // Pending-replica detector. Either deployment status DEPLOYING (Ray
+  // Serve is still reconciling) or a replica stuck in PENDING_ALLOCATION
+  // (resource queue) means the user just submitted a change that exceeds
+  // free cluster capacity. Surfaced as a banner so the user understands
+  // why the live counts haven't moved yet.
+  const hasPendingReplicas = useMemo(() => {
+    for (const { data } of deployments) {
+      const dStatus = String(data?.status ?? '').toUpperCase();
+      if (dStatus === 'DEPLOYING' || dStatus === 'UPDATING') return true;
+      const replicas = Array.isArray(data?.replicas) ? data.replicas : [];
+      for (const r of replicas) {
+        const rs = String(r?.state ?? '').toUpperCase();
+        if (rs === 'PENDING_ALLOCATION') return true;
+      }
+    }
+    return false;
+  }, [deployments]);
+
+  // Live scaling map from the worker. Always treated as authoritative —
+  // form deltas overlay this on Save so deployments the user didn't touch
+  // keep their existing values (Replacement semantics: passing
+  // scaling={...} replaces the previous map, so omitting an entry would
+  // accidentally reset that deployment to default).
+  const liveScaling = useMemo<Record<string, any>>(() => {
+    const raw = status?.scaling;
+    if (!raw || typeof raw !== 'object') return {};
+    const out: Record<string, any> = {};
+    for (const [k, v] of Object.entries(raw)) {
+      out[k] = v;
+    }
+    return out;
+  }, [status]);
+
+  // Re-seed the form whenever the dialog opens or the live scaling map
+  // changes after a successful Save. We snapshot the JSON shape so the
+  // dirty check is a plain string equality.
+  useEffect(() => {
+    if (!isOpen) return;
+    const seeded: Record<string, DeploymentScalingState> = {};
+    for (const dep of userDeployments) {
+      seeded[dep.name] = entryToState(liveScaling[dep.name]);
+    }
+    setScalingForm(seeded);
+    setScalingInitial(JSON.stringify(seeded));
+    setScalingSubmitError(null);
+    setScalingSubmitOk(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, JSON.stringify(liveScaling), JSON.stringify(userDeployments.map(d => d.name))]);
+
+  const isScalingDirty = JSON.stringify(scalingForm) !== scalingInitial;
+  const scalingEnabled =
+    !!updateAppScaling && meetsVersion(bioengineVersion, '0.11.6') && userDeployments.length > 0;
+
+  // Per-deployment validity check — the form's numeric inputs are unbounded,
+  // so guard against the user typing nonsense before we enable Save.
+  const scalingValidation = useMemo(() => {
+    const errors: Record<string, string> = {};
+    for (const [name, s] of Object.entries(scalingForm)) {
+      if (s.mode === 'fixed') {
+        if (!Number.isFinite(s.num_replicas) || s.num_replicas < 0) {
+          errors[name] = 'Replicas must be 0 or more.';
+        }
+      } else {
+        if (!Number.isFinite(s.min_replicas) || s.min_replicas < 0) {
+          errors[name] = 'Min replicas must be 0 or more.';
+        } else if (!Number.isFinite(s.max_replicas) || s.max_replicas < 1) {
+          errors[name] = 'Max replicas must be at least 1.';
+        } else if (s.max_replicas < s.min_replicas) {
+          errors[name] = 'Max replicas must be greater than or equal to min replicas.';
+        } else if (!Number.isFinite(s.target) || s.target < 1) {
+          errors[name] = 'Target ongoing requests must be at least 1.';
+        }
+      }
+    }
+    return errors;
+  }, [scalingForm]);
+
+  const scalingHasErrors = Object.keys(scalingValidation).length > 0;
+
+  const handleSaveScaling = async () => {
+    if (!updateAppScaling) return;
+    const artifactId = status?.artifact_id;
+    if (!artifactId) {
+      setScalingSubmitError('Cannot determine artifact_id for this app.');
+      return;
+    }
+
+    // Replacement semantics: start from the full live map (covers any
+    // deployments the dialog isn't editing — e.g. a future class added
+    // by the artifact but not yet in our form), overlay form deltas.
+    const fullScaling: Record<string, any> = { ...liveScaling };
+    for (const [name, s] of Object.entries(scalingForm)) {
+      fullScaling[name] = stateToEntry(s);
+    }
+
+    setScalingSubmitError(null);
+    setScalingSubmitOk(false);
+    setSavingScaling(true);
+    try {
+      await updateAppScaling({
+        application_id: applicationId,
+        artifact_id: artifactId,
+        scaling: fullScaling,
+      });
+      setScalingSubmitOk(true);
+      await loadStatus();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setScalingSubmitError(`Save failed: ${msg}`);
+    } finally {
+      setSavingScaling(false);
+    }
+  };
+
+  const updateForm = (name: string, patch: Partial<DeploymentScalingState>) => {
+    setScalingForm(prev => ({ ...prev, [name]: { ...prev[name], ...patch } }));
+    setScalingSubmitOk(false);
+  };
 
   if (!isOpen) return null;
 
@@ -173,6 +417,24 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
             </div>
           )}
 
+          {/* Pending-replica banner — Ray Serve queues replicas the cluster
+              can't yet schedule (no free CPU/GPU). Without this, a Save
+              that bumped max_replicas can look frozen because the new
+              replicas sit in PENDING_ALLOCATION until resources free up. */}
+          {hasPendingReplicas && (
+            <div className="flex items-start gap-3 px-4 py-3 bg-amber-50 border border-amber-200 rounded-lg">
+              <svg className="w-5 h-5 text-amber-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.84-2.75L13.74 4a2 2 0 00-3.48 0L3.16 16.25A2 2 0 005 19z" />
+              </svg>
+              <div className="text-sm text-amber-800">
+                <p className="font-medium">Replica deployment pending</p>
+                <p className="text-amber-700 mt-0.5">
+                  Ray Serve queues replicas that exceed cluster capacity. Pending replicas will start as resources free up.
+                </p>
+              </div>
+            </div>
+          )}
+
           {(!hasLoaded || loading) ? (
             <div className="flex flex-col items-center justify-center py-16 text-gray-600">
               <div className="w-10 h-10 border-4 border-gray-200 border-t-blue-600 rounded-full animate-spin mb-4" />
@@ -196,6 +458,32 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
               Refreshing deployment status...
             </div>
           ) : null}
+
+          {scalingEnabled && hasLoaded && (
+            <ScalingSection
+              userDeployments={userDeployments}
+              scalingForm={scalingForm}
+              advancedOpen={advancedOpen}
+              setAdvancedOpen={setAdvancedOpen}
+              updateForm={updateForm}
+              validation={scalingValidation}
+              isDirty={isScalingDirty}
+              hasErrors={scalingHasErrors}
+              saving={savingScaling}
+              submitError={scalingSubmitError}
+              submitOk={scalingSubmitOk}
+              onSave={handleSaveScaling}
+              onReset={() => {
+                try {
+                  setScalingForm(JSON.parse(scalingInitial));
+                  setScalingSubmitError(null);
+                  setScalingSubmitOk(false);
+                } catch {
+                  /* shouldn't happen — scalingInitial is set from a stringify */
+                }
+              }}
+            />
+          )}
 
           {hasLoaded && !loading && deployments.length === 0 ? (
             <p className="text-sm text-gray-500">No deployment entries found for this application.</p>
@@ -307,5 +595,278 @@ const AppDeploymentsStatusDialog: React.FC<AppDeploymentsStatusDialogProps> = ({
     </div>
   );
 };
+
+// --- Scaling editor ---------------------------------------------------------
+
+interface ScalingSectionProps {
+  userDeployments: Array<{ name: string; data: any }>;
+  scalingForm: Record<string, DeploymentScalingState>;
+  advancedOpen: Record<string, boolean>;
+  setAdvancedOpen: React.Dispatch<React.SetStateAction<Record<string, boolean>>>;
+  updateForm: (name: string, patch: Partial<DeploymentScalingState>) => void;
+  validation: Record<string, string>;
+  isDirty: boolean;
+  hasErrors: boolean;
+  saving: boolean;
+  submitError: string | null;
+  submitOk: boolean;
+  onSave: () => void;
+  onReset: () => void;
+}
+
+const numericInputClass =
+  'w-24 px-2.5 py-1.5 border border-gray-300 rounded-md text-sm tabular-nums focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500';
+
+const ScalingSection: React.FC<ScalingSectionProps> = ({
+  userDeployments,
+  scalingForm,
+  advancedOpen,
+  setAdvancedOpen,
+  updateForm,
+  validation,
+  isDirty,
+  hasErrors,
+  saving,
+  submitError,
+  submitOk,
+  onSave,
+  onReset,
+}) => {
+  return (
+    <div className="border border-gray-200 rounded-xl bg-white">
+      <style>{`
+        .scale-press { transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1); }
+        .scale-press:active:not(:disabled) { transform: scale(0.97); }
+      `}</style>
+
+      <div className="px-4 py-3 border-b border-gray-100 flex items-center gap-2">
+        <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+        </svg>
+        <h4 className="text-base font-semibold text-gray-800">Replica scaling</h4>
+        <span className="text-xs text-gray-500 ml-2">
+          ProxyDeployment runs at one fixed replica and is not editable.
+        </span>
+      </div>
+
+      <div className="p-4 space-y-4">
+        {userDeployments.map(({ name }) => {
+          const state = scalingForm[name];
+          if (!state) return null;
+          const isAuto = state.mode === 'autoscale';
+          const adv = !!advancedOpen[name];
+          const err = validation[name];
+          return (
+            <div key={name} className="border border-gray-200 rounded-lg p-3 bg-gray-50">
+              <div className="flex items-center justify-between gap-3 mb-3">
+                <div className="font-semibold text-gray-800">{name}</div>
+                <label className="inline-flex items-center gap-2 text-sm text-gray-700 cursor-pointer select-none">
+                  <span>Enable autoscaling</span>
+                  <ScaleToggle
+                    checked={isAuto}
+                    onChange={(next) =>
+                      updateForm(name, next ? { mode: 'autoscale' } : { mode: 'fixed' })
+                    }
+                  />
+                </label>
+              </div>
+
+              {!isAuto ? (
+                <div>
+                  <label className="flex items-center gap-3 text-sm text-gray-700">
+                    <span className="w-32">Replicas</span>
+                    <input
+                      type="number"
+                      min={0}
+                      value={Number.isFinite(state.num_replicas) ? state.num_replicas : 0}
+                      onChange={(e) =>
+                        updateForm(name, { num_replicas: parseInt(e.target.value || '0', 10) })
+                      }
+                      className={numericInputClass}
+                    />
+                  </label>
+                  {state.num_replicas === 0 && (
+                    <p className="mt-1.5 text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1 inline-block">
+                      Setting 0 frees all replicas and pauses the app.
+                    </p>
+                  )}
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  <div className="flex flex-wrap gap-4 items-end">
+                    <label className="flex flex-col gap-1 text-sm text-gray-700">
+                      <span>Min replicas</span>
+                      <input
+                        type="number"
+                        min={0}
+                        value={Number.isFinite(state.min_replicas) ? state.min_replicas : 0}
+                        onChange={(e) =>
+                          updateForm(name, { min_replicas: parseInt(e.target.value || '0', 10) })
+                        }
+                        className={numericInputClass}
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-sm text-gray-700">
+                      <span>Max replicas</span>
+                      <input
+                        type="number"
+                        min={1}
+                        value={Number.isFinite(state.max_replicas) ? state.max_replicas : 1}
+                        onChange={(e) =>
+                          updateForm(name, { max_replicas: parseInt(e.target.value || '1', 10) })
+                        }
+                        className={numericInputClass}
+                      />
+                    </label>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setAdvancedOpen(prev => ({ ...prev, [name]: !prev[name] }))
+                    }
+                    className="inline-flex items-center text-xs font-medium text-blue-600 hover:text-blue-800"
+                  >
+                    <svg
+                      className={`w-3.5 h-3.5 mr-1 transition-transform ${adv ? 'rotate-180' : ''}`}
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      style={{ transitionDuration: '180ms', transitionTimingFunction: 'cubic-bezier(0.23, 1, 0.32, 1)' }}
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                    {adv ? 'Hide advanced' : 'Show advanced'}
+                  </button>
+
+                  {adv && (
+                    <div className="flex flex-wrap gap-4 items-end pt-1 pl-1 border-l-2 border-gray-200 ml-1">
+                      <label className="flex flex-col gap-1 text-sm text-gray-700">
+                        <span>Target ongoing requests / replica</span>
+                        <input
+                          type="number"
+                          min={1}
+                          value={Number.isFinite(state.target) ? state.target : 1}
+                          onChange={(e) =>
+                            updateForm(name, { target: parseInt(e.target.value || '1', 10) })
+                          }
+                          className={numericInputClass}
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1 text-sm text-gray-700">
+                        <span>Upscale delay (s)</span>
+                        <input
+                          type="number"
+                          min={0}
+                          placeholder="auto"
+                          value={state.upscale_delay_s ?? ''}
+                          onChange={(e) =>
+                            updateForm(name, {
+                              upscale_delay_s: e.target.value === '' ? null : parseFloat(e.target.value),
+                            })
+                          }
+                          className={numericInputClass}
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1 text-sm text-gray-700">
+                        <span>Downscale delay (s)</span>
+                        <input
+                          type="number"
+                          min={0}
+                          placeholder="auto"
+                          value={state.downscale_delay_s ?? ''}
+                          onChange={(e) =>
+                            updateForm(name, {
+                              downscale_delay_s: e.target.value === '' ? null : parseFloat(e.target.value),
+                            })
+                          }
+                          className={numericInputClass}
+                        />
+                      </label>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {err && (
+                <p className="mt-2 text-xs text-red-600">{err}</p>
+              )}
+            </div>
+          );
+        })}
+
+        <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
+          <div className="text-xs text-gray-500 min-h-[1.25rem]">
+            {submitError ? (
+              <span className="text-red-600">{submitError}</span>
+            ) : submitOk ? (
+              <span className="text-green-700">Scaling updated. Ray Serve is rolling the change.</span>
+            ) : isDirty ? (
+              <span>Unsaved changes</span>
+            ) : (
+              <span className="text-gray-400">No changes yet</span>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onReset}
+              disabled={!isDirty || saving}
+              className="scale-press px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Reset
+            </button>
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={!isDirty || saving || hasErrors}
+              className="scale-press px-4 py-1.5 text-sm font-medium rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed inline-flex items-center"
+            >
+              {saving ? (
+                <>
+                  <svg className="w-4 h-4 mr-1.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  Saving...
+                </>
+              ) : (
+                'Save settings'
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// Small controlled switch matching the dashboard's blue accent. Uses
+// transform-only animation for the thumb so it stays smooth even when the
+// dialog body is re-rendering.
+const ScaleToggle: React.FC<{ checked: boolean; onChange: (next: boolean) => void }> = ({
+  checked,
+  onChange,
+}) => (
+  <button
+    type="button"
+    role="switch"
+    aria-checked={checked}
+    onClick={() => onChange(!checked)}
+    className={`scale-press inline-flex items-center w-10 h-6 rounded-full p-0.5 ${
+      checked ? 'bg-blue-600' : 'bg-gray-300'
+    }`}
+    style={{ transition: 'background-color 180ms cubic-bezier(0.23, 1, 0.32, 1), transform 160ms cubic-bezier(0.23, 1, 0.32, 1)' }}
+  >
+    <span
+      aria-hidden
+      className="w-5 h-5 bg-white rounded-full shadow"
+      style={{
+        transform: checked ? 'translateX(16px)' : 'translateX(0px)',
+        transition: 'transform 180ms cubic-bezier(0.23, 1, 0.32, 1)',
+      }}
+    />
+  </button>
+);
 
 export default AppDeploymentsStatusDialog;

--- a/src/components/bioengine/AppDiskCache.tsx
+++ b/src/components/bioengine/AppDiskCache.tsx
@@ -1,0 +1,537 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+interface AppDirectoryEntry {
+  name: string;
+  application_id: string | null;
+  path: string;
+  is_running: boolean;
+  size_bytes: number;
+  last_used_unix: number | null;
+  node_id: string;
+}
+
+interface AppDiskCacheProps {
+  serviceId: string;
+  server: any;
+  isLoggedIn: boolean;
+  // Changes whenever the parent's deployed-app set changes (deploy / undeploy /
+  // status flip). The cache list refetches on every change, which keeps the
+  // "Status" column honest without running its own auto-poll loop — the
+  // worker's list_app_directories fans out to every Ray node on per-node FS
+  // topologies, so we avoid a tight polling cadence.
+  refreshKey?: string;
+  // {node_id -> "Head Node (...)" | "Worker Node N (...)"} from the parent's
+  // cluster view, so the (rare, per-node FS) Node column matches the cluster
+  // section's numbering. May be empty.
+  nodeLabels?: Record<string, string>;
+}
+
+type SortColumn = 'application_id' | 'size_bytes' | 'last_used_unix';
+type SortDirection = 'asc' | 'desc';
+
+const formatBytes = (bytes: number): string => {
+  if (!bytes || bytes < 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB', 'TB'];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  // 1 decimal place once we get into MB+; KB stays as integer for compactness.
+  const formatted = unit === 0 ? Math.round(value).toString() : value.toFixed(1);
+  return `${formatted} ${units[unit]}`;
+};
+
+const formatRelativeTime = (unixSeconds: number | null, nowMs: number): string => {
+  if (!unixSeconds) return '—';
+  const diffSec = Math.max(0, (nowMs - unixSeconds * 1000) / 1000);
+  if (diffSec < 60) return `${Math.floor(diffSec)}s ago`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`;
+  if (diffSec < 86400 * 30) return `${Math.floor(diffSec / 86400)}d ago`;
+  if (diffSec < 86400 * 365) return `${Math.floor(diffSec / (86400 * 30))}mo ago`;
+  return `${Math.floor(diffSec / (86400 * 365))}y ago`;
+};
+
+const AppDiskCache: React.FC<AppDiskCacheProps> = ({
+  serviceId,
+  server,
+  isLoggedIn,
+  refreshKey,
+  nodeLabels,
+}) => {
+  const [entries, setEntries] = useState<AppDirectoryEntry[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [hasLoaded, setHasLoaded] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [clearingKey, setClearingKey] = useState<string | null>(null);
+  const [confirmEntry, setConfirmEntry] = useState<AppDirectoryEntry | null>(null);
+  const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+  const [sortColumn, setSortColumn] = useState<SortColumn>('last_used_unix');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [now, setNow] = useState<number>(Date.now());
+
+  const fetchInFlight = useRef<boolean>(false);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Tick once a minute so the "Last used" relative labels stay fresh without
+  // refetching the list. Cache mtimes change rarely; we don't need 1s ticks.
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const fetchEntries = useCallback(
+    async (showSpinner: boolean) => {
+      if (!serviceId || !isLoggedIn || !server) return;
+      if (fetchInFlight.current) return;
+      fetchInFlight.current = true;
+      if (showSpinner) setLoading(true);
+      try {
+        const worker = await server.getService(serviceId, { mode: 'random' });
+        const result: AppDirectoryEntry[] = await worker.list_app_directories();
+        // The worker already sorts by (name, node_id); our table re-sorts in
+        // the render, so we just take the raw list.
+        setEntries(Array.isArray(result) ? result : []);
+        setError(null);
+        setHasLoaded(true);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setError(`Failed to load app cache: ${msg}`);
+      } finally {
+        if (showSpinner) setLoading(false);
+        fetchInFlight.current = false;
+      }
+    },
+    [serviceId, isLoggedIn, server],
+  );
+
+  // Initial load + refresh whenever the parent's app status changes (deploy /
+  // undeploy is the main reason an app's is_running flag flips). We don't run
+  // a second auto-poll loop here; the worker's list_app_directories is a fan-
+  // out across Ray nodes on per-node FS topologies and is comparatively heavy.
+  useEffect(() => {
+    fetchEntries(!hasLoaded);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serviceId, isLoggedIn, refreshKey]);
+
+  // Multi-node only matters in the per-node FS topology. KTH (shared FS)
+  // returns every entry tagged with the same node id — hide the column in
+  // that case to keep the table clean. We probe distinct node ids in the
+  // current result set rather than asking the worker's topology hint, which
+  // keeps the UI honest even if the topology classification changes.
+  const isMultiNode = useMemo(() => {
+    const ids = new Set<string>();
+    for (const e of entries) {
+      if (e?.node_id) ids.add(e.node_id);
+      if (ids.size > 1) return true;
+    }
+    return false;
+  }, [entries]);
+
+  const sortedEntries = useMemo(() => {
+    const copy = [...entries];
+    const dir = sortDirection === 'asc' ? 1 : -1;
+    copy.sort((a, b) => {
+      if (sortColumn === 'application_id') {
+        const av = (a.application_id ?? a.name ?? '').toLowerCase();
+        const bv = (b.application_id ?? b.name ?? '').toLowerCase();
+        if (av === bv) return 0;
+        return av < bv ? -1 * dir : 1 * dir;
+      }
+      if (sortColumn === 'size_bytes') {
+        return ((a.size_bytes ?? 0) - (b.size_bytes ?? 0)) * dir;
+      }
+      // last_used_unix; treat null as the oldest possible value so it lands
+      // at the end on DESC and at the top on ASC.
+      const av = a.last_used_unix ?? -Infinity;
+      const bv = b.last_used_unix ?? -Infinity;
+      return (av - bv) * dir;
+    });
+    return copy;
+  }, [entries, sortColumn, sortDirection]);
+
+  const totals = useMemo(() => {
+    const totalBytes = entries.reduce((sum, e) => sum + (e.size_bytes ?? 0), 0);
+    const runningCount = entries.filter(e => e.is_running).length;
+    return { totalBytes, runningCount };
+  }, [entries]);
+
+  const handleSort = (column: SortColumn) => {
+    if (sortColumn === column) {
+      setSortDirection(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortColumn(column);
+      // Sensible default per column: size and last_used start descending
+      // (biggest / most recent first), id starts ascending (A→Z).
+      setSortDirection(column === 'application_id' ? 'asc' : 'desc');
+    }
+  };
+
+  const showToast = (kind: 'success' | 'error', text: string) => {
+    setToast({ kind, text });
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(null), 4000);
+  };
+
+  useEffect(() => () => {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+  }, []);
+
+  const handleConfirmClear = async () => {
+    if (!confirmEntry) return;
+    const entry = confirmEntry;
+    // application_id may be null on legacy / unrecognised dirs — fall back to
+    // the bare directory name. The worker accepts both: it first probes
+    // `<worker-workspace>-<id>`, then falls back to `<id>` (see
+    // bioengine/apps/manager.py:1494-1498).
+    const key = entry.application_id ?? entry.name;
+    setConfirmEntry(null);
+    setClearingKey(key);
+    try {
+      const worker = await server.getService(serviceId, { mode: 'random' });
+      const result = await worker.clear_app_directory({
+        application_id: key,
+        _rkwargs: true,
+      });
+      const deletedCount = Array.isArray(result?.deleted_on) ? result.deleted_on.length : 0;
+      const noun = deletedCount === 1 ? 'directory' : 'directories';
+      showToast('success', `Cleared ${deletedCount} ${noun} for ${key}`);
+      await fetchEntries(false);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      showToast('error', `Failed to clear ${key}: ${msg}`);
+    } finally {
+      setClearingKey(null);
+    }
+  };
+
+  const sortIcon = (column: SortColumn) => {
+    if (sortColumn !== column) {
+      return (
+        <svg className="w-3 h-3 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l4-4 4 4m0 6l-4 4-4-4" />
+        </svg>
+      );
+    }
+    return sortDirection === 'asc' ? (
+      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+      </svg>
+    ) : (
+      <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+      </svg>
+    );
+  };
+
+  return (
+    <div className="mb-8" style={{ animation: 'cacheFadeIn 220ms cubic-bezier(0.23, 1, 0.32, 1)' }}>
+      <style>{`
+        @keyframes cacheFadeIn {
+          from { opacity: 0; transform: translateY(6px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .cache-press { transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1); }
+        .cache-press:active:not(:disabled) { transform: scale(0.97); }
+        .cache-row { transition: background-color 150ms ease-out; }
+      `}</style>
+
+      <div className="flex justify-between items-center mb-6">
+        <div className="flex items-center">
+          <div className="w-10 h-10 bg-gradient-to-r from-slate-500 to-slate-600 rounded-xl flex items-center justify-center mr-3">
+            <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2 1 3 3 3h10c2 0 3-1 3-3V7M4 7c0-2 1-3 3-3h10c2 0 3 1 3 3M4 7h16M9 11h6M9 15h6" />
+            </svg>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-gray-800">App Disk Cache</h3>
+            <p className="text-xs text-gray-500">
+              Working directories on the Ray actor pods. Stop an app before clearing its cache.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => fetchEntries(true)}
+          disabled={loading}
+          className="cache-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          <svg
+            className={`w-4 h-4 mr-1.5 ${loading ? 'animate-spin' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v6h6M20 20v-6h-6M5.07 9A8 8 0 0119 9M19 15a8 8 0 01-13.93 0" />
+          </svg>
+          {loading ? 'Refreshing' : 'Refresh'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg flex justify-between items-start">
+          <div className="flex">
+            <svg className="w-5 h-5 text-red-400 mr-2 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <div>
+              <h4 className="text-sm font-medium text-red-800">Cache list error</h4>
+              <p className="text-sm text-red-700 mt-1">{error}</p>
+            </div>
+          </div>
+          <button
+            onClick={() => setError(null)}
+            className="text-red-400 hover:text-red-600"
+            aria-label="Dismiss error"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      <div className="bg-white/80 backdrop-blur-sm rounded-2xl shadow-sm border border-white/20">
+        {!hasLoaded && loading ? (
+          <div className="flex flex-col items-center justify-center py-12 text-gray-600">
+            <div className="w-8 h-8 border-2 border-gray-200 border-t-blue-600 rounded-full animate-spin mb-3" />
+            <p className="text-sm">Loading cache entries...</p>
+          </div>
+        ) : hasLoaded && entries.length === 0 ? (
+          <div className="py-12 text-center text-sm text-gray-500">
+            No cached app directories on this worker.
+          </div>
+        ) : (
+          <>
+            <div className="px-5 py-3 border-b border-gray-100 flex flex-wrap gap-4 items-center text-xs text-gray-600">
+              <span>
+                <span className="font-semibold text-gray-800">{entries.length}</span>{' '}
+                {entries.length === 1 ? 'entry' : 'entries'}
+              </span>
+              <span>
+                Total size{' '}
+                <span className="font-semibold text-gray-800">{formatBytes(totals.totalBytes)}</span>
+              </span>
+              <span>
+                Running{' '}
+                <span className="font-semibold text-gray-800">{totals.runningCount}</span>
+              </span>
+            </div>
+
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+                  <tr>
+                    <th className="text-left px-5 py-2.5 font-medium">
+                      <button
+                        onClick={() => handleSort('application_id')}
+                        className="cache-press inline-flex items-center gap-1.5 hover:text-gray-700"
+                      >
+                        Application ID
+                        {sortIcon('application_id')}
+                      </button>
+                    </th>
+                    <th className="text-right px-5 py-2.5 font-medium">
+                      <button
+                        onClick={() => handleSort('size_bytes')}
+                        className="cache-press inline-flex items-center gap-1.5 hover:text-gray-700"
+                      >
+                        Size
+                        {sortIcon('size_bytes')}
+                      </button>
+                    </th>
+                    <th className="text-left px-5 py-2.5 font-medium">
+                      <button
+                        onClick={() => handleSort('last_used_unix')}
+                        className="cache-press inline-flex items-center gap-1.5 hover:text-gray-700"
+                      >
+                        Last used
+                        {sortIcon('last_used_unix')}
+                      </button>
+                    </th>
+                    <th className="text-left px-5 py-2.5 font-medium">Status</th>
+                    {isMultiNode && (
+                      <th className="text-left px-5 py-2.5 font-medium">Node</th>
+                    )}
+                    <th className="text-right px-5 py-2.5 font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedEntries.map((entry) => {
+                    const idLabel = entry.application_id ?? entry.name;
+                    const rowKey = `${entry.node_id}::${entry.name}`;
+                    const isClearing = clearingKey === (entry.application_id ?? entry.name);
+                    const nodeLabel =
+                      isMultiNode
+                        ? nodeLabels?.[entry.node_id] ?? entry.node_id.slice(0, 8)
+                        : null;
+                    return (
+                      <tr
+                        key={rowKey}
+                        className="cache-row border-t border-gray-100 hover:bg-gray-50"
+                      >
+                        <td className="px-5 py-2.5 align-middle">
+                          <div className="font-mono text-gray-900 break-all">{idLabel}</div>
+                          {!entry.application_id && (
+                            <div className="text-[10px] text-gray-400 mt-0.5">
+                              legacy / unprefixed directory
+                            </div>
+                          )}
+                        </td>
+                        <td className="px-5 py-2.5 text-right tabular-nums text-gray-800 whitespace-nowrap">
+                          {formatBytes(entry.size_bytes)}
+                        </td>
+                        <td
+                          className="px-5 py-2.5 text-gray-700 whitespace-nowrap"
+                          title={
+                            entry.last_used_unix
+                              ? new Date(entry.last_used_unix * 1000).toLocaleString()
+                              : 'No files in cache'
+                          }
+                        >
+                          {formatRelativeTime(entry.last_used_unix, now)}
+                        </td>
+                        <td className="px-5 py-2.5">
+                          {entry.is_running ? (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700 border border-green-200">
+                              <span className="w-1.5 h-1.5 rounded-full bg-green-500 mr-1.5" />
+                              Running
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-50 text-gray-600 border border-gray-200">
+                              Idle
+                            </span>
+                          )}
+                        </td>
+                        {isMultiNode && (
+                          <td
+                            className="px-5 py-2.5 font-mono text-xs text-gray-600 whitespace-nowrap"
+                            title={entry.node_id}
+                          >
+                            {nodeLabel}
+                          </td>
+                        )}
+                        <td className="px-5 py-2.5 text-right">
+                          <button
+                            onClick={() => setConfirmEntry(entry)}
+                            disabled={entry.is_running || isClearing}
+                            title={
+                              entry.is_running
+                                ? 'Stop the app first'
+                                : `Delete ${entry.path}`
+                            }
+                            className={`cache-press inline-flex items-center px-2.5 py-1 text-xs font-medium rounded-md border ${
+                              entry.is_running || isClearing
+                                ? 'bg-gray-50 text-gray-400 border-gray-200 cursor-not-allowed'
+                                : 'bg-white text-red-700 border-red-200 hover:bg-red-50 hover:border-red-300'
+                            }`}
+                          >
+                            {isClearing ? (
+                              <>
+                                <svg className="w-3.5 h-3.5 mr-1 animate-spin" fill="none" viewBox="0 0 24 24">
+                                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                                </svg>
+                                Clearing
+                              </>
+                            ) : (
+                              <>
+                                <svg className="w-3.5 h-3.5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" />
+                                </svg>
+                                Clear
+                              </>
+                            )}
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+
+      {confirmEntry && (
+        <div
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+          style={{ animation: 'cacheFadeIn 180ms cubic-bezier(0.23, 1, 0.32, 1)' }}
+        >
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md">
+            <div className="px-5 py-4 border-b border-gray-100">
+              <h4 className="text-base font-semibold text-gray-800">Clear cached directory?</h4>
+            </div>
+            <div className="px-5 py-4 text-sm text-gray-700 space-y-3">
+              <p>
+                This deletes <code className="px-1 py-0.5 bg-gray-100 rounded font-mono text-xs break-all">{confirmEntry.path}</code> on
+                {' '}
+                {isMultiNode ? 'every node where it exists' : 'the Ray actor pod'}.
+                The next deploy of this app will rebuild the cache.
+              </p>
+              <p className="text-xs text-gray-500">
+                Application ID: <span className="font-mono">{confirmEntry.application_id ?? confirmEntry.name}</span>
+                {' · '}
+                Size: <span className="font-mono">{formatBytes(confirmEntry.size_bytes)}</span>
+              </p>
+            </div>
+            <div className="px-5 py-3 border-t border-gray-100 flex justify-end gap-2">
+              <button
+                onClick={() => setConfirmEntry(null)}
+                className="cache-press px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmClear}
+                className="cache-press px-3 py-1.5 text-sm font-medium rounded-lg bg-red-600 text-white hover:bg-red-700"
+              >
+                Clear directory
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {toast && (
+        <div
+          className="fixed bottom-6 right-6 z-50"
+          style={{ animation: 'cacheFadeIn 180ms cubic-bezier(0.23, 1, 0.32, 1)' }}
+        >
+          <div
+            className={`px-4 py-3 rounded-lg shadow-lg border text-sm flex items-start gap-2 max-w-sm ${
+              toast.kind === 'success'
+                ? 'bg-white border-green-200 text-green-800'
+                : 'bg-white border-red-200 text-red-800'
+            }`}
+          >
+            {toast.kind === 'success' ? (
+              <svg className="w-4 h-4 mt-0.5 text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            ) : (
+              <svg className="w-4 h-4 mt-0.5 text-red-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+            )}
+            <span className="break-all">{toast.text}</span>
+            <button
+              onClick={() => setToast(null)}
+              className="ml-2 text-gray-400 hover:text-gray-600"
+              aria-label="Dismiss"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AppDiskCache;

--- a/src/components/bioengine/AppDiskCache.tsx
+++ b/src/components/bioengine/AppDiskCache.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import ErrorDialog from './ErrorDialog';
 
 interface AppDirectoryEntry {
   name: string;
@@ -68,7 +69,10 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [clearingKey, setClearingKey] = useState<string | null>(null);
   const [confirmEntry, setConfirmEntry] = useState<AppDirectoryEntry | null>(null);
-  const [toast, setToast] = useState<{ kind: 'success' | 'error'; text: string } | null>(null);
+  // Only success toasts go here — failures route to ErrorDialog so a long
+  // stack trace stays readable.
+  const [toast, setToast] = useState<{ text: string } | null>(null);
+  const [clearError, setClearError] = useState<{ subtitle: string; message: string } | null>(null);
   const [sortColumn, setSortColumn] = useState<SortColumn>('last_used_unix');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
   const [now, setNow] = useState<number>(Date.now());
@@ -108,12 +112,15 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
     [serviceId, isLoggedIn, server],
   );
 
-  // Initial load + refresh whenever the parent's app status changes (deploy /
-  // undeploy is the main reason an app's is_running flag flips). We don't run
-  // a second auto-poll loop here; the worker's list_app_directories is a fan-
-  // out across Ray nodes on per-node FS topologies and is comparatively heavy.
+  // Refresh whenever the parent's app status changes (deploy / undeploy is
+  // the main reason an app's is_running flag flips), but ONLY after the
+  // operator has loaded the list at least once. list_app_directories fans
+  // out to every Ray node on per-node FS topologies and is genuinely
+  // expensive, so we never auto-load on mount — the operator has to opt
+  // in by clicking the load button.
   useEffect(() => {
-    fetchEntries(!hasLoaded);
+    if (!hasLoaded) return;
+    fetchEntries(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serviceId, isLoggedIn, refreshKey]);
 
@@ -170,8 +177,8 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
     }
   };
 
-  const showToast = (kind: 'success' | 'error', text: string) => {
-    setToast({ kind, text });
+  const showToast = (text: string) => {
+    setToast({ text });
     if (toastTimer.current) clearTimeout(toastTimer.current);
     toastTimer.current = setTimeout(() => setToast(null), 4000);
   };
@@ -198,11 +205,30 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
       });
       const deletedCount = Array.isArray(result?.deleted_on) ? result.deleted_on.length : 0;
       const noun = deletedCount === 1 ? 'directory' : 'directories';
-      showToast('success', `Cleared ${deletedCount} ${noun} for ${key}`);
-      await fetchEntries(false);
+      showToast(`Cleared ${deletedCount} ${noun} for ${key}`);
+      // Optimistic update — hide the cleared row(s) immediately so the
+      // operator doesn't see the just-deleted cache lingering until the
+      // next manual refresh. The worker raises ValueError when nothing
+      // was actually deleted, so reaching this branch guarantees at
+      // least one on-disk directory is gone. On multi-node FS, when
+      // `deleted_on` lists specific nodes, we drop rows by (key, node);
+      // otherwise we drop every row that matches the key.
+      setEntries(prev => {
+        const deletedNodes = new Set<string>(
+          Array.isArray(result?.deleted_on) ? result.deleted_on : [],
+        );
+        return prev.filter(e => {
+          const eKey = e.application_id ?? e.name;
+          if (eKey !== key) return true;
+          // Same key — drop if this specific node was in deleted_on, or
+          // if the worker returned no deleted_on list (treat as "all").
+          if (deletedNodes.size === 0) return false;
+          return !deletedNodes.has(e.node_id);
+        });
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      showToast('error', `Failed to clear ${key}: ${msg}`);
+      setClearError({ subtitle: key, message: msg });
     } finally {
       setClearingKey(null);
     }
@@ -227,6 +253,14 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
     );
   };
 
+  // Header button label flips from primary "Load app cache" (before first
+  // load) to a quieter "Refresh" once we have data. Mirrors the visual
+  // weight to the action: the first fetch is an explicit opt-in, the
+  // subsequent ones are housekeeping.
+  const loadButtonLabel = !hasLoaded
+    ? (loading ? 'Loading...' : 'Load app cache')
+    : (loading ? 'Refreshing' : 'Refresh');
+
   return (
     <div className="mb-8" style={{ animation: 'cacheFadeIn 220ms cubic-bezier(0.23, 1, 0.32, 1)' }}>
       <style>{`
@@ -238,6 +272,13 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
         .cache-press:active:not(:disabled) { transform: scale(0.97); }
         .cache-row { transition: background-color 150ms ease-out; }
       `}</style>
+
+      {/* Section divider — mirrors the trailing border at the end of
+          DeployedBioEngineApps (line 203) so each major section on the
+          worker dashboard is visually separated. Rendered as the first
+          child here so it only appears when the cache section actually
+          renders (admin + bioengine >= 0.11.6). */}
+      <div className="border-t border-gray-200 my-6" />
 
       <div className="flex justify-between items-center mb-6">
         <div className="flex items-center">
@@ -256,7 +297,11 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
         <button
           onClick={() => fetchEntries(true)}
           disabled={loading}
-          className="cache-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-60 disabled:cursor-not-allowed"
+          className={`cache-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border disabled:opacity-60 disabled:cursor-not-allowed ${
+            !hasLoaded
+              ? 'border-blue-600 bg-blue-600 text-white hover:bg-blue-700 hover:border-blue-700 disabled:bg-blue-400 disabled:border-blue-400'
+              : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50'
+          }`}
         >
           <svg
             className={`w-4 h-4 mr-1.5 ${loading ? 'animate-spin' : ''}`}
@@ -264,9 +309,13 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
             stroke="currentColor"
             viewBox="0 0 24 24"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v6h6M20 20v-6h-6M5.07 9A8 8 0 0119 9M19 15a8 8 0 01-13.93 0" />
+            {!hasLoaded && !loading ? (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v6h6M20 20v-6h-6M5.07 9A8 8 0 0119 9M19 15a8 8 0 01-13.93 0" />
+            )}
           </svg>
-          {loading ? 'Refreshing' : 'Refresh'}
+          {loadButtonLabel}
         </button>
       </div>
 
@@ -299,7 +348,14 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
             <div className="w-8 h-8 border-2 border-gray-200 border-t-blue-600 rounded-full animate-spin mb-3" />
             <p className="text-sm">Loading cache entries...</p>
           </div>
-        ) : hasLoaded && entries.length === 0 ? (
+        ) : !hasLoaded ? (
+          // First-visit empty state. Listing the cache fans out a Ray task
+          // per node on per-node FS topologies, so we don't fetch on mount —
+          // the operator has to opt in via the header button above.
+          <div className="py-12 text-center text-sm text-gray-500">
+            Cache is not loaded yet. Click <span className="font-medium text-gray-700">Load app cache</span> to query the worker.
+          </div>
+        ) : entries.length === 0 ? (
           <div className="py-12 text-center text-sm text-gray-500">
             No cached app directories on this worker.
           </div>
@@ -501,22 +557,10 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
           className="fixed bottom-6 right-6 z-50"
           style={{ animation: 'cacheFadeIn 180ms cubic-bezier(0.23, 1, 0.32, 1)' }}
         >
-          <div
-            className={`px-4 py-3 rounded-lg shadow-lg border text-sm flex items-start gap-2 max-w-sm ${
-              toast.kind === 'success'
-                ? 'bg-white border-green-200 text-green-800'
-                : 'bg-white border-red-200 text-red-800'
-            }`}
-          >
-            {toast.kind === 'success' ? (
-              <svg className="w-4 h-4 mt-0.5 text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-            ) : (
-              <svg className="w-4 h-4 mt-0.5 text-red-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            )}
+          <div className="px-4 py-3 rounded-lg shadow-lg border text-sm flex items-start gap-2 max-w-sm bg-white border-green-200 text-green-800">
+            <svg className="w-4 h-4 mt-0.5 text-green-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
             <span className="break-all">{toast.text}</span>
             <button
               onClick={() => setToast(null)}
@@ -530,6 +574,14 @@ const AppDiskCache: React.FC<AppDiskCacheProps> = ({
           </div>
         </div>
       )}
+
+      <ErrorDialog
+        open={!!clearError}
+        title="Cache delete failed"
+        subtitle={clearError?.subtitle}
+        message={clearError?.message ?? ''}
+        onClose={() => setClearError(null)}
+      />
     </div>
   );
 };

--- a/src/components/bioengine/AvailableBioEngineApps.tsx
+++ b/src/components/bioengine/AvailableBioEngineApps.tsx
@@ -42,8 +42,7 @@ interface AvailableBioEngineAppsProps {
   deployingArtifactId?: string | null;
   pendingDeploymentArtifactId?: string | null;
   artifactModes?: Record<string, string>;
-  deploymentError?: string | null;
-  setDeploymentError?: (error: string | null) => void;
+  // Deployment errors are surfaced via the worker-level ErrorDialog.
   // Deployment handlers
   onDeployArtifact?: (artifactId: string, mode?: string | null) => void;
   onUndeployArtifact?: (artifactId: string) => void;
@@ -65,8 +64,6 @@ const AvailableBioEngineApps: React.FC<AvailableBioEngineAppsProps> = ({
   deployingArtifactId,
   pendingDeploymentArtifactId,
   artifactModes = {},
-  deploymentError,
-  setDeploymentError,
   onDeployArtifact,
   onUndeployArtifact,
   onModeChange,
@@ -404,23 +401,10 @@ const AvailableBioEngineApps: React.FC<AvailableBioEngineAppsProps> = ({
         </div>
       </div>
 
-      {/* Deployment error */}
-      {deploymentError && setDeploymentError && (
-        <div className="p-4 bg-red-50 border border-red-200 rounded-lg flex justify-between items-start">
-          <div className="flex gap-2">
-            <svg className="w-5 h-5 text-red-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-            <div>
-              <h4 className="text-sm font-medium text-red-800">Deployment Error</h4>
-              <p className="text-sm text-red-700 mt-1">{deploymentError}</p>
-            </div>
-          </div>
-          <button onClick={() => setDeploymentError(null)} className="text-red-400 hover:text-red-600">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-          </button>
-        </div>
-      )}
+      {/* Deployment errors are now rendered by the worker-level
+          ErrorDialog (BioEngineWorker.tsx) so multi-line stack traces
+          stay readable. The internal "error" state below is for the
+          artifact-list fetch itself, which is a different code path. */}
 
       {/* Error */}
       {error && (

--- a/src/components/bioengine/BioEngineApps.tsx
+++ b/src/components/bioengine/BioEngineApps.tsx
@@ -33,6 +33,12 @@ interface BioEngineAppsProps {
     logs_tail?: number;
     n_previous_replica?: number;
   }) => Promise<any>;
+  updateAppScaling?: (params: {
+    application_id: string;
+    artifact_id: string;
+    scaling: Record<string, any>;
+  }) => Promise<void>;
+  bioengineVersion?: string;
 }
 
 const BioEngineApps: React.FC<BioEngineAppsProps> = ({
@@ -58,7 +64,9 @@ const BioEngineApps: React.FC<BioEngineAppsProps> = ({
   setUndeploymentError,
   formatTimeInfo,
   server,
-  fetchApplicationStatus
+  fetchApplicationStatus,
+  updateAppScaling,
+  bioengineVersion,
 }) => {
   const { server: hyphaServer, isLoggedIn } = useHyphaStore();
   const activeServer = server || hyphaServer;
@@ -75,6 +83,8 @@ const BioEngineApps: React.FC<BioEngineAppsProps> = ({
           undeploymentError={undeploymentError}
           setUndeploymentError={setUndeploymentError}
           fetchApplicationStatus={fetchApplicationStatus}
+          updateAppScaling={updateAppScaling}
+          bioengineVersion={bioengineVersion}
         />
       )}
 

--- a/src/components/bioengine/BioEngineApps.tsx
+++ b/src/components/bioengine/BioEngineApps.tsx
@@ -21,11 +21,10 @@ interface BioEngineAppsProps {
   getDeploymentStatus?: (artifactId: string) => string | null;
   isDeployButtonDisabled?: (artifactId: string) => boolean;
   getDeployButtonText?: (artifactId: string) => string;
-  // Error states and utility functions
-  deploymentError?: string | null;
-  undeploymentError?: string | null;
-  setDeploymentError?: (error: string | null) => void;
-  setUndeploymentError?: (error: string | null) => void;
+  // Worker errors are surfaced in a top-level ErrorDialog rendered by
+  // BioEngineWorker. Children no longer accept setDeploymentError /
+  // setUndeploymentError; this comment exists so a future refactor
+  // doesn't reintroduce them.
   formatTimeInfo?: (timestamp: number) => { formattedTime: string, uptime: string };
   server?: any;
   fetchApplicationStatus?: (params: {
@@ -58,10 +57,6 @@ const BioEngineApps: React.FC<BioEngineAppsProps> = ({
   getDeploymentStatus,
   isDeployButtonDisabled,
   getDeployButtonText,
-  deploymentError,
-  undeploymentError,
-  setDeploymentError,
-  setUndeploymentError,
   formatTimeInfo,
   server,
   fetchApplicationStatus,
@@ -80,8 +75,6 @@ const BioEngineApps: React.FC<BioEngineAppsProps> = ({
           undeployingArtifactId={undeployingArtifactId}
           onUndeployArtifact={onUndeployArtifact!}
           formatTimeInfo={formatTimeInfo}
-          undeploymentError={undeploymentError}
-          setUndeploymentError={setUndeploymentError}
           fetchApplicationStatus={fetchApplicationStatus}
           updateAppScaling={updateAppScaling}
           bioengineVersion={bioengineVersion}
@@ -98,8 +91,6 @@ const BioEngineApps: React.FC<BioEngineAppsProps> = ({
         deployingArtifactId={deployingArtifactId}
         pendingDeploymentArtifactId={pendingDeploymentArtifactId}
         artifactModes={artifactModes}
-        deploymentError={deploymentError}
-        setDeploymentError={setDeploymentError}
         onDeployArtifact={onDeployArtifact}
         onUndeployArtifact={onUndeployArtifact}
         onModeChange={onModeChange}

--- a/src/components/bioengine/BioEngineWorker.tsx
+++ b/src/components/bioengine/BioEngineWorker.tsx
@@ -1,9 +1,33 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useHyphaStore } from '../../store/hyphaStore';
 import BioEngineClusterResources from './BioEngineClusterResources';
 import BioEngineApps from './BioEngineApps';
 import DeploymentConfigModal from './DeploymentConfigModal';
+import AppDiskCache from './AppDiskCache';
+
+// Returns true when `actual` is >= `required` under loose semver-by-parts
+// comparison. Handles pre-release suffixes by stripping anything past the
+// first non-numeric character in each component. Falls back to false for
+// missing or unparseable inputs so unknown / pre-0.11.6 workers stay gated.
+const meetsVersion = (actual: string | undefined, required: string): boolean => {
+  if (!actual) return false;
+  const parse = (v: string): number[] =>
+    v
+      .split('.')
+      .map(part => parseInt(part.replace(/[^0-9].*$/, ''), 10))
+      .map(n => (Number.isFinite(n) ? n : 0));
+  const a = parse(actual);
+  const r = parse(required);
+  const len = Math.max(a.length, r.length);
+  for (let i = 0; i < len; i += 1) {
+    const av = a[i] ?? 0;
+    const rv = r[i] ?? 0;
+    if (av > rv) return true;
+    if (av < rv) return false;
+  }
+  return true;
+};
 
 
 // Add custom animations
@@ -875,6 +899,40 @@ const BioEngineWorker: React.FC = () => {
     return null;
   };
 
+  // A short, deterministic signature of the currently deployed app set.
+  // AppDiskCache refetches whenever this string changes (deploy / undeploy /
+  // status flip), which is the only event that affects the "Status" column —
+  // we deliberately don't run another auto-poll loop in the cache component.
+  const cacheRefreshKey = useMemo(() => {
+    const apps = status?.bioengine_apps;
+    if (!apps) return '';
+    return Object.entries(apps)
+      .filter(([key, value]) => key !== 'service_id' && key !== 'note' && typeof value === 'object' && value !== null)
+      .map(([key, value]: any) => `${key}:${value?.status ?? ''}`)
+      .sort()
+      .join('|');
+  }, [status]);
+
+  // Build the same {node_id -> "Head Node (...)"|"Worker Node N (...)"} map
+  // DeployedBioEngineApps builds for the placement badges. Used by
+  // AppDiskCache's Node column on per-node FS topologies — keeping the
+  // numbering consistent across the dashboard.
+  const cacheNodeLabels = useMemo(() => {
+    const out: Record<string, string> = {};
+    const rayNodes = status?.ray_cluster?.nodes;
+    if (!rayNodes || typeof rayNodes !== 'object') return out;
+    const entries = Object.entries(rayNodes as Record<string, any>).sort(([, a], [, b]) => {
+      if ((a?.head ?? false) === (b?.head ?? false)) return 0;
+      return a?.head ? -1 : 1;
+    });
+    let workerNumber = 0;
+    for (const [nodeId, node] of entries) {
+      const role = node?.head ? 'Head Node' : `Worker Node ${++workerNumber}`;
+      out[nodeId] = `${role} (${nodeId.slice(0, 8)})`;
+    }
+    return out;
+  }, [status]);
+
   // Worker admin membership: only admins can deploy/undeploy apps, read logs,
   // or stop the worker. Non-admins can still call get_status, list datasets,
   // list deployed apps, and any deployed app service that includes them in
@@ -1283,6 +1341,19 @@ ${token}`;
           server={server}
           fetchApplicationStatus={fetchApplicationStatus}
         />
+
+        {/* App Disk Cache — admin-only API, gated on bioengine 0.11.6+ which
+            ships the enriched list_app_directories / clear_app_directory
+            surface used here. Older workers silently omit this section. */}
+        {isWorkerAdmin && meetsVersion(status?.bioengine_version, '0.11.6') && (
+          <AppDiskCache
+            serviceId={serviceId}
+            server={server}
+            isLoggedIn={isLoggedIn}
+            refreshKey={cacheRefreshKey}
+            nodeLabels={cacheNodeLabels}
+          />
+        )}
 
         {pendingDeployment && (
           <DeploymentConfigModal

--- a/src/components/bioengine/BioEngineWorker.tsx
+++ b/src/components/bioengine/BioEngineWorker.tsx
@@ -856,6 +856,30 @@ const BioEngineWorker: React.FC = () => {
     fetchStatus(false);
   };
 
+  // Submit a scaling-only update for a running app. Calls deploy_app with
+  // just the {application_id, artifact_id, scaling} triple — every other
+  // deploy parameter (token, env vars, kwargs, GPU mode...) is preserved by
+  // the worker's is_update branch when the application_id already exists
+  // (bioengine/apps/manager.py:1910-1941). Ray Serve handles the new
+  // replica counts as a rolling reconfigure.
+  const updateAppScaling = async (params: {
+    application_id: string;
+    artifact_id: string;
+    scaling: Record<string, any>;
+  }) => {
+    if (!serviceId || !isLoggedIn) {
+      throw new Error('Service unavailable or user not logged in');
+    }
+    const bioengineWorker = await server.getService(serviceId);
+    await bioengineWorker.deploy_app({
+      application_id: params.application_id,
+      artifact_id: params.artifact_id,
+      scaling: params.scaling,
+      _rkwargs: true,
+    });
+    await fetchStatus(false);
+  };
+
   const fetchApplicationStatus = async (params: {
     application_ids?: string[];
     logs_tail?: number;
@@ -1340,6 +1364,8 @@ ${token}`;
           formatTimeInfo={formatTimeInfo}
           server={server}
           fetchApplicationStatus={fetchApplicationStatus}
+          updateAppScaling={updateAppScaling}
+          bioengineVersion={status?.bioengine_version}
         />
 
         {/* App Disk Cache — admin-only API, gated on bioengine 0.11.6+ which

--- a/src/components/bioengine/BioEngineWorker.tsx
+++ b/src/components/bioengine/BioEngineWorker.tsx
@@ -5,6 +5,7 @@ import BioEngineClusterResources from './BioEngineClusterResources';
 import BioEngineApps from './BioEngineApps';
 import DeploymentConfigModal from './DeploymentConfigModal';
 import AppDiskCache from './AppDiskCache';
+import ErrorDialog from './ErrorDialog';
 
 // Returns true when `actual` is >= `required` under loose semver-by-parts
 // comparison. Handles pre-release suffixes by stripping anything past the
@@ -197,8 +198,15 @@ const BioEngineWorker: React.FC = () => {
   // Deployment state
   const [deployingArtifactId, setDeployingArtifactId] = useState<string | null>(null);
   const [undeployingArtifactId, setUndeployingArtifactId] = useState<string | null>(null);
-  const [deploymentError, setDeploymentError] = useState<string | null>(null);
-  const [undeploymentError, setUndeploymentError] = useState<string | null>(null);
+  // Bioengine worker / app errors get rendered in ErrorDialog (a scrollable
+  // modal) instead of an inline red panel — backend stack traces can run
+  // dozens of lines and were getting truncated / pushing other UI around.
+  // The downstream "setDeploymentError" / "setUndeploymentError" string
+  // props that BioEngineApps and its children still accept are stubs that
+  // wrap the message into the new dialog state for backwards compatibility.
+  type WorkerErrorState = { title: string; subtitle?: string; message: string } | null;
+  const [deploymentError, setDeploymentError] = useState<WorkerErrorState>(null);
+  const [undeploymentError, setUndeploymentError] = useState<WorkerErrorState>(null);
   const [artifactModes, setArtifactModes] = useState<Record<string, string>>({});
   const [autoRefreshEnabled, setAutoRefreshEnabled] = useState(true);
   const [refreshInterval, setRefreshInterval] = useState<NodeJS.Timeout | null>(null);
@@ -556,7 +564,11 @@ const BioEngineWorker: React.FC = () => {
         return;
       }
 
-      setDeploymentError(`Failed to deploy ${artifactId}: ${errorMessage}`);
+      setDeploymentError({
+        title: 'Deployment failed',
+        subtitle: artifactId,
+        message: errorMessage,
+      });
       setDeployingArtifactId(null);
     }
   };
@@ -674,7 +686,11 @@ const BioEngineWorker: React.FC = () => {
         return;
       }
 
-      setUndeploymentError(`Failed to stop application ${applicationId}: ${errorMessage}`);
+      setUndeploymentError({
+        title: 'Stop application failed',
+        subtitle: applicationId,
+        message: errorMessage,
+      });
       setUndeployingArtifactId(null);
     }
   };
@@ -1356,11 +1372,10 @@ ${token}`;
           getDeploymentStatus={getDeploymentStatus}
           isDeployButtonDisabled={isDeployButtonDisabled}
           getDeployButtonText={getDeployButtonText}
-          // Pass error states and utility functions
-          deploymentError={deploymentError}
-          undeploymentError={undeploymentError}
-          setDeploymentError={setDeploymentError}
-          setUndeploymentError={setUndeploymentError}
+          // Deployment / undeployment errors are now surfaced at the
+          // worker level via ErrorDialog (see below); the inline red
+          // panels in Available / Deployed are gone, so the children
+          // don't need the error props any more.
           formatTimeInfo={formatTimeInfo}
           server={server}
           fetchApplicationStatus={fetchApplicationStatus}
@@ -1396,6 +1411,26 @@ ${token}`;
             manifest={pendingDeployment.manifest}
           />
         )}
+
+        {/* Worker-level error dialog. Renders for deployment failures and
+            for stop-application failures alike — both are bioengine worker
+            errors with the same scrollable-stack-trace shape. Only one
+            shows at a time (deployment > undeployment) since the two
+            workflows can't physically overlap. */}
+        <ErrorDialog
+          open={!!deploymentError}
+          title={deploymentError?.title ?? ''}
+          subtitle={deploymentError?.subtitle}
+          message={deploymentError?.message ?? ''}
+          onClose={() => setDeploymentError(null)}
+        />
+        <ErrorDialog
+          open={!!undeploymentError && !deploymentError}
+          title={undeploymentError?.title ?? ''}
+          subtitle={undeploymentError?.subtitle}
+          message={undeploymentError?.message ?? ''}
+          onClose={() => setUndeploymentError(null)}
+        />
       </div>
     </div>
   );

--- a/src/components/bioengine/DeployedBioEngineApps.tsx
+++ b/src/components/bioengine/DeployedBioEngineApps.tsx
@@ -14,6 +14,12 @@ interface DeployedBioEngineAppsProps {
     logs_tail?: number;
     n_previous_replica?: number;
   }) => Promise<any>;
+  updateAppScaling?: (params: {
+    application_id: string;
+    artifact_id: string;
+    scaling: Record<string, any>;
+  }) => Promise<void>;
+  bioengineVersion?: string;
 }
 
 const DeployedBioEngineApps: React.FC<DeployedBioEngineAppsProps> = ({
@@ -23,7 +29,9 @@ const DeployedBioEngineApps: React.FC<DeployedBioEngineAppsProps> = ({
   formatTimeInfo,
   undeploymentError,
   setUndeploymentError,
-  fetchApplicationStatus
+  fetchApplicationStatus,
+  updateAppScaling,
+  bioengineVersion,
 }) => {
   const [copySuccess, setCopySuccess] = React.useState(false);
   const [selectedAppId, setSelectedAppId] = React.useState<string | null>(null);
@@ -187,6 +195,8 @@ const DeployedBioEngineApps: React.FC<DeployedBioEngineAppsProps> = ({
           initialStatus={status?.bioengine_apps?.[selectedAppId]}
           fetchApplicationStatus={fetchApplicationStatus}
           nodeLabels={nodeLabels}
+          updateAppScaling={updateAppScaling}
+          bioengineVersion={bioengineVersion}
         />
       )}
 

--- a/src/components/bioengine/DeployedBioEngineApps.tsx
+++ b/src/components/bioengine/DeployedBioEngineApps.tsx
@@ -7,8 +7,7 @@ interface DeployedBioEngineAppsProps {
   undeployingArtifactId?: string | null;  // Now actually application_id
   onUndeployArtifact: (applicationId: string) => void;  // Changed: uses application_id
   formatTimeInfo?: (timestamp: number) => { formattedTime: string; uptime: string };
-  undeploymentError?: string | null;
-  setUndeploymentError?: (error: string | null) => void;
+  // Undeployment errors are surfaced via the worker-level ErrorDialog.
   fetchApplicationStatus?: (params: {
     application_ids?: string[];
     logs_tail?: number;
@@ -27,8 +26,6 @@ const DeployedBioEngineApps: React.FC<DeployedBioEngineAppsProps> = ({
   undeployingArtifactId,
   onUndeployArtifact,
   formatTimeInfo,
-  undeploymentError,
-  setUndeploymentError,
   fetchApplicationStatus,
   updateAppScaling,
   bioengineVersion,
@@ -112,31 +109,9 @@ const DeployedBioEngineApps: React.FC<DeployedBioEngineAppsProps> = ({
         </div>
       </div>
 
-      {/* Undeployment Error Display */}
-      {undeploymentError && setUndeploymentError && (
-        <div className="mb-4 p-4 bg-red-50 border border-red-200 rounded-lg">
-          <div className="flex justify-between items-start">
-            <div className="flex">
-              <svg className="w-5 h-5 text-red-400 mr-2 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              <div>
-                <h4 className="text-sm font-medium text-red-800">Undeployment Error</h4>
-                <p className="text-sm text-red-700 mt-1">{undeploymentError}</p>
-              </div>
-            </div>
-            <button
-              onClick={() => setUndeploymentError(null)}
-              className="text-red-400 hover:text-red-600"
-              aria-label="Dismiss error"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            </button>
-          </div>
-        </div>
-      )}
+      {/* Undeployment errors are now rendered by the worker-level
+          ErrorDialog (BioEngineWorker.tsx) so multi-line stack traces
+          stay readable. */}
 
       {deploymentServiceId && (
         <div className="mb-6">
@@ -178,8 +153,6 @@ const DeployedBioEngineApps: React.FC<DeployedBioEngineAppsProps> = ({
               key={deployment.application_id || index}
               deployment={deployment}
               serviceId={deploymentServiceId}
-              isUndeploying={undeployingArtifactId === (deployment.application_id || deployment.artifact_id)}
-              onUndeploy={onUndeployArtifact}
               formatTimeInfo={formatTimeInfo}
               onStatusClick={(applicationId) => setSelectedAppId(applicationId)}
             />
@@ -197,6 +170,8 @@ const DeployedBioEngineApps: React.FC<DeployedBioEngineAppsProps> = ({
           nodeLabels={nodeLabels}
           updateAppScaling={updateAppScaling}
           bioengineVersion={bioengineVersion}
+          onUndeploy={onUndeployArtifact}
+          isUndeploying={undeployingArtifactId === selectedAppId}
         />
       )}
 

--- a/src/components/bioengine/DeploymentCard.tsx
+++ b/src/components/bioengine/DeploymentCard.tsx
@@ -38,25 +38,27 @@ interface DeploymentCardProps {
     };
   };
   serviceId?: string;
-  isUndeploying?: boolean;
-  onUndeploy: (applicationId: string) => void;  // Changed: uses application_id
+  // Undeploy is now driven from the Monitor & Manage dialog, so the card
+  // doesn't need an undeploy handler or an "isUndeploying" flag any more.
+  // The status banner still surfaces the DELETING / DEPLOYING phases.
   formatTimeInfo?: (timestamp: number) => { formattedTime: string; uptime: string };
+  // Opens the Monitor & Manage dialog for this app. Always present — admins
+  // and viewers both get the same monitoring surface; the dialog itself
+  // gates write actions (scaling / undeploy) on admin membership upstream.
   onStatusClick?: (applicationId: string) => void;
 }
 
 const DeploymentCard: React.FC<DeploymentCardProps> = ({
   deployment,
   serviceId,
-  isUndeploying = false,
-  onUndeploy,
   formatTimeInfo,
   onStatusClick
 }) => {
   const [mcpCopied, setMcpCopied] = React.useState(false);
   const [appIdCopied, setAppIdCopied] = React.useState(false);
   const [serviceIdCopied, setServiceIdCopied] = React.useState(false);
-  const [isHovered, setIsHovered] = React.useState(false);
   const isAppRunning = deployment.status === "RUNNING";
+  const hasAppUi = !!deployment.static_site_url;
 
   // Helper function to format bytes to GB
   const formatMemoryToGB = (bytes: number): string => {
@@ -125,85 +127,130 @@ const DeploymentCard: React.FC<DeploymentCardProps> = ({
     }
   };
 
+  // Color tokens for the static (non-clickable) status banner. Mirrors the
+  // resource-pill palette so the card reads as a row of status chips:
+  // healthy reads green, deploying/updating amber, deleting muted, terminal
+  // failure red. Same set of states the dialog's stateClasses() handles.
+  const statusBannerClasses = (state: string): string => {
+    switch (state) {
+      case 'HEALTHY':
+      case 'RUNNING':
+        return 'bg-green-50 text-green-700 border-green-200';
+      case 'DEPLOYING':
+      case 'UPDATING':
+        return 'bg-amber-50 text-amber-700 border-amber-200';
+      case 'DELETING':
+      case 'STOPPING':
+      case 'STOPPED':
+        return 'bg-gray-100 text-gray-600 border-gray-300';
+      case 'DEPLOY_FAILED':
+      case 'FAILED':
+      case 'UNHEALTHY':
+        return 'bg-red-50 text-red-700 border-red-200';
+      default:
+        return 'bg-gray-50 text-gray-700 border-gray-200';
+    }
+  };
+
+  const openAppUi = () => {
+    if (!deployment.static_site_url) return;
+    window.open(deployment.static_site_url, '_blank', 'noopener,noreferrer');
+  };
+
   return (
-    <div
-      className="p-6 bg-gradient-to-r from-white to-gray-50 border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition-all duration-200"
-      onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
-    >
-      <div className="flex justify-between items-start mb-4">
-        <div>
-          <div className="flex items-center mb-2">
+    <div className="p-6 bg-gradient-to-r from-white to-gray-50 border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition-shadow duration-200">
+      <style>{`
+        .card-press { transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1); }
+        .card-press:active:not(:disabled) { transform: scale(0.97); }
+      `}</style>
+
+      {/* Title row: app name + version live on the same line as the
+          action buttons. Description and Artifact ID render BELOW this
+          row at full card width so the buttons' presence doesn't
+          shorten them. Both buttons share the same outline-button
+          styling so the visual weight stays even. */}
+      <div className="mb-4">
+        <div className="flex items-center justify-between gap-3 flex-wrap mb-2">
+          <div className="flex items-center gap-2 flex-wrap min-w-0">
             <h4 className="text-lg font-semibold">
               {deployment.display_name || deployment.artifact_id.split('/').pop()}
             </h4>
 
             {deployment.version && (
-              <span className="ml-2 px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 border border-gray-200">
+              <span className="px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 border border-gray-200">
                 {deployment.version === 'latest' ? 'latest' : `v${deployment.version}`}
               </span>
             )}
 
             {deployment.status === "UPDATING" && (
-              <div className="ml-3 w-4 h-4 border-2 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
+              <div className="ml-1 w-4 h-4 border-2 border-gray-300 border-t-blue-600 rounded-full animate-spin"></div>
             )}
           </div>
 
-          {deployment.description && (
-            <p className="text-sm text-gray-600 mt-2">{deployment.description}</p>
-          )}
-          <p className="text-sm text-gray-500 mt-2">
-            <span className="font-medium">Deployed from Artifact ID:</span> {deployment.artifact_id}
-          </p>
+          {/* Always-visible header actions. Open App appears to the
+              LEFT of Monitor & Manage only when the app exposes a UI
+              (static_site_url). Both buttons render identically — the
+              Monitor & Manage one is the dependable entry, Open App
+              just happens to deep-link out to the app's own UI. */}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {hasAppUi && (
+              <button
+                type="button"
+                onClick={openAppUi}
+                disabled={!isAppRunning}
+                title={isAppRunning ? 'Open the application UI in a new tab' : 'App must be RUNNING to open'}
+                className="card-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {/* Lucide-style external-link: three discrete strokes
+                    (arrow tip, diagonal, open-corner box) — no
+                    overlapping segments that read as random lines. */}
+                <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M15 3h6v6" />
+                  <path d="M10 14L21 3" />
+                  <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+                </svg>
+                Open App
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => onStatusClick?.(deployment.application_id || deployment.artifact_id)}
+              title="Open the monitor and manage dialog: logs, replica scaling, undeploy"
+              className="card-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-300 bg-white text-gray-700 hover:bg-gray-50"
+            >
+              <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              Monitor & Manage
+            </button>
+          </div>
         </div>
 
-        <div className={`transition-opacity duration-200 ${isHovered || isUndeploying || deployment.status === "DELETING" ? 'opacity-100' : 'opacity-0'}`}>
-          {isUndeploying ? (
-            <button
-              disabled={true}
-              className="px-4 py-2 text-sm bg-gradient-to-r from-red-400 to-red-500 text-white rounded-xl opacity-50 cursor-not-allowed flex items-center shadow-sm"
-            >
-              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
-              {deployment.status === "DEPLOYING" ? "Canceling..." : "Undeploying..."}
-            </button>
-          ) : deployment.status === "DELETING" ? (
-            <button
-              disabled={true}
-              className="px-4 py-2 text-sm bg-gradient-to-r from-gray-400 to-gray-500 text-white rounded-xl opacity-50 cursor-not-allowed flex items-center shadow-sm"
-            >
-              <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-2"></div>
-              Deleting...
-            </button>
-          ) : (
-            <button
-              onClick={() => onUndeploy(deployment.application_id || deployment.artifact_id)}
-              className="px-4 py-2 text-sm bg-gradient-to-r from-red-500 to-red-600 text-white rounded-xl hover:from-red-600 hover:to-red-700 shadow-sm hover:shadow-md transition-all duration-200"
-            >
-              {deployment.status === "DEPLOYING" ? "Cancel Deployment" : "Undeploy"}
-            </button>
-          )}
-        </div>
+        {deployment.description && (
+          <p className="text-sm text-gray-600 mt-2">{deployment.description}</p>
+        )}
+        <p className="text-sm text-gray-500 mt-2 break-all">
+          <span className="font-medium">Deployed from Artifact ID:</span> {deployment.artifact_id}
+        </p>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
-          {/* Application Status: clickable badge opens the deployment status dialog */}
-          <div className="mb-3 flex items-center gap-2">
-            <span className="text-sm font-medium text-gray-700">Application Status:</span>
-            <button
-              type="button"
-              onClick={() => onStatusClick?.(deployment.application_id || deployment.artifact_id)}
-              className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold border shadow-sm transition-all duration-200 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${deployment.status === "HEALTHY" || deployment.status === "RUNNING"
-                ? "bg-green-100 text-green-800 border-green-300 hover:bg-green-200 hover:border-green-400"
-                : "bg-gray-100 text-gray-800 border-gray-300 hover:bg-gray-200 hover:border-gray-400"
-                }`}
-              title="Click to view deployment status, logs, and replica details"
+          {/* Application Status: static banner mirroring the resource
+              pills below. No longer clickable — the entry point for
+              diagnostics now lives in the "Monitor & manage" button up
+              top, which is always visible. */}
+          <div className="mb-3">
+            <p className="text-sm font-medium text-gray-700 mb-2">Application Status:</p>
+            <span
+              className={`inline-flex items-center px-2 py-1 rounded text-xs font-medium border ${statusBannerClasses(deployment.status)}`}
             >
-              {deployment.status}
-              <svg className="w-3 h-3 opacity-80" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-            </button>
+              {deployment.status}
+            </span>
           </div>
 
           {deployment.start_time && formatTimeInfo && (
@@ -255,27 +302,6 @@ const DeploymentCard: React.FC<DeploymentCardProps> = ({
                   </span>
                 )}
               </div>
-            </div>
-          )}
-
-          {deployment.static_site_url && (
-            <div className="mt-3">
-              <p className="text-sm font-medium text-gray-700 mb-2">App UI:</p>
-              <button
-                type="button"
-                onClick={() => window.open(deployment.static_site_url!, "_blank", "noopener,noreferrer")}
-                disabled={!isAppRunning}
-                className={`inline-flex items-center px-3 py-1.5 rounded text-xs font-medium border transition-colors ${isAppRunning
-                  ? "bg-emerald-50 text-emerald-700 border-emerald-200 hover:bg-emerald-100 hover:text-emerald-800 cursor-pointer"
-                  : "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
-                  }`}
-                title={isAppRunning ? "Open app in a new tab" : "App must be RUNNING to open"}
-              >
-                <svg className="w-3 h-3 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.5 6H10a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3.5m-9-4.5L21 3m0 0v6m0-6h-6" />
-                </svg>
-                Open App
-              </button>
             </div>
           )}
         </div>
@@ -352,7 +378,12 @@ const DeploymentCard: React.FC<DeploymentCardProps> = ({
           {deployment.available_methods && deployment.available_methods.length > 0 && deployment.status !== "DEPLOYING" && (
             <div>
               <p className="text-sm font-medium text-gray-700 mb-2">Available Methods:</p>
-              <div className="flex flex-wrap gap-1">
+              {/* Cap the methods list at a sensible height. Apps with
+                  dozens of methods (e.g. cellpose-finetuning) were
+                  blowing the card vertical to a screenful; this gives
+                  the list its own scroll area so the rest of the card
+                  stays compact. ~10 rows of pills before scrolling. */}
+              <div className="flex flex-wrap gap-1 max-h-44 overflow-y-auto pr-1">
                 {deployment.available_methods.map((method: string) => {
                   // Use new service_ids structure, fallback to legacy serviceId
                   const wsServiceId = deployment.service_ids?.websocket_service_id || serviceId;

--- a/src/components/bioengine/ErrorDialog.tsx
+++ b/src/components/bioengine/ErrorDialog.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from 'react';
+
+interface ErrorDialogProps {
+  open: boolean;
+  // Short header label, e.g. "Deployment failed", "Cache delete failed".
+  title: string;
+  // Optional one-line context shown beneath the title (e.g. artifact id).
+  subtitle?: string;
+  // The full error text. Worker / app errors can be multi-line stack traces;
+  // the dialog body is scrollable so even very long traces stay usable.
+  message: string;
+  onClose: () => void;
+}
+
+// A reusable modal for surfacing errors that come back from a BioEngine
+// worker or app. Replaces inline red banners and toasts that would either
+// truncate long stack traces or push other content around. Stacks above
+// existing dialogs (z-60) so it can be opened from inside the deployment
+// status dialog (z-50). Centered with `transform-origin: center` per the
+// design rules — modals aren't anchored to a trigger.
+const ErrorDialog: React.FC<ErrorDialogProps> = ({
+  open,
+  title,
+  subtitle,
+  message,
+  onClose,
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  // ESC dismisses. Only attaches the listener while the dialog is open so
+  // we don't intercept ESC for the rest of the page.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  // Reset the "Copied" pill state whenever the dialog re-opens with a new
+  // message, otherwise it'd stay sticky from the previous error.
+  useEffect(() => {
+    if (!open) setCopied(false);
+  }, [open]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(message);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for browsers without clipboard API permission
+      const ta = document.createElement('textarea');
+      ta.value = message;
+      document.body.appendChild(ta);
+      ta.select();
+      try {
+        document.execCommand('copy');
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        /* swallow — best-effort */
+      }
+      document.body.removeChild(ta);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4"
+      style={{
+        zIndex: 60,
+        animation: 'errorDialogBackdropFade 180ms cubic-bezier(0.23, 1, 0.32, 1)',
+      }}
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="error-dialog-title"
+    >
+      <style>{`
+        @keyframes errorDialogBackdropFade {
+          from { opacity: 0; }
+          to   { opacity: 1; }
+        }
+        @keyframes errorDialogContentIn {
+          from { opacity: 0; transform: scale(0.96); }
+          to   { opacity: 1; transform: scale(1); }
+        }
+        .err-press { transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1); }
+        .err-press:active:not(:disabled) { transform: scale(0.97); }
+      `}</style>
+      <div
+        className="bg-white rounded-xl shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col"
+        style={{ animation: 'errorDialogContentIn 200ms cubic-bezier(0.23, 1, 0.32, 1)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-5 py-4 border-b border-gray-100 flex justify-between items-start gap-4">
+          <div className="flex items-start gap-3 min-w-0">
+            <div className="w-9 h-9 bg-red-50 border border-red-200 rounded-lg flex items-center justify-center flex-shrink-0">
+              <svg className="w-5 h-5 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M4.93 19h14.14a2 2 0 001.74-2.99l-7.07-12.24a2 2 0 00-3.48 0L3.19 16.01A2 2 0 004.93 19z" />
+              </svg>
+            </div>
+            <div className="min-w-0">
+              <h3 id="error-dialog-title" className="text-base font-semibold text-gray-900 break-words">
+                {title}
+              </h3>
+              {subtitle && (
+                <p className="text-xs text-gray-500 mt-0.5 break-all">{subtitle}</p>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            className="err-press text-gray-400 hover:text-gray-600 flex-shrink-0 -mr-1 -mt-1 p-1"
+            aria-label="Close error dialog"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Scrollable body — the actual error text. Rendered in a <pre> so
+            whitespace and multi-line stack traces survive intact; word-wrap
+            kicks in for very long lines so the user never has to scroll
+            horizontally. */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <pre className="text-xs text-gray-800 whitespace-pre-wrap break-words font-mono leading-relaxed">
+            {message || '(no error message returned)'}
+          </pre>
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-gray-100 flex justify-end gap-2 flex-shrink-0">
+          <button
+            onClick={handleCopy}
+            className={`err-press inline-flex items-center px-3 py-1.5 text-sm font-medium rounded-lg border ${
+              copied
+                ? 'bg-green-50 text-green-700 border-green-200'
+                : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'
+            }`}
+          >
+            <svg className="w-4 h-4 mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              {copied ? (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              ) : (
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-2a2 2 0 00-2 2v8a2 2 0 01-2 2z" />
+              )}
+            </svg>
+            {copied ? 'Copied' : 'Copy error'}
+          </button>
+          <button
+            onClick={onClose}
+            className="err-press px-3 py-1.5 text-sm font-medium rounded-lg bg-gray-900 text-white hover:bg-gray-800"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ErrorDialog;


### PR DESCRIPTION
## Motivation

Two operator workflows were missing from the BioEngine worker dashboard, forcing admins to drop into a Python shell or ssh into the cluster for routine tasks:

1. **App disk cache management.** Per-app working directories on the Ray actor pods accumulate over time (the KTH worker had 58 entries totalling 130+ GiB at branch time, most belonging to apps stopped weeks ago). There was no in-UI signal that the caches existed and no way to reclaim disk from the dashboard.
2. **Per-deployment replica scaling.** bioengine 0.11.6 made `scaling` a parameter of `deploy_app`, scoped per `@bioengine.app` class. The only way to use it was from a Python session — operators with dashboard-only access could not adjust replica counts during a workshop or for bursty traffic.

The bioengine team also shipped `list_app_directories` / `clear_app_directory` in 0.11.6 specifically to drive this UI, so this PR closes the loop.

Two further follow-ups landed on top once the initial pieces were in the operator's hands:

3. **Errors returned from the worker / apps** were dumped as inline red panels or toasts that truncated multi-line stack traces and pushed surrounding UI around. Operators were copy-pasting from the browser console to read them.
4. **The deployed-app card and its dialog** mixed always-visible info with a hover-only destructive button, buried the App UI link under metadata, conflated the status badge with a link to the dialog, and offered only a single global Log Lines / Previous Replicas input that forced every log fetch to refetch all deployments at the same depth.

## Solution

### App Disk Cache section (`AppDiskCache.tsx`, new)

A new section under the existing `Available BioEngine Apps` block renders a sortable table of cache entries (Application ID, Size, Last used, Status, Node, Actions). Per-row Clear button with confirm dialog; Clear is disabled with a "Stop the app first" tooltip when `is_running` is true. Header summary shows entry count, total size, running count.

- Manual load. No auto-fetch on mount: the first-visit empty state explains the cost and prompts the operator to click "Load app cache" (blue primary). Once loaded the button shrinks to the standard outline "Refresh" variant. Status-driven auto-refresh (deploy / undeploy) only kicks in after the operator has opted in.
- Optimistic delete. On `clear_app_directory` success the cleared row drops from local state immediately; if the response enumerates `deleted_on` nodes only matching (key, node) rows go, otherwise every row matching the cleared key drops.
- Node column auto-hides when every entry tags the same `node_id` (shared FS); shown on per-node FS topologies with the cluster-view-consistent "Head Node (...)" / "Worker Node N (...)" labels.
- Section divider mirrors the trailing border at the bottom of `DeployedBioEngineApps` so the four major dashboard sections share the same spacing rhythm.

### Per-deployment scaling controls (`AppDeploymentsStatusDialog.tsx`)

The existing "Application Deployment Status" dialog gains a Replica scaling section at the top:

- One block per user `@bioengine.app` deployment (ProxyDeployment is excluded by name — it always runs at one fixed replica per the worker's validator).
- Per-deployment toggle: "Enable autoscaling" switches between a fixed `num_replicas` input and an `autoscaling_config` form (min / max + collapsible Advanced for target ongoing requests, upscale / downscale delays).
- Defaults when toggling autoscaling ON for the first time: min=1, max=2, target=2. `num_replicas=0` is allowed and shows a yellow caveat that the app will be paused.
- One Save / Reset pair at the bottom. Save is disabled until the form is dirty and the per-field validators pass.
- Replacement semantics handled in the UI: on Save the dialog reads the live scaling map from `get_app_status()`, overlays the user's form deltas, and submits the full map so deployments the user did not touch keep their existing values.

New `updateAppScaling` helper in `BioEngineWorker.tsx` calls `deploy_app({application_id, artifact_id, scaling})` — every other parameter is preserved by the worker's `is_update` branch.

### Dashboard UX rework

- **ErrorDialog component** (new): single shared scrollable modal for any worker / app error. Multi-line stack traces stay readable, with a Copy button so operators can paste them into a Slack thread or bug ticket without re-typing. Deploy, undeploy, cache delete, and scaling save all route to it. Inline red panels in Available / Deployed are gone; the cache toast keeps only its success variant. Stacks at z-60 so it can pop above the Monitor & Manage dialog.
- **DeploymentCard restructured**: two always-visible header actions (Open App + Monitor & Manage) on the same row as the app name and version, both using the same outline-button styling. Description and Deployed-from-Artifact-ID lines render below at full card width. Application Status becomes a static colored banner matching the resource-pill palette. Available Methods list capped at `max-h-44 overflow-y-auto` so apps with dozens of methods do not blow the card vertical. Lower App UI block removed (header Open App replaces it); destructive Undeploy / Cancel Deployment removed from the card.
- **Monitor & Manage app dialog**: renamed from "Application Deployment Status". Header gains Refresh + Undeploy (or "Cancel deployment" when the app is still DEPLOYING) with a two-step inline confirm that auto-disarms after 6 seconds. Single global Log Lines / Previous Replicas inputs removed; each per-deployment card now carries its own controls and a Refresh logs button. Until the worker supports per-deployment log params natively, the interim merge strategy fetches the full status with the active block's params and merges only that deployment's slice back into local state — other deployments retain their last-loaded log buffers.

## Behaviour

- App Disk Cache section is gated on `isWorkerAdmin && bioengine_version >= 0.11.6` using a parts-wise semver compare. Older workers omit the section silently; non-admins never see it (the worker API would 403 anyway).
- Replica scaling section is gated on `bioengine_version >= 0.11.6` and the presence of `updateAppScaling` from the parent.
- Cache refresh is event-driven off a `refreshKey` derived from the deployed-app status signature, so deploys / undeploys keep the cache list fresh without a second auto-poll loop. The first load is always manual.
- Open App button in the card header is disabled with an "App must be RUNNING to open" tooltip when the app is not RUNNING.
- Undeploy button in the dialog reads "Cancel deployment" while the app is DEPLOYING and "Undeploy" otherwise.
- Section divider only renders when the cache section actually renders, so non-admin or older-worker dashboards do not show a dangling line.
- ErrorDialog dismisses on ESC, backdrop click, or close X. Reset to fresh state on each open so the "Copied" pill state from a previous error does not stick.

## Migration

None. All changes are additive or replace existing surfaces in place. The component prop signature for `BioEngineApps`, `AvailableBioEngineApps`, `DeployedBioEngineApps`, and `DeploymentCard` no longer accepts `deploymentError` / `undeploymentError` / `onUndeploy`, but the only call sites live in `src/components/bioengine/` and were updated in the same change.

## Test plan

- [x] Production build (`CI=true react-scripts build`) compiles clean — 7 pre-existing arc source-map warnings, no issues.
- [x] Live KTH worker (bioengine 0.11.10, shared FS): `list_app_directories` returns 58 entries totaling ~130 GiB on a single node. Optimistic delete drops the row immediately. Load / Refresh button label switches correctly between first-visit and subsequent state.
- [x] Live KTH worker: `get_app_status` returns `scaling: {}` for all three running apps. ProxyDeployment present in `deployments` and correctly excluded by name from the scaling form. Wire payload shape verified against the worker validator at `bioengine/apps/manager.py:2074-2102` without actually mutating prod apps.
- [x] Bundle smoke for the dashboard URL contains every expected user-visible string: `App Disk Cache`, `Replica scaling`, `HyphaStatusBanner`, `HYPHA_SERVER_URL`, `Load app cache`, `Cache is not loaded yet`, `Monitor & Manage app`, `Open App`, `Confirm undeploy`, `Refresh logs`, `Cancel deployment`, `Deployment failed`, `Stop application failed`, `Cache delete failed`, `Scaling update failed`.
- [ ] Walk a non-admin user through the dashboard to confirm cache section + scaling form + undeploy button are all hidden.
- [ ] Save scaling on a sandbox worker, observe Ray Serve rolling the replica count without restarting other deployments.
- [ ] Verify Monitor & Manage undeploy against a sandbox app (not exercised on prod KTH).

## Files

| File | Change |
| --- | --- |
| `src/components/bioengine/AppDiskCache.tsx` | New — cache table + manual load + optimistic delete |
| `src/components/bioengine/ErrorDialog.tsx` | New — shared scrollable error modal |
| `src/components/bioengine/AppDeploymentsStatusDialog.tsx` | Renamed to Monitor & Manage app; scaling moved to top; per-deployment log controls; header undeploy with confirm |
| `src/components/bioengine/DeploymentCard.tsx` | Header rebuilt (Open App + Monitor & Manage); status banner; scroll on Available Methods; removed App UI block and undeploy |
| `src/components/bioengine/BioEngineWorker.tsx` | Wired AppDiskCache + ErrorDialog; new updateAppScaling helper; version gate |
| `src/components/bioengine/BioEngineApps.tsx` | Stripped error prop forwarding; pass updateAppScaling / bioengineVersion through |
| `src/components/bioengine/AvailableBioEngineApps.tsx` | Stripped inline deployment-error panel |
| `src/components/bioengine/DeployedBioEngineApps.tsx` | Stripped inline undeployment-error panel; pass onUndeploy / isUndeploying to dialog instead of card |