### PR TITLE
Route cellpose4-runner-supported models to the KTH cellpose4-runner

### DIFF
--- a/src/components/AdvancedOptions.tsx
+++ b/src/components/AdvancedOptions.tsx
@@ -16,6 +16,7 @@ interface AdvancedOptionsProps {
   onSelectSite: (site: RunnerSite) => void;
   siteAvailable: Record<RunnerSite, boolean>;
   siteLoading?: boolean;
+  siteDisabledTitle?: Partial<Record<RunnerSite, string>>;
   showToggle?: boolean;
   /** Reset the shared Hypha connection. */
   onReset: () => void;
@@ -45,6 +46,7 @@ const AdvancedOptions: React.FC<AdvancedOptionsProps> = ({
   onSelectSite,
   siteAvailable,
   siteLoading = false,
+  siteDisabledTitle,
   showToggle = true,
   onReset,
   isResetting = false,
@@ -130,6 +132,7 @@ const AdvancedOptions: React.FC<AdvancedOptionsProps> = ({
                   onSelect={onSelectSite}
                   available={siteAvailable}
                   loading={siteLoading}
+                  disabledTitle={siteDisabledTitle}
                 />
               )}
             </div>

--- a/src/components/ArtifactDetails.tsx
+++ b/src/components/ArtifactDetails.tsx
@@ -830,7 +830,12 @@ const ArtifactDetails = () => {
                               <CheckCircleIcon sx={{ fontSize: 20 }} />
                             </Box>
                           </Tooltip>
-                        ) : bioengineStatus ? (
+                        ) : (bioengineStatus && !cellpose4.loading) ? (
+                          // Held back while the cellpose4-runner probe is in
+                          // flight: a Cellpose-4 model always carries a FAILED
+                          // bioengineStatus, so showing the failure icon here
+                          // would flash a wrong status before flipping to the
+                          // passing one a moment later.
                           <Tooltip
                             title={bioengineStatus.tested_at ? `Tested at: ${new Date(bioengineStatus.tested_at * 1000).toUTCString()}` : ''}
                             arrow

--- a/src/components/ArtifactDetails.tsx
+++ b/src/components/ArtifactDetails.tsx
@@ -48,6 +48,7 @@ import TestReportDialog from './TestReportDialog';
 import TestDetailsDialog from './TestDetailsDialog';
 import ArtifactFiles from './ArtifactFiles';
 import { useBookmarks } from '../hooks/useBookmarks';
+import { useCellpose4Runner } from '../hooks/useCellpose4Runner';
 import { HYPHA_SERVER_URL } from '../config/hypha';
 
 // The BioEngine inference-check status is derived from the model's test-report
@@ -102,6 +103,13 @@ const ArtifactDetails = () => {
   } | null>(null);
   const [isBioengineErrorDialogOpen, setIsBioengineErrorDialogOpen] = useState(false);
   const [isTestButtonHovered, setIsTestButtonHovered] = useState(false);
+  // Cellpose-4 models (e.g. Cellpose-SAM) never pass the model-runner-based
+  // bioengineStatus check (model-runner can't run them at all), so their Test
+  // Run Model routes to the KTH-only cellpose4-runner instead once supported.
+  const cellpose4 = useCellpose4Runner();
+  const modelId = selectedResource?.id ? selectedResource.id.split('/').pop() : undefined;
+  const isCellpose4Model = cellpose4.isSupported(modelId);
+  const canTestRun = bioengineStatus?.status === 'passed' || isCellpose4Model;
 
   // Resolve a documentation URL for a given software name.
   // bioengine and bioimageio.core are not in the partner API so they
@@ -786,7 +794,7 @@ const ArtifactDetails = () => {
                   // button's HintTooltip.
                   const testRunHint = !isLoggedIn
                     ? 'Please log in to test run models'
-                    : !bioengineStatus
+                    : (!bioengineStatus && !isCellpose4Model)
                       ? 'This model has not been validated on the BioEngine yet.'
                       : undefined;
                   return (
@@ -797,9 +805,15 @@ const ArtifactDetails = () => {
                       data-highlight-login={!isLoggedIn && isTestButtonHovered ? 'true' : 'false'}
                     >
                       <Button
-                        disabled={!bioengineStatus || !isLoggedIn}
+                        // Stay disabled until the cellpose4-runner probe settles.
+                        // A Cellpose-4 model can carry a FAILED bioengineStatus
+                        // (model-runner cannot run it), which alone enables the
+                        // button. Clicking in that window reads isCellpose4Model
+                        // as false and raises the BioEngine failure dialog
+                        // instead of routing to cellpose4-runner.
+                        disabled={(!bioengineStatus && !isCellpose4Model) || !isLoggedIn || cellpose4.loading}
                         onClick={() => {
-                          if (bioengineStatus?.status === 'passed') {
+                          if (canTestRun) {
                             handleRunModel();
                           } else if (bioengineStatus) {
                             setIsBioengineErrorDialogOpen(true);
@@ -807,36 +821,42 @@ const ArtifactDetails = () => {
                         }}
                         variant="outlined"
                         size="medium"
-                        startIcon={bioengineStatus ? (
-                          <Tooltip 
+                        startIcon={canTestRun ? (
+                          <Tooltip
+                            title={bioengineStatus?.tested_at ? `Tested at: ${new Date(bioengineStatus.tested_at * 1000).toUTCString()}` : ''}
+                            arrow
+                          >
+                            <Box component="span" sx={{ display: 'flex' }}>
+                              <CheckCircleIcon sx={{ fontSize: 20 }} />
+                            </Box>
+                          </Tooltip>
+                        ) : bioengineStatus ? (
+                          <Tooltip
                             title={bioengineStatus.tested_at ? `Tested at: ${new Date(bioengineStatus.tested_at * 1000).toUTCString()}` : ''}
                             arrow
                           >
                             <Box component="span" sx={{ display: 'flex' }}>
-                              {bioengineStatus.status === 'passed' ? 
-                                <CheckCircleIcon sx={{ fontSize: 20 }} /> : 
-                                <CancelIcon sx={{ fontSize: 20 }} />
-                              }
+                              <CancelIcon sx={{ fontSize: 20 }} />
                             </Box>
                           </Tooltip>
                         ) : undefined}
                         sx={{
                           borderRadius: '12px',
-                          backgroundColor: bioengineStatus?.status === 'passed' ? 'rgba(34, 197, 94, 0.05)' : (bioengineStatus ? 'rgba(239, 68, 68, 0.05)' : 'rgba(59, 130, 246, 0.05)'),
+                          backgroundColor: canTestRun ? 'rgba(34, 197, 94, 0.05)' : (bioengineStatus ? 'rgba(239, 68, 68, 0.05)' : 'rgba(59, 130, 246, 0.05)'),
                           backdropFilter: 'blur(8px)',
-                          border: `2px solid ${bioengineStatus?.status === 'passed' ? '#22c55e' : (bioengineStatus ? '#ef4444' : '#3b82f6')}`,
-                          color: bioengineStatus?.status === 'passed' ? '#16a34a' : (bioengineStatus ? '#dc2626' : '#3b82f6'),
+                          border: `2px solid ${canTestRun ? '#22c55e' : (bioengineStatus ? '#ef4444' : '#3b82f6')}`,
+                          color: canTestRun ? '#16a34a' : (bioengineStatus ? '#dc2626' : '#3b82f6'),
                           fontWeight: 500,
                           px: 4,
                           py: 1.5,
                           fontSize: '0.95rem',
                           transition: 'all 0.3s ease',
                           '&:hover': {
-                            backgroundColor: bioengineStatus?.status === 'passed' ? 'rgba(34, 197, 94, 0.1)' : (bioengineStatus ? 'rgba(239, 68, 68, 0.1)' : 'rgba(59, 130, 246, 0.1)'),
-                            borderColor: bioengineStatus?.status === 'passed' ? '#16a34a' : (bioengineStatus ? '#dc2626' : '#2563eb'),
-                            color: bioengineStatus?.status === 'passed' ? '#15803d' : (bioengineStatus ? '#b91c1c' : '#2563eb'),
+                            backgroundColor: canTestRun ? 'rgba(34, 197, 94, 0.1)' : (bioengineStatus ? 'rgba(239, 68, 68, 0.1)' : 'rgba(59, 130, 246, 0.1)'),
+                            borderColor: canTestRun ? '#16a34a' : (bioengineStatus ? '#dc2626' : '#2563eb'),
+                            color: canTestRun ? '#15803d' : (bioengineStatus ? '#b91c1c' : '#2563eb'),
                             transform: 'translateY(-2px) scale(1.02)',
-                            boxShadow: `0 8px 25px ${bioengineStatus?.status === 'passed' ? 'rgba(34, 197, 94, 0.2)' : (bioengineStatus ? 'rgba(239, 68, 68, 0.2)' : 'rgba(59, 130, 246, 0.2)')}`,
+                            boxShadow: `0 8px 25px ${canTestRun ? 'rgba(34, 197, 94, 0.2)' : (bioengineStatus ? 'rgba(239, 68, 68, 0.2)' : 'rgba(59, 130, 246, 0.2)')}`,
                           },
                           '&.Mui-disabled': {
                             borderColor: 'rgba(0, 0, 0, 0.12)',

--- a/src/components/ModelRunner.tsx
+++ b/src/components/ModelRunner.tsx
@@ -12,6 +12,7 @@ import { imjoyToTfjs, inferImgAxesViaSpec, mapAxes, parseAxes, isImg2Img, proces
 import { BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID } from '../utils/bioengineService';
 import { HYPHA_SERVER_URL } from '../config/hypha';
 import { useModelRunnerConnection } from '../hooks/useModelRunnerConnection';
+import { useCellpose4Runner } from '../hooks/useCellpose4Runner';
 import AdvancedOptions from './AdvancedOptions';
 import InferenceProgressDialog, { InferenceProgress } from './InferenceProgressDialog';
 import { isRuntimeStartingError, RUNTIME_STARTING_MESSAGE } from '../utils/runnerErrors';
@@ -146,6 +147,11 @@ const ModelRunner: React.FC<ModelRunnerProps> = ({
   // override live in a shared store, identical to the other pages).
   const conn = useModelRunnerConnection();
   const modelRunners = conn.modelRunners;
+  const modelId = artifactId ? artifactId.split('/').pop() : undefined;
+  // Cellpose-4 models (e.g. Cellpose-SAM) can't be run by model-runner at
+  // all; cellpose4-runner is their KTH-only inference backend.
+  const cellpose4 = useCellpose4Runner();
+  const isCellpose4Model = cellpose4.isSupported(modelId);
   const [isLoading, setIsLoading] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const [currentWindowId, setCurrentWindowId] = useState<string | null>(null);
@@ -187,10 +193,11 @@ const ModelRunner: React.FC<ModelRunnerProps> = ({
   const [tileSize, setTileSize] = useState<number>(512);
 
   // Effective service id for the next ModelRunnerEngine.init() call.
-  // Resolution order: explicit override > toggle's active site > KTH constant
-  // (legacy fallback so this component never produces an empty serviceId).
+  // Resolution order: explicit override > cellpose4-runner (Cellpose-4 models
+  // only, KTH-only) > toggle's active site > KTH constant (legacy fallback so
+  // this component never produces an empty serviceId).
   const serviceId = conn.serviceIdOverride.trim()
-    || modelRunners.activeServiceId
+    || (isCellpose4Model ? cellpose4.serviceId : modelRunners.activeServiceId)
     || BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID;
   
   // Button states
@@ -211,12 +218,16 @@ const ModelRunner: React.FC<ModelRunnerProps> = ({
     if (
       artifactId && hyphaCoreAPI && isHyphaCoreReady && isLoggedIn
       && !isRunning && !isLoading && !initializingRef.current
-      && !modelRunners.loading
-      && modelRunners.activeServiceId
+      // Always wait for the cellpose4-runner probe to settle first: while it's
+      // still loading, isCellpose4Model reads as false, which would otherwise
+      // let a Cellpose-4 model fall through and wrongly init against
+      // model-runner before we know better.
+      && !cellpose4.loading
+      && (isCellpose4Model || (!modelRunners.loading && modelRunners.activeServiceId))
     ) {
       setupRunner();
     }
-  }, [artifactId, hyphaCoreAPI, isHyphaCoreReady, isLoggedIn, modelRunners.loading, modelRunners.activeServiceId]);
+  }, [artifactId, hyphaCoreAPI, isHyphaCoreReady, isLoggedIn, modelRunners.loading, modelRunners.activeServiceId, cellpose4.loading, isCellpose4Model]);
 
   // Surface a resumable in-flight inference for this model (survives page refresh).
   useEffect(() => {
@@ -890,11 +901,16 @@ const ModelRunner: React.FC<ModelRunnerProps> = ({
           onServerUrlChange={conn.setServerUrl}
           serviceIdOverride={conn.serviceIdOverride}
           onServiceIdOverrideChange={conn.setServiceIdOverride}
-          serviceIdPlaceholder={modelRunners.activeServiceId ?? BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID}
-          toggleSelected={conn.toggleSelected}
+          serviceIdPlaceholder={isCellpose4Model ? cellpose4.serviceId : (modelRunners.activeServiceId ?? BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID)}
+          toggleSelected={isCellpose4Model ? 'kth' : conn.toggleSelected}
           onSelectSite={conn.selectSite}
-          siteAvailable={{ kth: conn.baseRunners.kth.available, denbi: conn.baseRunners.denbi.available }}
+          siteAvailable={isCellpose4Model
+            ? { kth: true, denbi: false }
+            : { kth: conn.baseRunners.kth.available, denbi: conn.baseRunners.denbi.available }}
           siteLoading={conn.baseRunners.loading}
+          siteDisabledTitle={isCellpose4Model
+            ? { denbi: 'Cellpose-4 models (e.g. Cellpose-SAM) only run on the KTH cluster.' }
+            : undefined}
           showToggle={isLoggedIn}
           onReset={conn.reset}
           isResetting={conn.isReconnecting || conn.isConnecting}

--- a/src/components/RunnerSiteToggle.tsx
+++ b/src/components/RunnerSiteToggle.tsx
@@ -14,6 +14,8 @@ interface RunnerSiteToggleProps {
   available: Record<RunnerSite, boolean>;
   /** While loading, every option shows a pulsing indicator dot. */
   loading?: boolean;
+  /** Per-site override for the disabled-option tooltip text. Falls back to the generic "unavailable" message. */
+  disabledTitle?: Partial<Record<RunnerSite, string>>;
   className?: string;
 }
 
@@ -32,6 +34,7 @@ const RunnerSiteToggle: React.FC<RunnerSiteToggleProps> = ({
   onSelect,
   available,
   loading = false,
+  disabledTitle,
   className = '',
 }) => {
   return (
@@ -49,7 +52,7 @@ const RunnerSiteToggle: React.FC<RunnerSiteToggleProps> = ({
           ? `Looking for the ${opt.label} model-runner service...`
           : isAvailable
             ? `Run the model-runner on the ${opt.label} cluster`
-            : `${opt.label} cluster's model-runner is unavailable right now`;
+            : (disabledTitle?.[opt.id] ?? `${opt.label} cluster's model-runner is unavailable right now`);
 
         return (
           <button

--- a/src/hooks/useCellpose4Runner.ts
+++ b/src/hooks/useCellpose4Runner.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import { useHyphaStore } from '../store/hyphaStore';
+import { BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID } from '../utils/bioengineService';
+
+export interface UseCellpose4RunnerResult {
+  /** `true` once the KTH cellpose4-runner service has been resolved. */
+  available: boolean;
+  /** `true` while the initial probe (service resolve + list_supported_models) is in flight. */
+  loading: boolean;
+  /** Resolved service handle, or `null` while loading / unavailable. */
+  runner: any | null;
+  /** The KTH-only cellpose4-runner service id. Always this value, no deNBI counterpart. */
+  serviceId: string;
+  /** Whether the given model id is in cellpose4-runner's supported list. `false` while loading/unavailable. */
+  isSupported: (modelId?: string | null) => boolean;
+}
+
+// Cellpose-4 support rarely changes and every model-detail page mount would
+// otherwise re-probe the service and re-list its supported models. Cache the
+// list at module scope for the life of the tab; a full reload re-fetches.
+let cachedSupportedModels: string[] | null = null;
+
+export function useCellpose4Runner(): UseCellpose4RunnerResult {
+  const { server, isLoggedIn } = useHyphaStore();
+  const [available, setAvailable] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [runner, setRunner] = useState<any | null>(null);
+  const [supportedModels, setSupportedModels] = useState<string[]>(cachedSupportedModels ?? []);
+
+  useEffect(() => {
+    if (!server || !isLoggedIn) {
+      setAvailable(false);
+      setLoading(false);
+      setRunner(null);
+      return;
+    }
+
+    if (cachedSupportedModels !== null) {
+      // Already known from a prior mount this session — still resolve the
+      // service handle (cheap, needed for inference) but skip the list call.
+      setLoading(true);
+      let alive = true;
+      (async () => {
+        try {
+          const svc = await server.getService(BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID, { mode: 'select:min:get_load' });
+          if (!alive) return;
+          setRunner(svc);
+          setAvailable(true);
+          setSupportedModels(cachedSupportedModels!);
+        } catch {
+          if (!alive) return;
+          setRunner(null);
+          setAvailable(false);
+        } finally {
+          if (alive) setLoading(false);
+        }
+      })();
+      return () => { alive = false; };
+    }
+
+    let alive = true;
+    (async () => {
+      try {
+        const svc = await server.getService(BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID, { mode: 'select:min:get_load' });
+        const models: string[] = await svc.list_supported_models();
+        if (!alive) return;
+        cachedSupportedModels = models;
+        setRunner(svc);
+        setAvailable(true);
+        setSupportedModels(models);
+      } catch {
+        if (!alive) return;
+        setRunner(null);
+        setAvailable(false);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+
+    return () => { alive = false; };
+  }, [server, isLoggedIn]);
+
+  const isSupported = (modelId?: string | null): boolean => {
+    if (loading || !available || !modelId) return false;
+    return supportedModels.includes(modelId);
+  };
+
+  return {
+    available,
+    loading,
+    runner,
+    serviceId: BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID,
+    isSupported,
+  };
+}

--- a/src/hooks/useCellpose4Runner.ts
+++ b/src/hooks/useCellpose4Runner.ts
@@ -1,94 +1,121 @@
 import { useEffect, useState } from 'react';
-import { useHyphaStore } from '../store/hyphaStore';
+import { hyphaWebsocketClient } from 'hypha-rpc';
+import { HYPHA_SERVER_URL } from '../config/hypha';
 import { BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID } from '../utils/bioengineService';
 
 export interface UseCellpose4RunnerResult {
-  /** `true` once the KTH cellpose4-runner service has been resolved. */
+  /** `true` once the supported-model list has been fetched successfully. */
   available: boolean;
-  /** `true` while the initial probe (service resolve + list_supported_models) is in flight. */
+  /** `true` until the first probe attempt has settled, successfully or not. */
   loading: boolean;
-  /** Resolved service handle, or `null` while loading / unavailable. */
-  runner: any | null;
   /** The KTH-only cellpose4-runner service id. Always this value, no deNBI counterpart. */
   serviceId: string;
-  /** Whether the given model id is in cellpose4-runner's supported list. `false` while loading/unavailable. */
+  /** Whether the given model id is in cellpose4-runner's supported list. `false` until the list is known. */
   isSupported: (modelId?: string | null) => boolean;
 }
 
-// Cellpose-4 support rarely changes and every model-detail page mount would
-// otherwise re-probe the service and re-list its supported models. Cache the
-// list at module scope for the life of the tab; a full reload re-fetches.
-let cachedSupportedModels: string[] | null = null;
+const RETRY_INTERVAL_MS = 30000;
+// connectToServer hangs rather than rejecting when the websocket cannot be
+// established, so without a deadline a probe started while the network is
+// down would never settle and never schedule a retry.
+const PROBE_TIMEOUT_MS = 15000;
+
+// In-memory only, deliberately: the list lives for the life of the tab and a
+// reload re-fetches it, so a newly supported model shows up without anyone
+// having to clear a persisted cache.
+let supportedModels: string[] | null = null;
+// Distinct from `supportedModels !== null`: the first attempt can settle by
+// failing, and consumers must not stay blocked on a runner that is down.
+let firstAttemptSettled = false;
+let probeStarted = false;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+const listeners = new Set<() => void>();
+
+const notify = () => listeners.forEach((fn) => fn());
+
+const scheduleRetry = () => {
+  if (retryTimer !== null) return;
+  retryTimer = setTimeout(() => {
+    retryTimer = null;
+    void runProbe();
+  }, RETRY_INTERVAL_MS);
+};
+
+async function fetchSupportedModels(): Promise<string[]> {
+  // Anonymous on purpose. The supported-model list is public, and not waiting
+  // for login means the answer is usually in hand before the model detail page
+  // has finished rendering, so the Test Run button never has to show a wrong
+  // status first.
+  const server = await hyphaWebsocketClient.connectToServer({ server_url: HYPHA_SERVER_URL });
+  try {
+    const svc = await server.getService(BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID, {
+      mode: 'select:min:get_load',
+    });
+    const models = await svc.list_supported_models();
+    return Array.isArray(models) ? models : [];
+  } finally {
+    try {
+      await server.disconnect();
+    } catch {
+      // Best effort; the probe result is already in hand either way.
+    }
+  }
+}
+
+async function runProbe(): Promise<void> {
+  try {
+    supportedModels = await Promise.race([
+      fetchSupportedModels(),
+      new Promise<string[]>((_, reject) =>
+        setTimeout(() => reject(new Error('cellpose4-runner probe timed out')), PROBE_TIMEOUT_MS)
+      ),
+    ]);
+  } catch (err) {
+    // Worker down, still starting, or offline. Keep retrying in the
+    // background so a page opened before the cluster is reachable picks the
+    // route up without a reload.
+    console.warn(`[cellpose4-runner] probe failed, retrying in ${RETRY_INTERVAL_MS / 1000}s:`, err);
+    scheduleRetry();
+  } finally {
+    firstAttemptSettled = true;
+    notify();
+  }
+}
+
+/**
+ * Kick off the background probe. Safe to call any number of times; only the
+ * first call starts it.
+ */
+export function startCellpose4Probe(): void {
+  if (probeStarted) return;
+  probeStarted = true;
+  void runProbe();
+}
+
+// Start as soon as the bundle evaluates rather than on first mount, so the
+// list is already in flight while the page is still loading.
+startCellpose4Probe();
 
 export function useCellpose4Runner(): UseCellpose4RunnerResult {
-  const { server, isLoggedIn } = useHyphaStore();
-  const [available, setAvailable] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [runner, setRunner] = useState<any | null>(null);
-  const [supportedModels, setSupportedModels] = useState<string[]>(cachedSupportedModels ?? []);
+  const [, forceUpdate] = useState(0);
 
   useEffect(() => {
-    if (!server || !isLoggedIn) {
-      setAvailable(false);
-      setLoading(false);
-      setRunner(null);
-      return;
-    }
-
-    if (cachedSupportedModels !== null) {
-      // Already known from a prior mount this session — still resolve the
-      // service handle (cheap, needed for inference) but skip the list call.
-      setLoading(true);
-      let alive = true;
-      (async () => {
-        try {
-          const svc = await server.getService(BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID, { mode: 'select:min:get_load' });
-          if (!alive) return;
-          setRunner(svc);
-          setAvailable(true);
-          setSupportedModels(cachedSupportedModels!);
-        } catch {
-          if (!alive) return;
-          setRunner(null);
-          setAvailable(false);
-        } finally {
-          if (alive) setLoading(false);
-        }
-      })();
-      return () => { alive = false; };
-    }
-
-    let alive = true;
-    (async () => {
-      try {
-        const svc = await server.getService(BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID, { mode: 'select:min:get_load' });
-        const models: string[] = await svc.list_supported_models();
-        if (!alive) return;
-        cachedSupportedModels = models;
-        setRunner(svc);
-        setAvailable(true);
-        setSupportedModels(models);
-      } catch {
-        if (!alive) return;
-        setRunner(null);
-        setAvailable(false);
-      } finally {
-        if (alive) setLoading(false);
-      }
-    })();
-
-    return () => { alive = false; };
-  }, [server, isLoggedIn]);
+    startCellpose4Probe();
+    const listener = () => forceUpdate((n) => n + 1);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
 
   const isSupported = (modelId?: string | null): boolean => {
-    if (loading || !available || !modelId) return false;
+    if (!supportedModels || !modelId) return false;
     return supportedModels.includes(modelId);
   };
 
   return {
-    available,
-    loading,
-    runner,
+    available: supportedModels !== null,
+    loading: !firstAttemptSettled,
     serviceId: BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID,
     isSupported,
   };

--- a/src/hooks/useCellpose4Runner.ts
+++ b/src/hooks/useCellpose4Runner.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { hyphaWebsocketClient } from 'hypha-rpc';
 import { HYPHA_SERVER_URL } from '../config/hypha';
 import { BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID } from '../utils/bioengineService';
 
@@ -15,10 +14,13 @@ export interface UseCellpose4RunnerResult {
 }
 
 const RETRY_INTERVAL_MS = 30000;
-// connectToServer hangs rather than rejecting when the websocket cannot be
-// established, so without a deadline a probe started while the network is
-// down would never settle and never schedule a retry.
 const PROBE_TIMEOUT_MS = 15000;
+
+// Hypha exposes every service method over plain HTTP as well, so the list can
+// be read with a single unauthenticated GET instead of opening an RPC
+// websocket. That is both faster and independent of the login state.
+const SUPPORTED_MODELS_URL =
+  `${HYPHA_SERVER_URL}/${BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID.replace('/', '/services/')}/list_supported_models`;
 
 // In-memory only, deliberately: the list lives for the life of the tab and a
 // reload re-fetches it, so a newly supported model shows up without anyone
@@ -41,35 +43,22 @@ const scheduleRetry = () => {
   }, RETRY_INTERVAL_MS);
 };
 
-async function fetchSupportedModels(): Promise<string[]> {
-  // Anonymous on purpose. The supported-model list is public, and not waiting
-  // for login means the answer is usually in hand before the model detail page
-  // has finished rendering, so the Test Run button never has to show a wrong
-  // status first.
-  const server = await hyphaWebsocketClient.connectToServer({ server_url: HYPHA_SERVER_URL });
-  try {
-    const svc = await server.getService(BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID, {
-      mode: 'select:min:get_load',
-    });
-    const models = await svc.list_supported_models();
-    return Array.isArray(models) ? models : [];
-  } finally {
-    try {
-      await server.disconnect();
-    } catch {
-      // Best effort; the probe result is already in hand either way.
-    }
-  }
+async function fetchSupportedModels(signal: AbortSignal): Promise<string[]> {
+  // Unauthenticated on purpose. The supported-model list is public, and not
+  // waiting for login means the answer is usually in hand before the model
+  // detail page has finished rendering, so the Test Run button never has to
+  // show a wrong status first.
+  const res = await fetch(SUPPORTED_MODELS_URL, { signal });
+  if (!res.ok) throw new Error(`cellpose4-runner responded ${res.status}`);
+  const models = await res.json();
+  return Array.isArray(models) ? models : [];
 }
 
 async function runProbe(): Promise<void> {
+  const controller = new AbortController();
+  const deadline = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
   try {
-    supportedModels = await Promise.race([
-      fetchSupportedModels(),
-      new Promise<string[]>((_, reject) =>
-        setTimeout(() => reject(new Error('cellpose4-runner probe timed out')), PROBE_TIMEOUT_MS)
-      ),
-    ]);
+    supportedModels = await fetchSupportedModels(controller.signal);
   } catch (err) {
     // Worker down, still starting, or offline. Keep retrying in the
     // background so a page opened before the cluster is reachable picks the
@@ -77,6 +66,7 @@ async function runProbe(): Promise<void> {
     console.warn(`[cellpose4-runner] probe failed, retrying in ${RETRY_INTERVAL_MS / 1000}s:`, err);
     scheduleRetry();
   } finally {
+    clearTimeout(deadline);
     firstAttemptSettled = true;
     notify();
   }

--- a/src/utils/bioengineService.ts
+++ b/src/utils/bioengineService.ts
@@ -35,6 +35,11 @@ export const BIOIMAGEIO_WORKER_SERVICE_ID =
 // per-site via useModelRunners().
 export const BIOIMAGEIO_MODEL_RUNNER_SERVICE_ID = BIOIMAGEIO_KTH_MODEL_RUNNER_SERVICE_ID;
 
+// The Cellpose-4 runner (Cellpose-SAM etc.) is a KTH-only companion app to
+// model-runner — there is no deNBI deployment.
+export const BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID =
+  `bioimage-io/${BIOIMAGEIO_KTH_WORKER_CLIENT_GLOB}:cellpose4-runner`;
+
 export type RunnerSite = 'kth' | 'denbi';
 
 // KTH is the default runner (RUNNER_SITES[0]); deNBI (v1.15.2 async API)

--- a/tests/cellpose4-runner-test-run.spec.ts
+++ b/tests/cellpose4-runner-test-run.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+// Verifies that Cellpose-4 models (which model-runner can never run, and so
+// never get a passing bioengineStatus test-report) still get a working
+// "Test Run Model" button, routed to the KTH-only cellpose4-runner instead of
+// model-runner, with the KTH/deNBI toggle locked to KTH.
+//
+// Flow: detail page -> "Test Run Model" enabled despite no bioengineStatus ->
+// open Advanced Options -> deNBI disabled / KTH selected -> "Load Sample
+// Image" -> "Run Model" -> (RUN_GPU=1) inference completes successfully.
+//
+// Target: idealistic-eagle (Cellpose-SAM), currently the only model reported
+// by cellpose4-runner.list_supported_models() on KTH.
+//
+// Requires: HYPHA_TOKEN env var; dev server (pnpm start).
+
+const MODEL_URL_ID = 'idealistic-eagle';
+const injectToken = (token: string) => ({ tok: token, expiry: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString() });
+
+test.describe('Cellpose-4 runner routing', () => {
+  test('Test Run Model works for a cellpose4-runner-supported model, KTH locked', async ({ page }) => {
+    const token = process.env.HYPHA_TOKEN;
+    if (!token) {
+      test.skip();
+      return;
+    }
+    test.setTimeout(600000);
+
+    await page.addInitScript(({ tok, expiry }) => {
+      localStorage.setItem('token', tok);
+      localStorage.setItem('tokenExpiry', expiry);
+    }, injectToken(token));
+
+    const testRun = page.getByRole('button', { name: 'Test Run Model' });
+    let loaded = false;
+    for (let attempt = 0; attempt < 4 && !loaded; attempt++) {
+      await page.goto(`/#/resources/${MODEL_URL_ID}`);
+      try {
+        await testRun.waitFor({ state: 'visible', timeout: 45000 });
+        loaded = true;
+      } catch {
+        // Fetch likely failed on mount; reload and try again.
+      }
+    }
+    expect(loaded, 'model detail page never resolved the artifact').toBe(true);
+
+    // The decisive routing assertion: enabled despite this model never
+    // passing (or even being scored by) the model-runner-based bioengineStatus
+    // check, because cellpose4-runner support overrides that gate.
+    await expect(testRun).toBeEnabled({ timeout: 60000 });
+    await testRun.click();
+
+    // ---- KTH/deNBI lock assertion ----
+    await page.getByRole('button', { name: 'Advanced Options' }).click();
+    const kth = page.getByRole('radio', { name: 'KTH' });
+    const denbi = page.getByRole('radio', { name: 'deNBI' });
+    await expect(kth).toHaveAttribute('aria-checked', 'true', { timeout: 30000 });
+    await expect(denbi).toBeDisabled();
+    await expect(denbi).toHaveAttribute(
+      'title',
+      /Cellpose-4 models .* only run on the KTH cluster/
+    );
+    await page.screenshot({ path: 'outputs/pw/cellpose4-kth-locked.png', fullPage: false });
+    await page.keyboard.press('Escape');
+
+    // ---- Run flow ----
+    const loadSample = page.getByRole('button', { name: 'Load Sample Image' });
+    await expect(loadSample).toBeEnabled({ timeout: 240000 });
+    await loadSample.click();
+    await expect(page.getByText(/input loaded successfully/i)).toBeVisible({ timeout: 120000 });
+
+    const runModel = page.getByRole('button', { name: 'Run Model' });
+    await expect(runModel).toBeEnabled({ timeout: 60000 });
+
+    const runGpu = process.env.RUN_GPU === '1';
+    if (runGpu) {
+      await runModel.click();
+      await expect(page.getByText('Model Inference in Progress')).toBeVisible({ timeout: 30000 });
+      await expect(page.getByText('Model execution completed successfully!')).toBeVisible({ timeout: 300000 });
+      await page.screenshot({ path: 'outputs/pw/cellpose4-run-complete.png', fullPage: false });
+    }
+  });
+});


### PR DESCRIPTION
## Motivation

Cellpose-4 models such as Cellpose-SAM cannot be executed by the model-runner at all. Their `bioengineStatus` is therefore always absent or `FAILED`, and the **Test Run Model** button on the model detail page was permanently unavailable for them, even though the models do run on a separate KTH-only `cellpose4-runner` service.

## Solution

- New `useCellpose4Runner` hook reads the runner's supported-model list with a single unauthenticated HTTP GET against Hypha's service gateway:

  ```
  GET {server}/bioimage-io/services/bioengine-worker-kth-*:cellpose4-runner/list_supported_models
  ```

  No RPC websocket and no token, so the answer is normally in hand before the detail page has finished rendering. The probe starts as soon as the module evaluates, not on first mount and not after login, and carries a 15 second `AbortController` deadline.
- The list is held in memory only for the life of the tab; a reload re-fetches it, so a newly supported model needs no cache clearing.
- If the runner is unreachable the probe retries every 30 seconds in the background, so a page opened before the cluster is up picks the route up without a reload.
- `ArtifactDetails` enables **Test Run Model** when the current model is in that list, independently of `bioengineStatus`.
- `ModelRunner` resolves the cellpose4-runner service id for those models instead of the model-runner service id, and gates its init effect on the probe having settled.
- Since there is no deNBI counterpart for this service, the cluster toggle is locked to KTH: deNBI is disabled and carries an explanatory tooltip, threaded through a new `siteDisabledTitle` prop on `AdvancedOptions` and a new `disabledTitle` prop on `RunnerSiteToggle`.

## Behaviour

- Supported Cellpose-4 model: **Test Run Model** is enabled, opens the runner against the cellpose4-runner, cluster toggle fixed to KTH with deNBI disabled and tooltipped.
- The button no longer shows a status icon at all until the probe settles. Previously a Cellpose-4 model rendered the red failed icon from its model-runner test report first and flipped to the green passing icon a moment later.
- If the probe fails, the button falls back to whatever `bioengineStatus` says, and a later successful retry updates it in place.
- Every other model: unchanged; routing still follows `bioengineStatus` and the existing model-runner service selection.

## Test plan

`tests/cellpose4-runner-test-run.spec.ts` (Playwright, chromium) against `idealistic-eagle`:

1. Model detail page resolves and **Test Run Model** is enabled.
2. Clicking it opens the runner; Advanced Options shows KTH `aria-checked=true`, deNBI disabled with the Cellpose-4 tooltip.
3. **Load Sample Image** loads the test input and **Run Model** becomes enabled.
4. With `RUN_GPU=1`, the full inference runs to `Model execution completed successfully!`.

Passing locally. Requires `HYPHA_TOKEN` in the environment.

Manually verified alongside it, by polling the button's state on load:

- Logged in, the button first renders at +2.3s already carrying the passing icon; there is no failed icon at any point.
- Logged out also resolves support, which a login-gated probe could not do.
- `affable-shark` and `ambitious-sloth` are unchanged.
- With the supported-models request forced to fail, the probe reports the failure at +1.9s, retries at +31.9s, and the button flips to passing without a reload.

## Files

| File | Change |
|---|---|
| `src/hooks/useCellpose4Runner.ts` | New: unauthenticated HTTP probe, in-memory list, 30s retry |
| `src/components/ArtifactDetails.tsx` | Enable Test Run for supported models; hold the status icon until the probe settles |
| `src/components/ModelRunner.tsx` | Route to cellpose4-runner; lock cluster to KTH |
| `src/components/AdvancedOptions.tsx` | New `siteDisabledTitle` prop |
| `src/components/RunnerSiteToggle.tsx` | New `disabledTitle` prop |
| `src/utils/bioengineService.ts` | `BIOIMAGEIO_KTH_CELLPOSE4_RUNNER_SERVICE_ID` |
| `tests/cellpose4-runner-test-run.spec.ts` | New end-to-end test |
