### PR TITLE
Fix k8s wizard worker YAML; migrate model-runner callers to cache param

### DIFF
--- a/scripts/bioengine_model_test.py
+++ b/scripts/bioengine_model_test.py
@@ -37,7 +37,9 @@ async def run_test(
     ``asyncio.TimeoutError`` when the run does not complete within
     ``TEST_TIMEOUT_SECONDS``.
     """
-    run_id = await runner.test(model_id=model_id, stage=False, skip_cache=skip_cache)
+    run_id = await runner.test(
+        model_id=model_id, stage=False, cache="skip" if skip_cache else "check"
+    )
 
     # Legacy synchronous runners returned the report dict directly instead of a
     # run id; accept that so the script keeps working during a rollout.

--- a/src/components/ModelTester.tsx
+++ b/src/components/ModelTester.tsx
@@ -364,13 +364,17 @@ const ModelTester = forwardRef<ModelTesterHandle, ModelTesterProps>(({
       // never ask it for one, regardless of the toggle's last value.
       const effectiveCustomEnv = customEnvDisabled ? false : customEnvironment;
 
+      // "Skip cache" in the UI maps to the runner's "skip" cache mode (force
+      // reload); unchecked maps to "check" (the default: reload only if stale).
+      const cacheMode = skipCache ? 'skip' : 'check';
+
       setLoadingStep('Starting test run...');
-      console.log(`Testing model ${modelId}, stage: ${isStaged}, skip_cache: ${skipCache}, custom_environment: ${effectiveCustomEnv}`);
+      console.log(`Testing model ${modelId}, stage: ${isStaged}, cache: ${cacheMode}, custom_environment: ${effectiveCustomEnv}`);
 
       const testResponse = await runner.test({
         model_id: modelId,
         stage: isStaged,
-        skip_cache: skipCache,
+        cache: cacheMode,
         custom_environment: effectiveCustomEnv,
         _rkwargs: true,
       });

--- a/src/components/bioengine/BioEngineGuide.tsx
+++ b/src/components/bioengine/BioEngineGuide.tsx
@@ -833,6 +833,12 @@ spec:
         - "--client-id"
         - "$(BIOENGINE_CLIENT_ID)"${extraArgs}
         env:
+        # UID 65534 (nobody) has no writable home dir (/nonexistent) in the
+        # base image, which crashes the worker on startup. Pin HOME to the
+        # same path mounted below (PVC-backed, or an ephemeral emptyDir when
+        # no PVC is available) so it's always writable.
+        - name: HOME
+          value: /home/bioengine
         - name: HYPHA_TOKEN
           valueFrom:
             secretKeyRef:
@@ -852,7 +858,7 @@ spec:
             - /bin/sh
             - -c
             - 'curl -sf "${serverUrlVal}/${workspaceVal}/services/$POD_NAME:bioengine-worker/get_status"
-              | grep -E "\"is_ready\":\\s*true"'
+              | grep -E ''"is_ready":\\s*true'''
           initialDelaySeconds: 60
           periodSeconds: 20
           timeoutSeconds: 10
@@ -863,18 +869,18 @@ spec:
             - /bin/sh
             - -c
             - 'curl -sf "${serverUrlVal}/${workspaceVal}/services/$POD_NAME:bioengine-worker/get_status"
-              | grep -E "\"is_ready\":\\s*true"'
+              | grep -E ''"is_ready":\\s*true'''
           initialDelaySeconds: 10
           periodSeconds: 30
           timeoutSeconds: 10
-          failureThreshold: 2${hasPvc ? `
+          failureThreshold: 2
         volumeMounts:
         - name: bioengine
           mountPath: /home/bioengine
       volumes:
       - name: bioengine
-        persistentVolumeClaim:
-          claimName: bioengine-pvc` : ''}`;
+        ${hasPvc ? `persistentVolumeClaim:
+          claimName: bioengine-pvc` : `emptyDir: {}`}`;
   };
 
   // Rendered between the standard configuration fields and the advanced options,

--- a/tests/queue-fill.py
+++ b/tests/queue-fill.py
@@ -61,7 +61,7 @@ async def main():
                 # (that's what tripped Ray admission at ~122). Polling to
                 # completion keeps exactly POOL jobs live in the GPU queue and
                 # at most one outstanding RPC per worker (<= POOL <= 10).
-                rid = await runner.infer(model_id=MODEL, inputs=arr, skip_cache=True)
+                rid = await runner.infer(model_id=MODEL, inputs=arr, cache="skip")
                 if isinstance(rid, str):
                     for _ in range(180):
                         if stop or time.monotonic() - start >= SECONDS:


### PR DESCRIPTION
## Summary
- Fix the BioEngine setup wizard's generated Kubernetes Deployment YAML: pin `HOME=/home/bioengine` (UID 65534's default home isn't writable, which crashed the worker on startup) and make that mount unconditional (PVC-backed, or an ephemeral `emptyDir` fallback when no PVC is configured).
- Fix the startup/liveness probe's `grep` pattern, whose double-quoted regex was consumed by the shell's own quoting instead of reaching `grep`, so it could never match the `get_status` response and the pod never went Ready.
- Migrate `model-runner` callers (the Edit-page Test Model flow in `ModelTester.tsx`, `scripts/bioengine_model_test.py`, `tests/queue-fill.py`) from the deprecated `skip_cache: bool` to the new `cache: "skip" | "check" | "reuse"` parameter now live on `model-runner`. (`cellpose4-runner` also exposes the same `cache` API, but none of these call sites use it, they only ever talk to `model-runner`.)

## Test plan
- Both wizard YAML fixes were live-verified against the real KTH k8s cluster: with both probes re-enabled and no PVC configured (exercising the `emptyDir` fallback), the pod reached and sustained `1/1 Ready` with zero restarts.
- Confirmed the live production `model-runner`'s `test()` schema exposes `cache: Literal["skip","check","reuse"] = "check"` with `skip_cache` as a deprecated alias, matching the migrated call sites.
- Round-tripped both cache modes against the live KTH `model-runner`: `cache="check"` reused the warm model in 2.5s, `cache="skip"` forced a full re-download/retest in 61.7s, confirming the parameter is honored server-side end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
