### PR TITLE
Hold-to-preview Cellpose-SAM dialog and mount-time kernel request

### DIFF
--- a/src/HyphaContext.tsx
+++ b/src/HyphaContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { HyphaCore } from 'hypha-core';
 // Add WinBox type declaration
 declare global {
@@ -39,8 +39,18 @@ export function HyphaProvider({ children }: { children: React.ReactNode }) {
   const [hyphaCoreAPI, setHyphaCoreAPI] = useState<any | null>(null);
   const [isHyphaCoreReady, setIsHyphaCoreReady] = useState<boolean>(false);
 
+  // Guards against React 18 StrictMode's dev-only double-invoke of this
+  // effect. HyphaCore has no public teardown API and throws "Server already
+  // running" if start() is called a second time for the same URL while the
+  // first instance is still registered, so we skip the second invocation
+  // entirely rather than trying to tear down and recreate it.
+  const hasInitializedRef = useRef(false);
+
   // Initialize hypha-core
   useEffect(() => {
+    if (hasInitializedRef.current) return;
+    hasInitializedRef.current = true;
+
     const initHyphaCore = async () => {
       try {
         // Initialize HyphaCore

--- a/src/components/annotate/CellposeConfigDialog.tsx
+++ b/src/components/annotate/CellposeConfigDialog.tsx
@@ -18,13 +18,14 @@ import {
   Checkbox,
   FormControlLabel,
   Divider,
+  CircularProgress,
 } from '@mui/material';
-import { alpha } from '@mui/material/styles';
 import ListSubheader from '@mui/material/ListSubheader';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import StraightenIcon from '@mui/icons-material/Straighten';
+import VisibilityIcon from '@mui/icons-material/Visibility';
 import InputAdornment from '@mui/material/InputAdornment';
 import { MICRO_SAM_MODEL_TYPE, MICRO_SAM_MODEL_OPTIONS, MICRO_SAM_GROUP_LABELS } from '../../utils/microSamService';
 
@@ -131,9 +132,9 @@ interface CellposeConfigDialogProps {
   onRun?: (config: CellposeConfig) => void;
   isRunning?: boolean;
   /** When true, the parent has already cached (dP, cellprob) for the current
-   *  image and the instant-group sliders re-run mask gen locally in Pyodide.
-   *  In that mode each instant slider drag debounce-fires
-   *  ``onInstantConfigChange`` and the dialog stays open after Run. */
+   *  image, so the "Show preview" hold button and "Done" can re-run mask
+   *  gen locally in Pyodide via ``onShowPreview``. The dialog stays open
+   *  after Run in this mode. */
   livePreviewReady?: boolean;
   /** True once any Cellpose run has returned a result, whether via the
    *  instant local-preview path or a plain server round trip. Drives the
@@ -151,9 +152,11 @@ interface CellposeConfigDialogProps {
    *  first one, so re-running after manually reopening the Run section
    *  still collapses it. */
   completedRunId?: number;
-  /** Fires on every instant-group slider change while ``livePreviewReady``;
-   *  callers are expected to debounce + run compute_masks_np locally. */
-  onInstantConfigChange?: (config: CellposeConfig) => void;
+  /** Runs local Pyodide postprocessing (compute_masks_np) against the cached
+   *  flow field and the given config, repainting the preview. Awaited by the
+   *  dialog's "Show preview" hold button and "Done" button — those are the
+   *  only two triggers for a recompute; slider drags no longer fire this. */
+  onShowPreview?: (config: CellposeConfig) => Promise<void>;
   /** Whether the μSAM backend is reachable. Gates the μSAM option in the
    *  backend selector. */
   microSamAvailable?: boolean;
@@ -212,13 +215,6 @@ const SectionHeader: React.FC<{ title: string; subtitle?: string; open: boolean;
   </Box>
 );
 
-const INSTANT_KEYS: (keyof CellposeConfig)[] = [
-  'flow_threshold',
-  'cellprob_threshold',
-  'niter',
-  'min_mask_area',
-];
-
 const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
   open,
   config: initialConfig,
@@ -229,7 +225,7 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
   livePreviewReady,
   resultReady,
   completedRunId,
-  onInstantConfigChange,
+  onShowPreview,
   microSamAvailable,
   cellposeAvailable,
   onDialogOpen,
@@ -276,20 +272,8 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
 
   const bothUnavailable = microSamAvailable === false && cellposeAvailable === false;
 
-  // Fire instant-group updates back to the caller (debounced by the caller's
-  // own debouncer; we just propagate every state change). React batches the
-  // setState above so we read the latest config from the next render.
-  const instantConfigChangeRef = useRef(onInstantConfigChange);
-  instantConfigChangeRef.current = onInstantConfigChange;
-
   const update = <K extends keyof CellposeConfig>(key: K, value: CellposeConfig[K]) => {
-    setConfig((prev) => {
-      const next = { ...prev, [key]: value };
-      if (livePreviewReady && INSTANT_KEYS.includes(key)) {
-        instantConfigChangeRef.current?.(next);
-      }
-      return next;
-    });
+    setConfig((prev) => ({ ...prev, [key]: value }));
   };
 
   const handleReset = () => {
@@ -353,13 +337,77 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
     prevResultReady.current = isResultReady;
   }, [completedRunId, isResultReady]);
 
-  // Flow Threshold and Cell Probability Threshold repaint the mask overlay
-  // live, so while either is being dragged the dialog fades out to reveal
-  // the image underneath. The slider itself stays fully opaque (only the
-  // Paper/backdrop backgrounds lose alpha), and the dialog restores on release.
-  const [draggingSlider, setDraggingSlider] = useState(false);
-  const startSliderDrag = () => setDraggingSlider(true);
-  const endSliderDrag = () => setDraggingSlider(false);
+  // "Show preview" is a hold button: while held, the entire dialog (paper +
+  // backdrop) hides so the user can see the image and current mask preview
+  // underneath, and reappears on release. Postprocessing (the local Pyodide
+  // recompute against the cached flow field) runs once on press, and the
+  // dialog only hides once that recompute has actually finished — see
+  // handleShowPreviewPointerDown. previewHeldRef tracks whether the pointer
+  // is still down when the async recompute resolves, since a fast tap can
+  // release before postprocessing completes.
+  const [previewHeld, setPreviewHeld] = useState(false);
+  const [postprocessing, setPostprocessing] = useState(false);
+  const previewHeldRef = useRef(false);
+
+  // Reset hold/spinner state whenever the dialog closes, in case a pointer
+  // capture release was missed (e.g. the dialog closed via Escape mid-hold).
+  useEffect(() => {
+    if (!open) {
+      previewHeldRef.current = false;
+      setPreviewHeld(false);
+      setPostprocessing(false);
+    }
+  }, [open]);
+
+  const handleShowPreviewPointerDown = useCallback(async (e: React.PointerEvent<HTMLButtonElement>) => {
+    if (postprocessing || !onShowPreview) return;
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // ignore — capture is best-effort
+    }
+    previewHeldRef.current = true;
+    setPostprocessing(true);
+    try {
+      await onShowPreview(config);
+    } catch (err) {
+      console.warn('[CellposeConfigDialog] Show preview failed:', err);
+    } finally {
+      setPostprocessing(false);
+      if (previewHeldRef.current) setPreviewHeld(true);
+    }
+  }, [postprocessing, onShowPreview, config]);
+
+  const handleShowPreviewRelease = useCallback((e: React.PointerEvent<HTMLButtonElement>) => {
+    previewHeldRef.current = false;
+    setPreviewHeld(false);
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {
+      // ignore — capture may already have been released
+    }
+  }, []);
+
+  const handleDone = useCallback(async () => {
+    if (isResultReady) {
+      if (!isMicroSam && livePreviewReady && onShowPreview && !postprocessing) {
+        setPostprocessing(true);
+        try {
+          await onShowPreview(config);
+        } catch (err) {
+          console.warn('[CellposeConfigDialog] Done postprocessing failed:', err);
+        } finally {
+          setPostprocessing(false);
+        }
+      }
+      handleApply();
+      onClose();
+    } else {
+      onCancelRun?.();
+      onClose();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isResultReady, isMicroSam, livePreviewReady, onShowPreview, postprocessing, config]);
 
   return (
     <Dialog
@@ -367,22 +415,12 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
       onClose={onClose}
       maxWidth="sm"
       fullWidth
+      hideBackdrop={previewHeld}
       PaperProps={{
-        sx: (theme) => ({
+        sx: {
           borderRadius: 3,
-          transition: 'background-color 180ms ease, box-shadow 180ms ease',
-          ...(draggingSlider && {
-            bgcolor: alpha(theme.palette.background.paper, 0.1),
-            boxShadow: 'none',
-          }),
-        }),
-      }}
-      slotProps={{
-        backdrop: {
-          sx: {
-            transition: 'background-color 180ms ease',
-            ...(draggingSlider && { bgcolor: 'rgba(0,0,0,0.04)' }),
-          },
+          transition: 'opacity 120ms ease-out',
+          ...(previewHeld && { opacity: 0, pointerEvents: 'none' }),
         },
       }}
     >
@@ -662,8 +700,6 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
                         <Slider
                           value={config.flow_threshold}
                           onChange={(_, val) => update('flow_threshold', val as number)}
-                          onChangeCommitted={endSliderDrag}
-                          onPointerDown={startSliderDrag}
                           min={0} max={3} step={0.1}
                           valueLabelDisplay="auto"
                           size="small"
@@ -686,8 +722,6 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
                         <Slider
                           value={config.cellprob_threshold}
                           onChange={(_, val) => update('cellprob_threshold', val as number)}
-                          onChangeCommitted={endSliderDrag}
-                          onPointerDown={startSliderDrag}
                           min={-6} max={6} step={0.1}
                           valueLabelDisplay="auto"
                           size="small"
@@ -733,6 +767,27 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
                       />
                     </Grid>
 
+                    {onShowPreview && (
+                      <Grid item xs={12}>
+                        <Button
+                          variant="outlined"
+                          color="secondary"
+                          fullWidth
+                          disabled={!livePreviewReady || postprocessing}
+                          startIcon={postprocessing ? <CircularProgress size={16} /> : <VisibilityIcon fontSize="small" />}
+                          onPointerDown={handleShowPreviewPointerDown}
+                          onPointerUp={handleShowPreviewRelease}
+                          onPointerCancel={handleShowPreviewRelease}
+                          sx={{ touchAction: 'none', userSelect: 'none' }}
+                        >
+                          Show Preview
+                        </Button>
+                        <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5, textAlign: 'center' }}>
+                          Hold to preview, let go to return to dialog.
+                        </Typography>
+                      </Grid>
+                    )}
+
                   </Grid>
                 </Collapse>
               </Grid>
@@ -748,17 +803,11 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
           </Button>
         )}
         <Button
-          onClick={() => {
-            if (isResultReady) {
-              handleApply();
-              onClose();
-            } else {
-              onCancelRun?.();
-              onClose();
-            }
-          }}
+          onClick={handleDone}
           color={isResultReady ? 'primary' : 'inherit'}
           variant={isResultReady ? 'outlined' : 'text'}
+          disabled={postprocessing}
+          startIcon={postprocessing && isResultReady ? <CircularProgress size={16} /> : undefined}
         >
           {isResultReady ? 'Done' : 'Cancel'}
         </Button>
@@ -771,17 +820,18 @@ export function useCellposeConfig(opts?: {
   onRun?: (config: CellposeConfig) => void;
   isRunning?: boolean;
   /** When true, the dialog keeps the (dP, cellprob) flows path active: the
-   *  Apply / Run path does NOT close the dialog so the instant-group
-   *  sliders can keep updating the preview. ``Done`` saves + closes;
-   *  Cancel closes without saving. Pass this when the parent has wired
-   *  the Pyodide compute_masks call back through onInstantConfigChange. */
+   *  Apply / Run path does NOT close the dialog so "Show preview" and
+   *  "Done" can trigger local recompute against the cached flows. ``Done``
+   *  saves + closes; Cancel closes without saving. Pass this when the
+   *  parent has wired the Pyodide compute_masks call back through
+   *  onShowPreview. */
   keepOpenAfterApply?: boolean;
   livePreviewReady?: boolean;
   resultReady?: boolean;
   /** Monotonically increasing id bumped on every completed run — see the
    *  matching prop doc on ``CellposeConfigDialogProps``. */
   completedRunId?: number;
-  onInstantConfigChange?: (config: CellposeConfig) => void;
+  onShowPreview?: (config: CellposeConfig) => Promise<void>;
   microSamAvailable?: boolean;
   /** Whether the Cellpose-SAM backend (cellpose4-runner) is reachable. */
   cellposeAvailable?: boolean;
@@ -846,7 +896,7 @@ export function useCellposeConfig(opts?: {
       livePreviewReady={opts?.livePreviewReady}
       resultReady={opts?.resultReady}
       completedRunId={opts?.completedRunId}
-      onInstantConfigChange={opts?.onInstantConfigChange}
+      onShowPreview={opts?.onShowPreview}
       microSamAvailable={opts?.microSamAvailable}
       cellposeAvailable={opts?.cellposeAvailable}
       onDialogOpen={opts?.onDialogOpen}

--- a/src/pages/AnnotatePage.tsx
+++ b/src/pages/AnnotatePage.tsx
@@ -9,7 +9,6 @@ import ConfirmDialog from '../components/annotate/ConfirmDialog';
 import FloatingBanners, { useBanners } from '../components/annotate/FloatingBanners';
 import { useCellposeConfig, CellposeConfig } from '../components/annotate/CellposeConfigDialog';
 import CLAHEDialog, { useCLAHE } from '../components/annotate/CLAHEDialog';
-import { useColabKernel } from '../components/colab/useColabKernel';
 import { useSharedKernelIfAvailable } from '../components/colab/KernelContext';
 import MaskFilterDialog from '../components/annotate/MaskFilterDialog';
 import HelpTutorial from '../components/annotate/HelpTutorial';
@@ -166,14 +165,34 @@ const AnnotatePage: React.FC<AnnotatePageProps> = ({ backTo }) => {
 
   const { claheConfig, setClaheConfig, dialogOpen: claheDialogOpen, openDialog: openCLAHEDialog, closeDialog: closeCLAHEDialog } = useCLAHE();
   
-  // Always call both hooks unconditionally (required by React Rules of Hooks)
-  // Use shared kernel if available (when called from Colab), otherwise use local kernel
+  // AnnotatePage is only ever rendered inside ColabPage's <KernelProvider>
+  // (see ColabPage.tsx), so the shared kernel is always available here. A
+  // second, uninitialized local kernel used to be kept as a fallback, but it
+  // was dead code that booted its own full Pyodide instance in parallel with
+  // the shared one as soon as anything requested a kernel, which starved the
+  // main thread badly enough to stall canvas mounting.
   const sharedKernel = useSharedKernelIfAvailable();
-  const localKernel = useColabKernel();
-  
-  const kernel = sharedKernel || localKernel;
+  const kernel = sharedKernel!;
   const kernelReady = kernel.isReady;
   const executeCode = kernel.executeCode;
+
+  // The shared kernel (from ColabPage's KernelProvider) stays idle until
+  // something calls requestKernel(). That used to only happen from the CLAHE
+  // toggle handler below, but this page's core Cellpose-SAM live-preview
+  // flow (runCellposeFlowsPipeline / maskGen) also needs kernelReady, and a
+  // user landing on the annotate page has already committed to interacting
+  // with images, so request it as soon as this page mounts rather than
+  // waiting for CLAHE specifically. Deliberately mount-once (empty deps): the
+  // KernelProvider's context value is a fresh object on every render (its
+  // kernelStatus ticks through many states during boot), so depending on
+  // `sharedKernel` here re-fires this effect dozens of times a second for the
+  // whole boot window and starves the page's own rendering. requestKernel()
+  // itself is a stable, idempotent useCallback, so reading it once on mount
+  // is sufficient.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    sharedKernel?.requestKernel?.();
+  }, []);
 
   // Pyodide-side mask gen — only used when the server returns flows-only.
   // The hook lazily installs scipy + execs public/cellpose_mask_gen.py on the

--- a/src/pages/AnnotatePage.tsx
+++ b/src/pages/AnnotatePage.tsx
@@ -112,7 +112,7 @@ const AnnotatePage: React.FC<AnnotatePageProps> = ({ backTo }) => {
   const { service, loading: serviceLoading, error: serviceError, cellposeAvailable, microSamAvailable, retry: retryService, probeAvailability } = useHyphaService(serviceConfig);
   const { banners, addBanner, removeBanner } = useBanners();
   const runCellposeRef = React.useRef<(config: CellposeConfig) => void>(() => {});
-  const instantConfigChangeRef = React.useRef<(config: CellposeConfig) => void>(() => {});
+  const showPreviewRef = React.useRef<(config: CellposeConfig) => Promise<void>>(async () => {});
   const [isRunningCellpose, setIsRunningCellpose] = useState(false);
   const [livePreviewReady, setLivePreviewReady] = useState(false);
   // True after ANY successful Cellpose run, local Pyodide flows path or full
@@ -148,7 +148,7 @@ const AnnotatePage: React.FC<AnnotatePageProps> = ({ backTo }) => {
     cellposeAvailable,
     onDialogOpen: probeAvailability,
     claheActive: isCLAHEActive,
-    onInstantConfigChange: (config) => instantConfigChangeRef.current(config),
+    onShowPreview: (config) => showPreviewRef.current(config),
     onCancelRun: () => cellposeAbortRef.current?.abort(),
     onMeasureDiameter: (currentConfig, onMeasured) => {
       setCellposeConfig(currentConfig);
@@ -260,10 +260,8 @@ const AnnotatePage: React.FC<AnnotatePageProps> = ({ backTo }) => {
   // stale/mismatched polygons onto the current preview.
   const flowsRunSeqRef = useRef(0);
   // OL features added by the latest Cellpose run. Replaced wholesale on each
-  // instant-slider recompute so the preview stays in sync.
+  // "Show preview" / Done recompute so the preview stays in sync.
   const previewFeaturesRef = useRef<Feature[]>([]);
-  // Debounce timer for instant-config slider drags.
-  const instantRecomputeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [kernelPackagesInstalled, setKernelPackagesInstalled] = useState(false);
 
@@ -1114,31 +1112,32 @@ print('CLAHE packages ready')
     closeCellposeConfig,
   ]);
 
-  // Re-run mask gen using the cached flows on every instant-config drag.
-  // Debounced so a fast slider sweep only fires one Pyodide call.
-  const handleInstantConfigChange = useCallback((cfg: CellposeConfig) => {
+  // Re-run mask gen against the cached flows. Called explicitly by the
+  // dialog's "Show preview" hold button and "Done" button only — no longer
+  // fired on every slider change, so no debounce is needed here.
+  const handleShowPreview = useCallback(async (cfg: CellposeConfig) => {
     if (!flowsCacheRef.current) return;
-    if (instantRecomputeTimerRef.current) clearTimeout(instantRecomputeTimerRef.current);
-    instantRecomputeTimerRef.current = setTimeout(async () => {
-      try {
-        const n = await runCellposeFlowsPipeline(cfg);
-        if (n !== undefined) {
-          console.log('[AnnotatePage] Live preview: %d masks', n);
-        }
-      } catch (err: any) {
-        console.warn('[AnnotatePage] Live preview failed:', err);
+    try {
+      const n = await runCellposeFlowsPipeline(cfg);
+      if (n !== undefined) {
+        console.log('[AnnotatePage] Preview: %d masks', n);
       }
-    }, 200);
-  }, [runCellposeFlowsPipeline]);
+    } catch (err: any) {
+      const fullError = err?.message || String(err);
+      console.warn('[AnnotatePage] Preview failed:', fullError);
+      addBanner('Preview failed', 'error', 8000, fullError);
+      throw err;
+    }
+  }, [runCellposeFlowsPipeline, addBanner]);
 
-  // Keep refs in sync so the config dialog's Run button + instant-config
+  // Keep refs in sync so the config dialog's Run button + show-preview
   // callback can trigger the latest closures without a re-render of the dialog.
   React.useEffect(() => {
     runCellposeRef.current = handleRunCellpose;
   }, [handleRunCellpose]);
   React.useEffect(() => {
-    instantConfigChangeRef.current = handleInstantConfigChange;
-  }, [handleInstantConfigChange]);
+    showPreviewRef.current = handleShowPreview;
+  }, [handleShowPreview]);
 
   // Invalidate the flows cache whenever the source image changes — different
   // image, the cached network outputs no longer apply.


### PR DESCRIPTION
## Motivation

Refining Cellpose-SAM results meant dragging sliders while the dialog faded to a semi-transparent state, and every slider change triggered a local postprocessing recompute. The fade made the dialog hard to read mid-drag, and the recompute-per-change wasted work on intermediate values. Separately, the local live-preview path (and its Pyodide kernel) only activated if the user had opened the Enhance Contrast tool first in the same visit, because that toggle was the only place the shared kernel was ever requested.

## Changes

- The Refine Results section gains a Show Preview hold button: while held, the dialog hides completely so the image and current masks are visible underneath, and it returns on release. Pointer capture keeps the release reliable for mouse and touch even when the pointer leaves the button.
- Postprocessing (local mask regeneration against the cached flow field) now runs only when Show Preview is pressed or Done is clicked, with a spinner on both buttons while it runs. Slider changes just update values, with no recompute and no dialog transparency.
- The annotate page requests the shared Pyodide kernel on mount instead of only from the Enhance Contrast toggle, so the live-preview path is available without opening CLAHE first. The unused local-kernel fallback is removed; it booted a second full Pyodide instance in parallel once anything requested a kernel, starving the main thread enough to stall canvas mounting.
- HyphaCore initialization is guarded against React 18 StrictMode's dev-only double effect invocation, which previously threw "Server already running".

## Behaviour

After a Cellpose-SAM run with cached flows, adjusting Flow Threshold or Cell Probability Threshold changes nothing until the user holds Show Preview (recompute, spinner, then the dialog hides while held) or clicks Done (recompute, spinner, apply, close). Runs that fell back to the server path keep Show Preview disabled since there is nothing to recompute locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)