### PR TITLE
Add configurable model-runner service id to the workflows

### DIFF
--- a/.github/workflows/model-inference.yml
+++ b/.github/workflows/model-inference.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: false
         type: boolean
+      service_id:
+        description: 'Model-runner service id (leave empty for bioimage-io/model-runner)'
+        required: false
+        type: string
 
 jobs:
   test-bioimageio-model-inference:
@@ -56,6 +60,7 @@ jobs:
         # Set safe defaults for inputs (handle scheduled runs)
         MODEL_IDS="${{ github.event.inputs.model_ids || '' }}"
         SKIP_CACHE="${{ github.event.inputs.skip_cache || 'false' }}"
+        SERVICE_ID="${{ github.event.inputs.service_id || '' }}"
 
         # Build command arguments
         ARGS=""
@@ -67,6 +72,10 @@ jobs:
 
         if [ "$SKIP_CACHE" = "true" ]; then
           ARGS="$ARGS --skip-cache"
+        fi
+
+        if [ -n "$SERVICE_ID" ]; then
+          ARGS="$ARGS --service-id $SERVICE_ID"
         fi
 
         echo "Running: python -u bioengine_model_infer.py $ARGS"

--- a/.github/workflows/model-testing.yml
+++ b/.github/workflows/model-testing.yml
@@ -15,6 +15,10 @@ on:
         required: false
         default: false
         type: boolean
+      service_id:
+        description: 'Model-runner service id (leave empty for bioimage-io/model-runner)'
+        required: false
+        type: string
 
 jobs:
   test-bioimageio-models:
@@ -55,6 +59,7 @@ jobs:
         # Set safe defaults for inputs (handle scheduled runs)
         MODEL_IDS="${{ github.event.inputs.model_ids || '' }}"
         SKIP_CACHE="${{ github.event.inputs.skip_cache || 'false' }}"
+        SERVICE_ID="${{ github.event.inputs.service_id || '' }}"
 
         # Build command arguments
         ARGS=""
@@ -66,6 +71,10 @@ jobs:
 
         if [ "$SKIP_CACHE" = "true" ]; then
           ARGS="$ARGS --skip-cache"
+        fi
+
+        if [ -n "$SERVICE_ID" ]; then
+          ARGS="$ARGS --service-id $SERVICE_ID"
         fi
 
         echo "Running: python -u bioengine_model_test.py $ARGS"

--- a/scripts/bioengine_model_infer.py
+++ b/scripts/bioengine_model_infer.py
@@ -33,6 +33,10 @@ INFERENCE_REPORT_FILE = "inference_report.json"
 INFERENCE_TIMEOUT_SECONDS = 120
 INFERENCE_POLL_INTERVAL_SECONDS = 2
 
+# Fully-qualified id of the model-runner service to run inference on.
+# Overridable via --service-id so a run can target a specific worker/cluster.
+DEFAULT_SERVICE_ID = f"{WORKSPACE}/model-runner"
+
 
 def save_inference_summary(summary_file: str, summary: Dict[str, int | float]) -> None:
     summary_path = Path(summary_file)
@@ -257,6 +261,7 @@ async def check_bmz_model_inference(
     model_ids: Optional[List[str]] = None,
     summary_file: str = DEFAULT_INFERENCE_SUMMARY_PATH,
     skip_cache: bool = False,
+    service_id: str = DEFAULT_SERVICE_ID,
 ) -> None:
     """Run inference on BioImage.IO models and publish the inference report.
 
@@ -267,6 +272,7 @@ async def check_bmz_model_inference(
         skip_cache: When True, re-run inference even for models that previously
             passed and haven't changed since (bypasses the in-script result
             cache), and ask the model-runner to bypass its own cache too.
+        service_id: Fully-qualified id of the model-runner service to use.
 
     Raises:
         RuntimeError: If fetching model IDs fails.
@@ -278,8 +284,9 @@ async def check_bmz_model_inference(
         {"server_url": SERVER_URL, "token": token, "method_timeout": 300}
     )
 
+    print(f"Using model-runner service '{service_id}'")
     runner = await server.get_service(
-        f"{WORKSPACE}/model-runner", {"mode": "select:min:get_load"}
+        service_id, {"mode": "select:min:get_load"}
     )
     artifact_manager = await server.get_service("public/artifact-manager")
 
@@ -429,6 +436,11 @@ if __name__ == "__main__":
         "(re-run inference even for previously-passed unchanged models, "
         "and ask the model-runner to bypass its own cache)",
     )
+    parser.add_argument(
+        "--service-id",
+        default=DEFAULT_SERVICE_ID,
+        help=f"Model-runner service id to run inference on (default: {DEFAULT_SERVICE_ID})",
+    )
 
     args = parser.parse_args()
 
@@ -441,5 +453,6 @@ if __name__ == "__main__":
             model_ids=args.model_ids,
             summary_file=args.summary_file,
             skip_cache=args.skip_cache,
+            service_id=args.service_id,
         )
     )

--- a/scripts/bioengine_model_test.py
+++ b/scripts/bioengine_model_test.py
@@ -13,6 +13,10 @@ from hypha_rpc import connect_to_server, login
 from hypha_rpc.utils import ObjectProxy
 
 
+# Fully-qualified id of the model-runner service to test against. Overridable
+# via --service-id so a run can target a specific worker/cluster.
+DEFAULT_SERVICE_ID = "bioimage-io/model-runner"
+
 # Testing is submitted through the async model-runner API: ``test()`` returns a
 # run id immediately and the report is retrieved by polling
 # ``get_test_status(test_run_id)`` until its ``result`` field is populated.
@@ -86,6 +90,7 @@ async def test_bmz_models(
     model_ids: Optional[List[str]] = None,
     reports_dir: Optional[Path] = None,
     skip_cache: bool = False,
+    service_id: str = DEFAULT_SERVICE_ID,
 ) -> None:
     """Test BioImage.IO models and generate test reports.
 
@@ -98,6 +103,7 @@ async def test_bmz_models(
         model_ids: List of model IDs to test. If None, fetches all models.
         reports_dir: Directory where per-model JSON test reports are written.
         skip_cache: Whether to skip cache during model testing.
+        service_id: Fully-qualified id of the model-runner service to use.
 
     Raises:
         RuntimeError: If fetching model IDs fails.
@@ -110,8 +116,9 @@ async def test_bmz_models(
         {"server_url": server_url, "token": token, "method_timeout": 300}
     )
 
+    print(f"Using model-runner service '{service_id}'")
     model_runner = await server.get_service(
-        "bioimage-io/model-runner", {"mode": "select:min:get_load"}
+        service_id, {"mode": "select:min:get_load"}
     )
 
     current_runner_version = await fetch_runner_version(model_runner)
@@ -378,6 +385,11 @@ def main():
         action="store_true",
         help="Skip cache during model testing",
     )
+    parser.add_argument(
+        "--service-id",
+        default=DEFAULT_SERVICE_ID,
+        help=f"Model-runner service id to test against (default: {DEFAULT_SERVICE_ID})",
+    )
 
     args = parser.parse_args()
 
@@ -398,6 +410,7 @@ def main():
                 model_ids=args.model_ids,
                 reports_dir=reports_dir,
                 skip_cache=args.skip_cache,
+                service_id=args.service_id,
             )
         )
 


### PR DESCRIPTION
## Motivation

The inference and testing workflow scripts hardcoded the `bioimage-io/model-runner` service, so a run could not be pointed at a specific worker or cluster (for example a staging deNBI or KTH worker) without editing the script.

## Solution

- Add a `--service-id` argument to both `bioengine_model_infer.py` and `bioengine_model_test.py`, defaulting to `bioimage-io/model-runner`, and use it for the `get_service` call.
- Expose it as an optional `service_id` `workflow_dispatch` input in both the Model Inference and Model Testing workflows, threaded into the script arguments.

## Behaviour

Leaving the field empty keeps the previous default (`bioimage-io/model-runner`). Providing a value targets that service. The resolved service id is printed at the start of each run.

## Test plan

- Both scripts compile and expose `--service-id` in `--help` with the default shown.
- Ran the inference script with an explicit `--service-id`; the resolved id is printed and passed to `get_service` (a bogus id fails at service lookup as expected, confirming the value is used).
- Both workflow YAML files parse.

## Files

- `scripts/bioengine_model_infer.py`
- `scripts/bioengine_model_test.py`
- `.github/workflows/model-inference.yml`
- `.github/workflows/model-testing.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)