### PR TITLE
feat(colab): model export for fine-tuned sessions + annotate availability and polish

### DIFF
--- a/src/components/annotate/CellposeConfigDialog.tsx
+++ b/src/components/annotate/CellposeConfigDialog.tsx
@@ -147,6 +147,13 @@ interface CellposeConfigDialogProps {
   /** Whether the μSAM backend is reachable. Gates the μSAM option in the
    *  backend selector. */
   microSamAvailable?: boolean;
+  /** Whether the Cellpose-SAM backend (cellpose4-runner) is reachable. Gates
+   *  the Cellpose-SAM option in the backend selector. */
+  cellposeAvailable?: boolean;
+  /** Fires once whenever the dialog transitions to open, so the caller can
+   *  re-check service availability without polling while the dialog is
+   *  closed. */
+  onDialogOpen?: () => void;
   /** Whether CLAHE is currently active on the image. Gates the "Use
    *  contrast enhanced image" checkbox, shown for both backends. */
   claheActive?: boolean;
@@ -214,6 +221,8 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
   completedRunId,
   onInstantConfigChange,
   microSamAvailable,
+  cellposeAvailable,
+  onDialogOpen,
   claheActive,
   onMeasureDiameter,
   onCancelRun,
@@ -225,6 +234,37 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
       setConfig(initialConfig);
     }
   }, [open, initialConfig]);
+
+  // Re-check availability every time the dialog opens, so a stale probe from
+  // before the dialog was last shown doesn't linger.
+  const onDialogOpenRef = useRef(onDialogOpen);
+  onDialogOpenRef.current = onDialogOpen;
+  useEffect(() => {
+    if (open) {
+      onDialogOpenRef.current?.();
+    }
+  }, [open]);
+
+  // If the currently selected backend's service is unavailable but the other
+  // one is up, switch to the available one. Runs on open and again whenever
+  // availability changes while the dialog stays open, so a probe refresh (or
+  // a service coming back) re-derives the selection without user action.
+  // Default stays μSAM when both are up: this only ever moves away from an
+  // unavailable backend, never toward a preference between two available ones.
+  useEffect(() => {
+    if (!open) return;
+    setConfig((prev) => {
+      if (prev.backend === 'microsam' && microSamAvailable === false && cellposeAvailable !== false) {
+        return { ...prev, backend: 'cellpose' };
+      }
+      if (prev.backend === 'cellpose' && cellposeAvailable === false && microSamAvailable !== false) {
+        return { ...prev, backend: 'microsam' };
+      }
+      return prev;
+    });
+  }, [open, microSamAvailable, cellposeAvailable]);
+
+  const bothUnavailable = microSamAvailable === false && cellposeAvailable === false;
 
   // Fire instant-group updates back to the caller (debounced by the caller's
   // own debouncer; we just propagate every state change). React batches the
@@ -360,10 +400,16 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
                 <MenuItem value="microsam" disabled={!microSamAvailable} sx={{ fontSize: '0.8rem' }}>
                   {microSamAvailable ? 'μSAM' : 'μSAM (unavailable)'}
                 </MenuItem>
-                <MenuItem value="cellpose" sx={{ fontSize: '0.8rem' }}>Cellpose-SAM</MenuItem>
+                <MenuItem value="cellpose" disabled={!cellposeAvailable} sx={{ fontSize: '0.8rem' }}>
+                  {cellposeAvailable ? 'Cellpose-SAM' : 'Cellpose-SAM (unavailable)'}
+                </MenuItem>
               </Select>
             </Box>
-            {isMicroSam && (
+            {bothUnavailable ? (
+              <Typography variant="caption" color="error" sx={{ display: 'block', mt: 0.75, px: 0.5 }}>
+                Segmentation services are currently unavailable. Please try again shortly.
+              </Typography>
+            ) : isMicroSam && (
               <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.75, px: 0.5 }}>
                 μSAM segments every object automatically.
               </Typography>
@@ -411,7 +457,7 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
                   onClick={() => { handleApply(); onRun(config); }}
                   variant="contained"
                   color="secondary"
-                  disabled={isRunning}
+                  disabled={isRunning || bothUnavailable}
                   fullWidth
                   sx={{ mt: 2 }}
                 >
@@ -529,7 +575,7 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
                         onClick={() => { handleApply(); onRun(config); }}
                         variant="contained"
                         color="secondary"
-                        disabled={isRunning}
+                        disabled={isRunning || bothUnavailable}
                         fullWidth
                       >
                         {livePreviewReady ? 'Re-run on Server' : 'Compute Flow Field'}
@@ -688,6 +734,10 @@ export function useCellposeConfig(opts?: {
   completedRunId?: number;
   onInstantConfigChange?: (config: CellposeConfig) => void;
   microSamAvailable?: boolean;
+  /** Whether the Cellpose-SAM backend (cellpose4-runner) is reachable. */
+  cellposeAvailable?: boolean;
+  /** Fires whenever the dialog opens, for a cheap availability re-check. */
+  onDialogOpen?: () => void;
   /** Whether CLAHE is currently active. Gates the "Use contrast enhanced
    *  image" checkbox, shown for both backends. */
   claheActive?: boolean;
@@ -749,6 +799,8 @@ export function useCellposeConfig(opts?: {
       completedRunId={opts?.completedRunId}
       onInstantConfigChange={opts?.onInstantConfigChange}
       microSamAvailable={opts?.microSamAvailable}
+      cellposeAvailable={opts?.cellposeAvailable}
+      onDialogOpen={opts?.onDialogOpen}
       claheActive={opts?.claheActive}
       onMeasureDiameter={opts?.onMeasureDiameter ? handleMeasureDiameter : undefined}
       onCancelRun={opts?.onCancelRun}

--- a/src/components/annotate/ToolBar.tsx
+++ b/src/components/annotate/ToolBar.tsx
@@ -121,6 +121,10 @@ const ToolBar: React.FC<ToolBarProps> = ({
 
   const tooltipPlacement = isPortrait ? 'bottom' : 'right';
 
+  // Full Image Segmentation only needs one of the two backends up. It's
+  // disabled solely when both the Cellpose-SAM and μSAM services are down.
+  const segmentationUnavailable = !cellposeAvailable && !microSamAvailable;
+
   return (
     <Box
       role="toolbar"
@@ -197,7 +201,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
                   <>
                     <Divider flexItem orientation={isPortrait ? 'vertical' : 'horizontal'} sx={{ opacity: 0.35 }} />
                     <Tooltip
-                      title={cellposeAvailable ? `Full Image Segmentation: ${AI_BACKEND_DESCRIPTION}` : 'Full Image Segmentation unavailable (cellpose service is offline)'}
+                      title={segmentationUnavailable ? 'Segmentation services are currently unavailable' : `Full Image Segmentation: ${AI_BACKEND_DESCRIPTION}`}
                       placement={tooltipPlacement}
                     >
                       <span>
@@ -205,12 +209,12 @@ const ToolBar: React.FC<ToolBarProps> = ({
                           size={btnSize}
                           data-tool="cellpose"
                           onClick={onOpenCellposeConfig}
-                          disabled={isRunningCellpose || !cellposeAvailable}
+                          disabled={isRunningCellpose || segmentationUnavailable}
                           aria-label="Full Image Segmentation"
                           sx={{
                             ...floatingBtnSx(cellposeConfigOpen),
                             flexShrink: 0,
-                            ...aiTintSx(cellposeConfigOpen, !cellposeAvailable),
+                            ...aiTintSx(cellposeConfigOpen, segmentationUnavailable),
                             color: cellposeConfigOpen ? 'secondary.main' : undefined,
                             ...touchSx,
                           }}
@@ -330,14 +334,14 @@ const ToolBar: React.FC<ToolBarProps> = ({
                   <>
                     <Divider sx={{ my: 0.4, opacity: 0.5 }} />
                     <Tooltip
-                      title={cellposeAvailable ? '' : 'Cellpose service is currently offline'}
+                      title={segmentationUnavailable ? 'Segmentation services are currently unavailable' : ''}
                       placement="right"
-                      disableHoverListener={cellposeAvailable}
+                      disableHoverListener={!segmentationUnavailable}
                     >
                       <span style={{ width: '100%' }}>
                         <ButtonBase
                           onClick={onOpenCellposeConfig}
-                          disabled={isRunningCellpose || !cellposeAvailable}
+                          disabled={isRunningCellpose || segmentationUnavailable}
                           data-tool="cellpose"
                           aria-label="Full Image Segmentation"
                           sx={{
@@ -348,7 +352,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
                             '&:hover': { bgcolor: cellposeConfigOpen ? 'rgba(156,39,176,0.18)' : 'rgba(156,39,176,0.11)' },
                             transition: 'background-color 140ms ease, transform 140ms cubic-bezier(0.23, 1, 0.32, 1)',
                             '&:active': { transform: 'scale(0.98)' },
-                            opacity: (isRunningCellpose || !cellposeAvailable) ? 0.5 : 1,
+                            opacity: (isRunningCellpose || segmentationUnavailable) ? 0.5 : 1,
                             minHeight: isCompact ? 48 : undefined,
                             touchAction: 'manipulation',
                             ...reducedMotionSx,
@@ -364,7 +368,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
                             </Typography>
                             <Typography variant="caption" color="text.secondary" display="block"
                               sx={{ fontSize: '0.63rem', lineHeight: 1.3, mt: 0.1 }}>
-                              {cellposeAvailable ? AI_BACKEND_DESCRIPTION : 'Service offline'}
+                              {segmentationUnavailable ? 'Service offline' : AI_BACKEND_DESCRIPTION}
                             </Typography>
                           </Box>
                         </ButtonBase>

--- a/src/components/annotate/floatingPanelStyles.tsx
+++ b/src/components/annotate/floatingPanelStyles.tsx
@@ -2,15 +2,13 @@ import React from 'react';
 import { Box } from '@mui/material';
 
 // Shared visual language for the annotate page's floating panels (tools,
-// actions): blur-backed translucent card, transform/opacity-only
-// transitions, and press feedback via scale (emil-design-eng guidance).
+// actions): opaque card, transform/opacity-only transitions, and press
+// feedback via scale (emil-design-eng guidance).
 
 export const FLOAT_EASE_OUT = 'cubic-bezier(0.23, 1, 0.32, 1)';
 
 export const floatingPanelSx = {
-  background: 'rgba(255,255,255,0.82)',
-  backdropFilter: 'blur(14px)',
-  WebkitBackdropFilter: 'blur(14px)',
+  background: '#ffffff',
   border: '1px solid rgba(255,255,255,0.6)',
   borderRadius: 3,
   boxShadow: '0 4px 24px rgba(15,23,42,0.16)',

--- a/src/components/annotate/hooks/useHyphaService.ts
+++ b/src/components/annotate/hooks/useHyphaService.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { hyphaWebsocketClient } from 'hypha-rpc';
 import { resolveCellpose4RunnerService, pollCellpose4Infer, CELLPOSE4_RUNNER_MODEL_ID } from '../../../utils/cellpose4RunnerService';
 import { resolveMicroSamService, MICRO_SAM_MODEL_TYPE } from '../../../utils/microSamService';
@@ -501,6 +501,8 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
   microSamAvailable: boolean;
   /** Tear down and re-run the connect flow from scratch (same config). */
   retry: () => void;
+  /** Re-check cellpose4-runner and micro-sam reachability without reconnecting. */
+  probeAvailability: () => void;
 } {
   const [service, setService] = useState<AnnotationDataService | null>(null);
   const [loading, setLoading] = useState(true);
@@ -1001,5 +1003,20 @@ export function useHyphaService(config: AnnotationServiceConfig | null): {
 
   const retry = () => setRetryNonce((n) => n + 1);
 
-  return { service, loading, error, cellposeAvailable, microSamAvailable, retry };
+  // Cheap re-check of both services (one websocket round-trip each) without
+  // tearing down the connection -- used when a dialog that offers a choice
+  // between them opens, since a service that was down at page load may have
+  // recovered (or vice versa) by then.
+  const probeAvailability = useCallback(() => {
+    const server = serverRef.current;
+    if (!server) return;
+    resolveCellpose4RunnerService(server)
+      .then(() => setCellposeAvailable(true))
+      .catch(() => setCellposeAvailable(false));
+    resolveMicroSamService(server)
+      .then(() => setMicroSamAvailable(true))
+      .catch(() => setMicroSamAvailable(false));
+  }, []);
+
+  return { service, loading, error, cellposeAvailable, microSamAvailable, retry, probeAvailability };
 }

--- a/src/components/colab/ExportModelDialog.tsx
+++ b/src/components/colab/ExportModelDialog.tsx
@@ -1,0 +1,396 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { resolvePinnedMicroSamTrainingService } from '../../utils/microSamTrainingPin';
+import { buildReviewerPermissions } from '../../utils/roles';
+import { Spinner } from './Finetune';
+
+export interface ExportModelDialogProps {
+  open: boolean;
+  onClose: () => void;
+  server: any;
+  artifactManager: any;
+  user: any;
+  datasetArtifactId: string;
+  annotationLabel: string;
+  session: { session_id: string; model_type?: string };
+  splitName: string;
+  existingCheckpoint: { session_id: string; model_type: string; [key: string]: any };
+  onExported: (exportedModelId: string) => void;
+}
+
+interface AuthorRow {
+  name: string;
+  affiliation: string;
+}
+
+type Phase = 'form' | 'building' | 'creating' | 'pushing' | 'done' | 'error';
+
+type ExportStatus = {
+  status: 'PENDING' | 'BUILDING' | 'READY' | 'FAILED';
+  progress?: number;
+  message?: string;
+  download_url?: string;
+  size_bytes?: number;
+  files?: { name: string; size: number }[];
+  error?: string;
+};
+
+const findEmoji = (config: any, type: string, name: string): string => {
+  const category = type === 'model' ? 'animal' : type === 'application' ? 'object' : type === 'dataset' ? 'fruit' : null;
+  if (!category || !config?.id_parts?.[category]) return '🦒';
+  const names = config.id_parts[category];
+  const emojis = config.id_parts[`${category}_emoji`];
+  const index = names.indexOf(name);
+  return index >= 0 ? emojis[index] : '🦒';
+};
+
+const extractNounFromId = (id: string): string => {
+  const parts = id.split('-');
+  return parts[parts.length - 1];
+};
+
+const ExportModelDialog: React.FC<ExportModelDialogProps> = ({
+  open,
+  onClose,
+  server,
+  artifactManager,
+  user,
+  datasetArtifactId,
+  annotationLabel,
+  session,
+  splitName,
+  existingCheckpoint,
+  onExported,
+}) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [license, setLicense] = useState('CC-BY-4.0');
+  const [authors, setAuthors] = useState<AuthorRow[]>([{ name: user?.email || '', affiliation: '' }]);
+
+  const [phase, setPhase] = useState<Phase>('form');
+  const [statusMessage, setStatusMessage] = useState('');
+  const [exportStatus, setExportStatus] = useState<ExportStatus | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [artifactId, setArtifactId] = useState<string | null>(null);
+
+  const abortRef = useRef<{ aborted: boolean }>({ aborted: false });
+
+  useEffect(() => {
+    return () => {
+      abortRef.current.aborted = true;
+    };
+  }, []);
+
+  if (!open) return null;
+
+  const handleClose = () => {
+    if (phase !== 'form' && phase !== 'done' && phase !== 'error') return;
+    abortRef.current.aborted = true;
+    onClose();
+  };
+
+  const runExport = async () => {
+    abortRef.current = { aborted: false };
+    const localAbort = abortRef.current;
+    setErrorMessage('');
+
+    try {
+      setPhase('building');
+      setStatusMessage('Requesting export...');
+      const svc = await resolvePinnedMicroSamTrainingService(server);
+      const { export_id } = await svc.export_model({
+        session_id: session.session_id,
+        name,
+        description,
+        authors: authors.filter((a) => a.name.trim().length > 0),
+        license,
+        provenance: {
+          dataset_artifact_id: datasetArtifactId,
+          label: annotationLabel,
+          split_name: splitName,
+          session_lineage: [session.session_id],
+        },
+        _rkwargs: true,
+      });
+
+      setStatusMessage('Building package... (usually about 20 seconds)');
+      let finalStatus: ExportStatus | null = null;
+      while (!localAbort.aborted) {
+        const status: ExportStatus = await svc.get_export_status({ export_id, _rkwargs: true });
+        if (localAbort.aborted) return;
+        setExportStatus(status);
+        if (status.status === 'READY') {
+          finalStatus = status;
+          break;
+        }
+        if (status.status === 'FAILED') {
+          throw new Error(status.error || status.message || 'Export failed while building the package.');
+        }
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+      }
+      if (localAbort.aborted || !finalStatus) return;
+
+      setPhase('creating');
+      setStatusMessage('Creating the model artifact...');
+      const collection = await artifactManager.read({ artifact_id: 'bioimage-io/bioimage.io', _rkwargs: true });
+      const reviewerPermissions = buildReviewerPermissions(collection?.config, undefined);
+
+      const manifest = {
+        type: 'model',
+        name,
+        description,
+        authors: authors.filter((a) => a.name.trim().length > 0),
+        license,
+        tags: ['micro-sam', 'prompt-free', 'instance-segmentation'],
+        uploader: { email: user?.email },
+      };
+
+      const artifact = await artifactManager.create({
+        parent_id: 'bioimage-io/bioimage.io',
+        alias: '{animal_adjective}-{animal}',
+        type: 'model',
+        manifest,
+        config: { publish_to: 'sandbox_zenodo', permissions: reviewerPermissions },
+        stage: true,
+        _rkwargs: true,
+        overwrite: true,
+      });
+
+      const shortId = artifact.id.split('/').pop() || '';
+      const noun = extractNounFromId(shortId);
+      const emoji = findEmoji(collection.config, 'model', noun);
+      const updatedManifest = { ...manifest, id: shortId, id_emoji: emoji, status: 'draft' };
+      await artifactManager.edit({ artifact_id: artifact.id, manifest: updatedManifest, stage: true, _rkwargs: true });
+      setArtifactId(artifact.id);
+
+      if (localAbort.aborted) return;
+      setPhase('pushing');
+      setStatusMessage('Uploading model files...');
+      const filesMap: Record<string, string> = {};
+      for (const f of finalStatus.files || []) {
+        const putUrl = await artifactManager.put_file({ artifact_id: artifact.id, file_path: f.name, _rkwargs: true });
+        filesMap[f.name] = putUrl;
+      }
+      await svc.push_export({ export_id, files: filesMap, _rkwargs: true });
+
+      if (localAbort.aborted) return;
+      onExported(artifact.id);
+      setPhase('done');
+    } catch (err) {
+      if (localAbort.aborted) return;
+      setErrorMessage((err as Error).message || 'Export failed.');
+      setPhase('error');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50" onClick={handleClose}>
+      <div
+        className="bg-white rounded-2xl shadow-lg max-w-lg w-full mx-4 max-h-[85vh] flex flex-col animate-scaleIn"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="p-5 border-b border-gray-200 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-gray-900">Export as model</h2>
+          {(phase === 'form' || phase === 'done' || phase === 'error') && (
+            <button onClick={handleClose} className="text-gray-400 hover:text-gray-600 transition-colors">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        <div className="p-5 overflow-y-auto space-y-4">
+          {phase === 'form' && (
+            <>
+              <div className="p-3 bg-purple-50 border border-purple-200 rounded-lg text-xs text-purple-800 space-y-1">
+                <p>
+                  The exported model outputs the three AIS (automatic instance segmentation) maps and runs
+                  prompt-free in the Model Zoo.
+                </p>
+                <p>Instance labels come from micro-sam's watershed postprocessing on those maps.</p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1.5">Model name</label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g. My Cell Segmentation Model"
+                  className="w-full px-3.5 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1.5">Description (optional)</label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={3}
+                  className="w-full px-3.5 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <label className="block text-sm font-medium text-gray-700">Authors</label>
+                  <button
+                    type="button"
+                    onClick={() => setAuthors((prev) => [...prev, { name: '', affiliation: '' }])}
+                    className="px-2.5 py-1 text-xs font-medium text-purple-700 bg-purple-50 border border-purple-200 rounded-md hover:bg-purple-100 transition-colors active:scale-[0.97]"
+                  >
+                    Add author
+                  </button>
+                </div>
+                {authors.map((author, index) => (
+                  <div key={`author-${index}`} className="grid grid-cols-1 md:grid-cols-12 gap-2">
+                    <input
+                      type="text"
+                      value={author.name}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setAuthors((prev) => prev.map((a, i) => (i === index ? { ...a, name: value } : a)));
+                      }}
+                      placeholder="Author name"
+                      className="md:col-span-5 px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                    />
+                    <input
+                      type="text"
+                      value={author.affiliation}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        setAuthors((prev) => prev.map((a, i) => (i === index ? { ...a, affiliation: value } : a)));
+                      }}
+                      placeholder="Affiliation (optional)"
+                      className="md:col-span-6 px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                    />
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setAuthors((prev) => (prev.length === 1 ? [{ name: '', affiliation: '' }] : prev.filter((_, i) => i !== index)))
+                      }
+                      className="md:col-span-1 px-2 py-1.5 text-xs font-medium text-red-700 bg-red-50 border border-red-200 rounded-lg hover:bg-red-100 transition-colors"
+                      aria-label={`Remove author ${index + 1}`}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                ))}
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1.5">License</label>
+                <input
+                  type="text"
+                  value={license}
+                  onChange={(e) => setLicense(e.target.value)}
+                  className="w-full px-3.5 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+                />
+              </div>
+            </>
+          )}
+
+          {(phase === 'building' || phase === 'creating' || phase === 'pushing') && (
+            <div className="flex flex-col items-center justify-center py-10 text-center">
+              <Spinner className="w-8 h-8 text-purple-600 mb-4" />
+              <p className="text-sm text-gray-700 font-medium">{statusMessage}</p>
+              {phase === 'building' && exportStatus?.progress != null && (
+                <div className="w-full max-w-xs mt-4 bg-gray-100 rounded-full h-1.5 overflow-hidden">
+                  <div
+                    className="h-1.5 bg-purple-600 transition-[width] duration-200 ease-out"
+                    style={{ width: `${Math.min(100, Math.round(exportStatus.progress * 100))}%` }}
+                  />
+                </div>
+              )}
+              {phase === 'building' && exportStatus?.message && (
+                <p className="text-xs text-gray-400 mt-2">{exportStatus.message}</p>
+              )}
+            </div>
+          )}
+
+          {phase === 'error' && (
+            <div className="space-y-3">
+              <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-600">{errorMessage}</div>
+              <button
+                type="button"
+                onClick={() => setPhase('form')}
+                className="px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors active:scale-[0.97]"
+              >
+                Try again
+              </button>
+            </div>
+          )}
+
+          {phase === 'done' && artifactId && (
+            <div className="space-y-4">
+              <div className="p-3 bg-emerald-50 border border-emerald-200 rounded-lg text-sm text-emerald-700">
+                Model exported and staged for review.
+              </div>
+              <div className="flex flex-col gap-2">
+                <Link
+                  to={`/edit/${encodeURIComponent(artifactId)}/stage`}
+                  className="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm font-medium text-center hover:bg-purple-700 transition-colors active:scale-[0.97]"
+                >
+                  Open artifact page
+                </Link>
+                <Link
+                  to="/my-artifacts"
+                  className="px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-medium text-gray-700 text-center hover:bg-gray-50 transition-colors active:scale-[0.97]"
+                >
+                  View in My Artifacts
+                </Link>
+                {exportStatus?.download_url && (
+                  <a
+                    href={exportStatus.download_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-medium text-gray-700 text-center hover:bg-gray-50 transition-colors active:scale-[0.97]"
+                  >
+                    Download package
+                  </a>
+                )}
+                {exportStatus?.download_url && (
+                  <p className="text-xs text-gray-400 text-center">(download link expires in 6 hours)</p>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="p-5 border-t border-gray-200 flex items-center justify-end gap-2">
+          {phase === 'form' && (
+            <>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-800 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={runExport}
+                disabled={name.trim().length === 0}
+                className="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm font-medium hover:bg-purple-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors active:scale-[0.97]"
+              >
+                Export as model
+              </button>
+            </>
+          )}
+          {phase === 'done' && (
+            <button
+              type="button"
+              onClick={handleClose}
+              className="px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors active:scale-[0.97]"
+            >
+              Close
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ExportModelDialog;

--- a/src/components/colab/Finetune.tsx
+++ b/src/components/colab/Finetune.tsx
@@ -7,9 +7,12 @@ import {
   BrokerRole,
   DatasetWithRole,
   getDataset,
+  listSplits,
+  setSplitCheckpoint,
 } from './brokerApi';
 import { resolvePinnedMicroSamTrainingService } from '../../utils/microSamTrainingPin';
 import LoginButton from '../LoginButton';
+import ExportModelDialog from './ExportModelDialog';
 
 export interface FinetuneProps {
   artifactId: string;
@@ -21,7 +24,7 @@ export interface FinetuneProps {
 
 type TrainingStatusValue = 'PREPARING' | 'TRAINING' | 'COMPLETED' | 'FAILED' | 'STOPPED' | 'UNKNOWN';
 
-interface TrainingSessionStatus {
+export interface TrainingSessionStatus {
   session_id: string;
   status: TrainingStatusValue;
   message?: string;
@@ -60,7 +63,7 @@ const formatUnixTime = (seconds?: number): string => {
   return new Date(seconds * 1000).toLocaleString();
 };
 
-const Spinner: React.FC<{ className?: string }> = ({ className = 'w-8 h-8 text-purple-600' }) => (
+export const Spinner: React.FC<{ className?: string }> = ({ className = 'w-8 h-8 text-purple-600' }) => (
   <svg className={`animate-spin ${className}`} fill="none" viewBox="0 0 24 24">
     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
     <path
@@ -81,7 +84,7 @@ const sessionTag = (alias: string, annotationLabel: string) => `${alias}/${annot
 
 // Training runs are started from a dataset's finetune view now
 // (colab-rework-plan.md §23.2); this page is monitoring-only.
-const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, user }) => {
+const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, user, artifactManager }) => {
   const navigate = useNavigate();
 
   const [dataset, setDataset] = useState<DatasetWithRole | null>(null);
@@ -93,6 +96,39 @@ const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, 
   const [sessionsError, setSessionsError] = useState<string | null>(null);
   const [stoppingSessionId, setStoppingSessionId] = useState<string | null>(null);
   const [confirmStopId, setConfirmStopId] = useState<string | null>(null);
+
+  const [exportTarget, setExportTarget] = useState<{
+    session: TrainingSessionStatus;
+    annotationLabel: string;
+    splitName: string;
+    checkpoint: { session_id: string; model_type: string; [key: string]: any };
+  } | null>(null);
+  const [exportResolveError, setExportResolveError] = useState<{ sessionId: string; message: string } | null>(null);
+  const [resolvingExportSessionId, setResolvingExportSessionId] = useState<string | null>(null);
+
+  const handleOpenExport = async (s: TrainingSessionStatus, annotationLabel: string) => {
+    setExportResolveError(null);
+    setResolvingExportSessionId(s.session_id);
+    try {
+      const splits = await listSplits(server, artifactId, annotationLabel);
+      const owner = splits.find((sp) => sp.checkpoint?.session_id === s.session_id);
+      if (!owner || !owner.checkpoint) {
+        setExportResolveError({
+          sessionId: s.session_id,
+          message: 'Could not determine the training split for this session, export is unavailable.',
+        });
+        return;
+      }
+      setExportTarget({ session: s, annotationLabel, splitName: owner.name, checkpoint: owner.checkpoint });
+    } catch (err) {
+      setExportResolveError({
+        sessionId: s.session_id,
+        message: (err as Error).message || 'Failed to resolve the training split for this session.',
+      });
+    } finally {
+      setResolvingExportSessionId(null);
+    }
+  };
 
   const role: BrokerRole | undefined = dataset?.role;
   const canManage = role === 'owner' || role === 'manager';
@@ -358,7 +394,7 @@ const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, 
                   </p>
                 )}
                 {s.checkpoint_available && annotationLabel && s.model_type && (
-                  <div className="mt-3 pt-3 border-t border-gray-100">
+                  <div className="mt-3 pt-3 border-t border-gray-100 flex items-center gap-2 flex-wrap">
                     <button
                       type="button"
                       onClick={() =>
@@ -373,13 +409,46 @@ const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, 
                     >
                       Use for annotation
                     </button>
+                    {s.status === 'COMPLETED' && (
+                      <button
+                        type="button"
+                        onClick={() => handleOpenExport(s, annotationLabel)}
+                        disabled={resolvingExportSessionId === s.session_id}
+                        className="px-3 py-1.5 bg-white border border-gray-200 rounded-md text-xs font-medium text-gray-700 hover:border-purple-300 hover:bg-purple-50 hover:text-purple-700 transition-colors disabled:opacity-50"
+                      >
+                        {resolvingExportSessionId === s.session_id ? 'Resolving split...' : 'Export as model'}
+                      </button>
+                    )}
                   </div>
+                )}
+                {exportResolveError?.sessionId === s.session_id && (
+                  <div className="mt-2 text-xs text-red-600">{exportResolveError.message}</div>
                 )}
               </div>
             );
           })}
         </div>
       </div>
+      {exportTarget && (
+        <ExportModelDialog
+          open
+          onClose={() => setExportTarget(null)}
+          server={server}
+          artifactManager={artifactManager}
+          user={user}
+          datasetArtifactId={artifactId}
+          annotationLabel={exportTarget.annotationLabel}
+          session={exportTarget.session}
+          splitName={exportTarget.splitName}
+          existingCheckpoint={exportTarget.checkpoint}
+          onExported={async (exportedModelId) => {
+            await setSplitCheckpoint(server, artifactId, exportTarget.annotationLabel, exportTarget.splitName, {
+              ...exportTarget.checkpoint,
+              exported_model_id: exportedModelId,
+            });
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/AnnotatePage.tsx
+++ b/src/pages/AnnotatePage.tsx
@@ -1529,7 +1529,7 @@ print("CLAHE_RESULT:" + result_b64)
       {/* Floating header bar (Google-Maps-like: spans full width, overlays the
           fullscreen viewer rather than pushing it down) */}
       <div
-        className="flex items-center justify-between px-3 bg-gradient-to-r from-blue-100/90 via-purple-100/85 to-cyan-100/90 backdrop-blur-lg border-b border-blue-200/40 shadow-sm"
+        className="flex items-center justify-between px-3 bg-gradient-to-r from-blue-100 via-purple-100 to-cyan-100 border-b border-blue-200/40 shadow-sm"
         style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 1200, height: isMobile ? 48 : 40 }}
       >
         <div className="flex items-center gap-2 z-10 flex-shrink-0">
@@ -1545,7 +1545,7 @@ print("CLAHE_RESULT:" + result_b64)
                   padding: isMobile ? '5px 8px' : '3px 10px',
                   color: '#1976d2',
                   borderColor: 'rgba(25,118,210,0.45)',
-                  bgcolor: 'rgba(255,255,255,0.7)',
+                  bgcolor: '#ffffff',
                   fontSize: '0.75rem',
                   fontWeight: 600,
                   textTransform: 'none',

--- a/src/pages/AnnotatePage.tsx
+++ b/src/pages/AnnotatePage.tsx
@@ -108,7 +108,7 @@ const AnnotatePage: React.FC<AnnotatePageProps> = ({ backTo }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm')); // < 600px
 
-  const { service, loading: serviceLoading, error: serviceError, cellposeAvailable, microSamAvailable, retry: retryService } = useHyphaService(serviceConfig);
+  const { service, loading: serviceLoading, error: serviceError, cellposeAvailable, microSamAvailable, retry: retryService, probeAvailability } = useHyphaService(serviceConfig);
   const { banners, addBanner, removeBanner } = useBanners();
   const runCellposeRef = React.useRef<(config: CellposeConfig) => void>(() => {});
   const instantConfigChangeRef = React.useRef<(config: CellposeConfig) => void>(() => {});
@@ -134,7 +134,7 @@ const AnnotatePage: React.FC<AnnotatePageProps> = ({ backTo }) => {
   // from the dialog's Cancel button is always safe.
   const cellposeAbortRef = useRef<AbortController | null>(null);
 
-  const { config: cellposeConfig, setConfig: setCellposeConfig, openDialog: openCellposeConfig, dialogOpen: cellposeConfigOpen, dialogElement: cellposeDialogElement } = useCellposeConfig({
+  const { config: cellposeConfig, setConfig: setCellposeConfig, openDialog: openCellposeConfig, closeDialog: closeCellposeConfig, dialogOpen: cellposeConfigOpen, dialogElement: cellposeDialogElement } = useCellposeConfig({
     onRun: (config) => runCellposeRef.current(config),
     isRunning: isRunningCellpose,
     // The flows + Pyodide path keeps the dialog open so the instant sliders
@@ -144,6 +144,8 @@ const AnnotatePage: React.FC<AnnotatePageProps> = ({ backTo }) => {
     resultReady: hasCellposeResult,
     completedRunId: cellposeCompletedRunId,
     microSamAvailable,
+    cellposeAvailable,
+    onDialogOpen: probeAvailability,
     claheActive: isCLAHEActive,
     onInstantConfigChange: (config) => instantConfigChangeRef.current(config),
     onCancelRun: () => cellposeAbortRef.current?.abort(),
@@ -1004,6 +1006,10 @@ print('CLAHE packages ready')
             console.log('[AnnotatePage] micro-sam added', n, 'masks');
             addBanner(`Added ${n} mask${n !== 1 ? 's' : ''} from μSAM`, 'success', 5000);
           }
+          // μSAM has no tunable sliders, so there's nothing left to do in the
+          // dialog once a run completes: masks are already applied above, so
+          // close it the same way the Done button would (apply, then close).
+          closeCellposeConfig();
         } catch (msErr: any) {
           removeBanner(bannerId);
           const msg = msErr?.message || 'Unknown error';
@@ -1090,6 +1096,7 @@ print('CLAHE packages ready')
     cellposeConfig, isCLAHEActive, claheEnhancedUrl, kernelReady, currentImageStem,
     ensureStoredEmbedding, runCellposeFlowsPipeline, applyPolygonsAsPreview,
     getVectorSource, pushUndo, addBanner, removeBanner, deriveCellposeSource,
+    closeCellposeConfig,
   ]);
 
   // Re-run mask gen using the cached flows on every instant-config drag.


### PR DESCRIPTION
## Motivation

A completed fine-tuning session in the colab finetune view produced a servable checkpoint, but there was no way to turn it into a bioimage.io model from the UI. In the annotate view, the floating panels used a translucent, blurred surface that read as dim against the dark canvas, and the Full Image Segmentation dialog had no handling for a segmentation backend being unreachable.

## Changes

**Model export (`ExportModelDialog.tsx`, `Finetune.tsx`)**
- New "Export as model" action beside "Use for annotation" on completed sessions with an available checkpoint. The dialog collects name, description, authors, and license, then drives the micro-sam export bridge: `export_model`, polls `get_export_status` with a progress bar, creates a staged model artifact in `bioimage-io/bioimage.io` with the user's own token, mints `put_file` URLs for every package member, and hands them to `push_export` so weights stream server-side without passing through the browser.
- Training provenance (dataset, label, split, session lineage) is baked into the packaged RDF, and the split checkpoint records the exported model id.
- The success state links to the staged artifact page, My Artifacts, and a 6 hour download URL.

**Annotate view polish and resilience**
- Floating panels (Annotation Tools, Actions, header bar) are now fully opaque: solid white surface, no backdrop blur, shadows and borders unchanged.
- The Full Image Segmentation dialog's model selector reflects live reachability of both backends: an unavailable backend disables and labels itself "(unavailable)", the selection auto-switches away from an unavailable backend, and a fresh probe fires each time the dialog opens. When both backends are down, the run buttons disable inline with an explanatory caption and the toolbar entry disables with a tooltip. This also fixes a pre-existing bug where the toolbar entry disabled on Cellpose-SAM availability alone, ignoring the μSAM backend entirely.
- After a μSAM run completes, the dialog closes automatically (masks are already applied; there are no tunable sliders). Cellpose-SAM runs keep the dialog open: the Cancel button becomes Done, Refine Results expands, and Compute Flow Field collapses so the threshold sliders are immediately at hand.

## Test plan

- Full export chain driven through the real UI via Playwright against the deployed BioEngine: form to staged draft with correct manifest, files, provenance, and split-checkpoint update; the exported package was then executed by model id on the micro-sam app and returned instance masks. The test draft was removed afterwards.
- Opaque panels verified via computed styles (opaque surface, no backdrop filter) and screenshots.
- Availability states verified live: both backends up (μSAM default, both selectable), μSAM down (auto-switch to Cellpose-SAM, disabled option), both down (toolbar entry disabled).
- Completion behavior verified with real runs of both backends; `tsc --noEmit` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
