### PR TITLE
Fix brush radius stepper buttons producing NaN

### DIFF
--- a/src/components/annotate/ToolBar.tsx
+++ b/src/components/annotate/ToolBar.tsx
@@ -402,7 +402,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
                       }}>
                         <IconButton
                           size="small"
-                          onClick={decreaseBrushRadius}
+                          onClick={() => decreaseBrushRadius()}
                           disabled={brushRadius <= MIN_BRUSH_RADIUS}
                           aria-label="Decrease brush radius"
                           sx={{ ...floatingBtnSx(), width: 26, height: 26 }}
@@ -414,7 +414,7 @@ const ToolBar: React.FC<ToolBarProps> = ({
                         </Typography>
                         <IconButton
                           size="small"
-                          onClick={increaseBrushRadius}
+                          onClick={() => increaseBrushRadius()}
                           disabled={brushRadius >= MAX_BRUSH_RADIUS}
                           aria-label="Increase brush radius"
                           sx={{ ...floatingBtnSx(), width: 26, height: 26 }}

--- a/src/store/annotationStore.ts
+++ b/src/store/annotationStore.ts
@@ -209,13 +209,18 @@ export const useAnnotationStore = create<AnnotationState>((set, get) => ({
     persistBrushRadius(clamped);
     set({ brushRadius: clamped });
   },
+  // The runtime typeof guard (not just the default) matters: passing these
+  // straight to onClick hands them a MouseEvent as `step`, and
+  // radius + event = NaN, which clamp then propagates.
   increaseBrushRadius: (step = BRUSH_RADIUS_STEP) => set((state) => {
-    const clamped = clampBrushRadius(state.brushRadius + step);
+    const s = typeof step === 'number' && Number.isFinite(step) ? step : BRUSH_RADIUS_STEP;
+    const clamped = clampBrushRadius(state.brushRadius + s);
     persistBrushRadius(clamped);
     return { brushRadius: clamped };
   }),
   decreaseBrushRadius: (step = BRUSH_RADIUS_STEP) => set((state) => {
-    const clamped = clampBrushRadius(state.brushRadius - step);
+    const s = typeof step === 'number' && Number.isFinite(step) ? step : BRUSH_RADIUS_STEP;
+    const clamped = clampBrushRadius(state.brushRadius - s);
     persistBrushRadius(clamped);
     return { brushRadius: clamped };
   }),


### PR DESCRIPTION
## Motivation

The brush radius stepper's + and - buttons were broken in production: clicking either showed NaNpx and the stepper stayed broken until reload. The buttons passed the store's increaseBrushRadius/decreaseBrushRadius directly as onClick handlers, so the MouseEvent arrived as the optional step parameter and radius + event evaluated to NaN. The keyboard path (which passes a numeric step) was unaffected, which is why it slipped through.

## Changes

- Wrap the two onClick handlers so the store actions are called with no argument.
- Guard the store actions with a runtime number check so a non-numeric step falls back to the default step instead of poisoning the persisted radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)