### PR TITLE
feat(annotate): warn on images below the 256 px segmentation floor

### DIFF
--- a/src/components/annotate/ActionPanel.tsx
+++ b/src/components/annotate/ActionPanel.tsx
@@ -25,6 +25,7 @@ import { useAnnotationStore } from '../../store/annotationStore';
 import { useResponsiveLayout } from './hooks/useResponsiveLayout';
 import { usePanelExpansion } from './hooks/usePanelExpansion';
 import { floatingPanelSx, floatingBtnSx, reducedMotionSx, iconSlotSx } from './floatingPanelStyles';
+import { isSmallImageDims, SMALL_IMAGE_WARNING_TEXT } from '../../utils/imageSize';
 
 export interface ActionPanelProps {
   onSave: () => void;
@@ -54,6 +55,7 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
   const canUndo = useAnnotationStore((s) => s.canUndo);
   const imageWidth = useAnnotationStore((s) => s.imageWidth);
   const imageHeight = useAnnotationStore((s) => s.imageHeight);
+  const isSmallImage = isSmallImageDims(imageWidth, imageHeight);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const { isPortrait, isCompact } = useResponsiveLayout();
@@ -243,9 +245,16 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
           <Divider flexItem orientation={isPortrait ? 'vertical' : 'horizontal'} sx={{ opacity: 0.35 }} />
 
           {/* Help */}
-          <Tooltip title={`${imageName || 'No image'} (${imageWidth}×${imageHeight} px)`} placement={tooltipPlacement}>
+          <Tooltip
+            title={
+              isSmallImage
+                ? `${imageName || 'No image'} (${imageWidth}×${imageHeight} px). ${SMALL_IMAGE_WARNING_TEXT}`
+                : `${imageName || 'No image'} (${imageWidth}×${imageHeight} px)`
+            }
+            placement={tooltipPlacement}
+          >
             <IconButton size={btnSize} data-tool="info" aria-label="Image info"
-              sx={{ ...floatingBtnSx(), flexShrink: 0, ...touchSx }}>
+              sx={{ ...floatingBtnSx(), flexShrink: 0, ...(isSmallImage ? { color: 'warning.main' } : {}), ...touchSx }}>
               <InfoIcon fontSize="small" />
             </IconButton>
           </Tooltip>
@@ -477,9 +486,16 @@ const ActionPanel: React.FC<ActionPanelProps> = ({
 
           {(imageName || (imageWidth && imageHeight)) && (
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 1, py: 0.4 }}>
-              <InfoIcon sx={{ fontSize: '0.85rem', color: 'text.disabled' }} aria-hidden="true" />
-              <Typography variant="caption" color="text.disabled" sx={{ fontSize: '0.6rem' }} noWrap>
+              <InfoIcon sx={{ fontSize: '0.85rem', color: isSmallImage ? 'warning.main' : 'text.disabled' }} aria-hidden="true" />
+              <Typography variant="caption" color={isSmallImage ? 'warning.main' : 'text.disabled'} sx={{ fontSize: '0.6rem' }} noWrap>
                 {imageName}{imageWidth && imageHeight ? ` (${imageWidth}×${imageHeight} px)` : ''}
+              </Typography>
+            </Box>
+          )}
+          {isSmallImage && (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, px: 1, pb: 0.4 }}>
+              <Typography variant="caption" color="warning.main" sx={{ fontSize: '0.58rem', lineHeight: 1.3 }}>
+                {SMALL_IMAGE_WARNING_TEXT}
               </Typography>
             </Box>
           )}

--- a/src/components/colab/CreateDatasetModal.tsx
+++ b/src/components/colab/CreateDatasetModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { COLLECTION_ID } from './datasetApi';
 import { registerDataset } from './brokerApi';
+import { isSmallImageDims, readImageDimensions } from '../../utils/imageSize';
 
 export interface CreateDatasetModalProps {
   server: any;
@@ -47,6 +48,7 @@ const CreateDatasetModal: React.FC<CreateDatasetModalProps> = ({
   const [description, setDescription] = useState('');
   const [folderHandle, setFolderHandle] = useState<any>(null);
   const [fileCount, setFileCount] = useState(0);
+  const [smallImageCount, setSmallImageCount] = useState(0);
   const [step, setStep] = useState<'configure' | 'creating'>('configure');
   const [error, setError] = useState<string | null>(null);
 
@@ -57,19 +59,40 @@ const CreateDatasetModal: React.FC<CreateDatasetModalProps> = ({
       if (!name.trim()) setName(dirHandle.name);
 
       let count = 0;
+      const imageHandles: any[] = [];
       for await (const entry of dirHandle.values()) {
         if (entry.kind === 'file') {
           const ext = entry.name.slice(entry.name.lastIndexOf('.')).toLowerCase();
-          if (SUPPORTED_EXTENSIONS.includes(ext)) count += 1;
+          if (SUPPORTED_EXTENSIONS.includes(ext)) {
+            count += 1;
+            imageHandles.push(entry);
+          }
         }
       }
       setFileCount(count);
+      setSmallImageCount(0);
       setError(null);
+
+      // Dims are free client-side at this point (the handles are already
+      // in hand), but decoding every picked file can take a moment for a
+      // large folder, so this scan runs in the background instead of
+      // gating folder selection or the Create button.
+      scanForSmallImages(imageHandles);
     } catch (err) {
       if ((err as Error).name !== 'AbortError') {
         setError(`Failed to select folder: ${(err as Error).message}`);
       }
     }
+  };
+
+  const scanForSmallImages = async (fileHandles: any[]) => {
+    let small = 0;
+    for (const handle of fileHandles) {
+      const file = await handle.getFile();
+      const dims = await readImageDimensions(file);
+      if (dims && isSmallImageDims(dims.width, dims.height)) small += 1;
+    }
+    setSmallImageCount(small);
   };
 
   const createDataset = async (): Promise<string> => {
@@ -181,6 +204,11 @@ const CreateDatasetModal: React.FC<CreateDatasetModalProps> = ({
                 <p className="text-xs text-gray-500 mt-1.5">
                   Images are not uploaded now. You can upload them, one at a time or all at once, from the dataset page.
                 </p>
+                {smallImageCount > 0 && (
+                  <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-1.5 mt-1.5">
+                    {smallImageCount} image{smallImageCount === 1 ? ' is' : 's are'} below 256 px on a side. AI segmentation quality may be reduced for {smallImageCount === 1 ? 'it' : 'those'}.
+                  </p>
+                )}
               </div>
 
               {error && (

--- a/src/components/colab/DatasetOverview.tsx
+++ b/src/components/colab/DatasetOverview.tsx
@@ -40,6 +40,7 @@ import {
   updateSplit,
 } from './brokerApi';
 import { resolvePinnedMicroSamTrainingService } from '../../utils/microSamTrainingPin';
+import { isSmallImageDims, readImageDimensions } from '../../utils/imageSize';
 import LabelManager from './LabelManager';
 import FinetuneView from './FinetuneView';
 import AnnotationStatsView from './AnnotationStatsView';
@@ -185,6 +186,9 @@ const DatasetOverview: React.FC<DatasetOverviewProps> = ({
   const [uploadingStems, setUploadingStems] = useState<Set<string>>(new Set());
   const [mounting, setMounting] = useState(false);
   const [folderMounted, setFolderMounted] = useState(false);
+  // Round-31: non-blocking count of picked local images under 256px on a
+  // side, from a background dims scan of the mounted folder handle.
+  const [smallImageCount, setSmallImageCount] = useState(0);
   // colab-rework-plan.md §14 item 9: a folder picked before the kernel has
   // finished starting is queued here instead of erroring, and mounted
   // automatically once executeCode/mountDirectory become available.
@@ -681,6 +685,28 @@ const DatasetOverview: React.FC<DatasetOverviewProps> = ({
     }
   }, [server, artifactId, selectedLabel, currentPair]);
 
+  // Round-31: dims are free client-side from a picked FileSystemDirectoryHandle
+  // (no Python/Pyodide round trip needed), so this scans in the background
+  // whenever a folder is mounted and just counts how many images are under
+  // the 256px floor. Non-blocking by design, runs alongside mountLocalFolder
+  // rather than gating it.
+  const scanFolderForSmallImages = useCallback(async (dirHandle: any) => {
+    let small = 0;
+    try {
+      for await (const entry of dirHandle.values()) {
+        if (entry.kind !== 'file') continue;
+        const ext = entry.name.slice(entry.name.lastIndexOf('.')).toLowerCase();
+        if (!['.png', '.jpg', '.jpeg', '.tif', '.tiff'].includes(ext)) continue;
+        const file = await entry.getFile();
+        const dims = await readImageDimensions(file);
+        if (dims && isSmallImageDims(dims.width, dims.height)) small += 1;
+      }
+    } catch {
+      // Advisory scan only, ignore failures.
+    }
+    setSmallImageCount(small);
+  }, []);
+
   // colab-rework-plan.md §11 item 2: mounting a folder never uploads
   // anything by itself, it only registers the Python data-provider service
   // (reused by uploadSingleImage/handleUploadAll below) and lists which
@@ -694,6 +720,8 @@ const DatasetOverview: React.FC<DatasetOverviewProps> = ({
         return;
       }
       setMounting(true);
+      setSmallImageCount(0);
+      scanFolderForSmallImages(dirHandle);
       try {
         let token = localStorage.getItem('token') || '';
         if (!token && typeof server?.generateToken === 'function') {
@@ -762,7 +790,7 @@ print("Service registered successfully", end='')
         setMounting(false);
       }
     },
-    [executeCode, mountDirectory, requestKernel, server, user, artifactId, images],
+    [executeCode, mountDirectory, requestKernel, server, user, artifactId, images, scanFolderForSmallImages],
   );
 
   // Completes a mount that was queued in mountLocalFolder because the kernel
@@ -799,6 +827,7 @@ print("Service registered successfully", end='')
     setUploadingStems(new Set());
     setUploadProgress(null);
     setFolderMounted(false);
+    setSmallImageCount(0);
   };
 
   // Auto-mount the folder handed over from CreateDatasetModal, if any, so
@@ -1509,6 +1538,12 @@ print("Service registered successfully", end='')
           )}
         </div>
       </div>
+
+      {!finetuneViewOpen && smallImageCount > 0 && (
+        <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-1.5 mb-4">
+          {smallImageCount} local image{smallImageCount === 1 ? ' is' : 's are'} below 256 px on a side. AI segmentation quality may be reduced for {smallImageCount === 1 ? 'it' : 'those'}.
+        </p>
+      )}
 
       <div className="grid grid-cols-1 lg:grid-cols-[260px_1fr_320px] gap-4">
         {/* Left: image list */}

--- a/src/utils/imageSize.ts
+++ b/src/utils/imageSize.ts
@@ -1,0 +1,32 @@
+// Round-31 (colab-rework-plan.md, 2026-08-18): the deployed segmentation
+// backend (cellpose4-runner) has a 256x256 input minimum. Since main commit
+// 4e84090 the client upsamples undersized images to that floor so they still
+// work, just with reduced quality. This module is the single place the
+// 256px threshold and its user-facing copy are defined, so the annotate view
+// and the upload/mount flows agree on both.
+
+export const SMALL_IMAGE_DIM_THRESHOLD = 256;
+
+export const SMALL_IMAGE_WARNING_TEXT = 'Below 256 px. AI segmentation quality may be reduced.';
+
+export function isSmallImageDims(width: number, height: number): boolean {
+  return width > 0 && height > 0 && (width < SMALL_IMAGE_DIM_THRESHOLD || height < SMALL_IMAGE_DIM_THRESHOLD);
+}
+
+/**
+ * Decode a picked file's pixel dimensions entirely client-side, for the
+ * upload/mount-time warning scan. Returns null instead of throwing when the
+ * browser can't decode the format (e.g. TIFF has no native codec in Chrome
+ * or Firefox), since this check is advisory and must not block the upload
+ * or mount flow it runs alongside.
+ */
+export async function readImageDimensions(file: File): Promise<{ width: number; height: number } | null> {
+  try {
+    const bitmap = await createImageBitmap(file);
+    const dims = { width: bitmap.width, height: bitmap.height };
+    bitmap.close();
+    return dims;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Motivation

The annotate page's Cellpose backend serves a model with a 256x256 input minimum. Since the client now upsamples undersized images to that floor, small images work but with reduced segmentation quality, and nothing told the user. Images below 256 px on a side should be flagged wherever their dimensions are known, without blocking any workflow.

## Changes

- New `src/utils/imageSize.ts`: single source for the 256 px threshold, the `isSmallImageDims` predicate, the shared warning copy, and a `createImageBitmap`-based `readImageDimensions(file)` helper (returns null for formats the browser cannot decode, e.g. TIFF).
- Annotate view: the size readout in the Actions panel turns amber with a warning icon when the loaded image is below the threshold, with the warning as a caption line in the expanded state and in the tooltip when collapsed.
- Folder pick / mount / upload: picked files are scanned in the background and a non-blocking amber banner reports how many images are under 256 px on a side. The scan never gates Create or Mount.

The dataset-overview image list intentionally shows no per-image badge yet: the dataset index carries no dimensions today. Once the annotation broker adds width/height to its index entries, the list badge can reuse the same predicate.

## Test plan

- Loaded a 200x150 test image in the annotate view: amber readout plus "Below 256 px. AI segmentation quality may be reduced." caption. A 1344x1024 image shows the plain readout with no warning.
- Type-check clean against the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
