### PR TITLE
Point the annotation UI at the model-finetune service

### DIFF
--- a/src/utils/microSamService.ts
+++ b/src/utils/microSamService.ts
@@ -1,14 +1,14 @@
-// Service-ID and helpers for the bioimageio-finetune (display "BioImageIO
+// Service-ID and helpers for the model-finetune (display "BioImageIO
 // Fine-tune") Hypha service that backs the annotation UI's box-prompt
 // segmentation and μSAM auto pre-segmentation.
 //
 // The app runs as a BioEngine app on the shared `bioimage-io` workers. Every
-// worker that deploys it registers the same `bioimageio-finetune` service
-// name (e.g. `bioimage-io/bioengine-worker-denbi-...:bioimageio-finetune` and
-// `bioimage-io/bioengine-worker-kth-...:bioimageio-finetune`), and the app is
+// worker that deploys it registers the same `model-finetune` service name
+// (e.g. `bioimage-io/bioengine-worker-denbi-...:model-finetune` and
+// `bioimage-io/bioengine-worker-kth-...:model-finetune`), and the app is
 // published with public `authorized_users {'*':['*']}`, so it is callable
 // cross-workspace from any connected server. We therefore resolve the
-// *unqualified* workspace name `bioimage-io/bioimageio-finetune` rather than
+// *unqualified* workspace name `bioimage-io/model-finetune` rather than
 // a single worker's client-scoped id: Hypha's service selector then spreads
 // calls across whichever workers are up. This means the UI transparently
 // discovers the service on both the KTH and de.NBI workers, and survives
@@ -21,6 +21,12 @@
 // segmentation inference and fine-tuning. The rename is a byte-identical RPC
 // contract, so no call-site shape changed, only this constant.
 //
+// round-31c (2026-08-18): renamed again, `bioimageio-finetune` ->
+// `model-finetune`, to pair with `model-runner` and avoid the
+// bioimage-io/bioimageio stutter. Again byte-identical, only this constant
+// changes. The old service stays registered until every frontend deploy has
+// switched, then retires.
+//
 // Unlike cellpose-finetuning (see utils/cellposeServicePin.ts), this service
 // is stateless across replicas for segmentation calls, so there is nothing to
 // pin: every call re-resolves a fresh handle (Hypha handles expire after a
@@ -28,8 +34,8 @@
 
 // Workspace-scoped service name. Deliberately NOT client-qualified so it
 // load-balances across every `bioimage-io` worker that registers
-// `bioimageio-finetune`.
-export const MICRO_SAM_SERVICE_ID = 'bioimage-io/bioimageio-finetune';
+// `model-finetune`.
+export const MICRO_SAM_SERVICE_ID = 'bioimage-io/model-finetune';
 
 // Model type used for every μSAM call. As of micro-sam 0.7.0 the service
 // default flipped to 'vit_l_lm' (DeepBacs zero-shot mean F1 0.229 -> 0.799 vs
@@ -60,9 +66,9 @@ export const MICRO_SAM_GROUP_LABELS: Record<MicroSamModelOption['group'], string
 };
 
 // Phase B (colab-rework-plan.md §29, 2026-08-17): all 6 generalists are now
-// served by bioimageio-finetune 0.10.0. The selector groups by `group`
-// generically, so this array is the single place either group's membership
-// is defined.
+// served by model-finetune (née bioimageio-finetune) 0.10.0. The selector
+// groups by `group` generically, so this array is the single place either
+// group's membership is defined.
 //
 // trainableOnT4: false on both "Large" entries per colab-rework-plan.md §20.2
 // and confirmed again on 0.10.0 (round-30, 2026-08-17, keen-puma relaying
@@ -93,7 +99,7 @@ export const MICRO_SAM_TRAINABLE_MODEL_OPTIONS: MicroSamModelOption[] =
  * handle would raise.
  *
  * Resolution uses the `select:min:get_load` selector against the unqualified
- * `bioimage-io/bioimageio-finetune` name, so when the app is deployed on more
+ * `bioimage-io/model-finetune` name, so when the app is deployed on more
  * than one worker (KTH + de.NBI) each call lands on the least-busy replica.
  * This mirrors how the model-runner resolves across workers (see
  * hooks/useModelRunners.ts). Segmentation calls are stateless across

--- a/src/utils/microSamTrainingPin.ts
+++ b/src/utils/microSamTrainingPin.ts
@@ -1,16 +1,17 @@
 /**
- * Resolves the ``bioimage-io/bioimageio-finetune`` service (renamed from
- * ``micro-sam`` in round-29 Phase B, colab-rework-plan.md §29), pinning a
- * specific worker replica for the duration of the browser tab, for
- * fine-tuning calls (and export_model/get_export_status/push_export, which
- * share the training service's per-replica in-memory state) only.
+ * Resolves the ``bioimage-io/model-finetune`` service (renamed from
+ * ``micro-sam`` in round-29 Phase B, colab-rework-plan.md §29, then from
+ * ``bioimageio-finetune`` in round-31c), pinning a specific worker replica
+ * for the duration of the browser tab, for fine-tuning calls (and
+ * export_model/get_export_status/push_export, which share the training
+ * service's per-replica in-memory state) only.
  *
  * Why this differs from `microSamService.ts`'s `resolveMicroSamService`
  * -----------------------------------------------------------------------
  * Inference (`infer`, `compute_embedding`, `get_onnx_model`) is stateless
  * across replicas, so `resolveMicroSamService` deliberately re-resolves via
  * `select:min:get_load` on every call to spread load across every worker
- * (KTH + de.NBI) that registers `bioimageio-finetune`.
+ * (KTH + de.NBI) that registers `model-finetune`.
  *
  * Fine-tuning is the opposite: `training.py`'s session store
  * (`~/.bioengine/micro_sam_sessions/<session_id>/status.json` +
@@ -90,7 +91,7 @@ export async function resolvePinnedMicroSamTrainingService(server: any): Promise
   const id = (svc && (svc as any).id) as string | undefined;
   if (id) {
     setPinnedMicroSamTrainingServiceId(id);
-    console.log('[resolvePinnedMicroSamTrainingService] Pinned bioimageio-finetune replica:', id);
+    console.log('[resolvePinnedMicroSamTrainingService] Pinned model-finetune replica:', id);
   }
   return svc;
 }


### PR DESCRIPTION
## Motivation

The backend app serving μSAM segmentation and fine-tuning was renamed from bioimageio-finetune to model-finetune. Both service names currently serve identical code side by side; this switches the frontend to the new name so the old registration can be retired.

## Changes

MICRO_SAM_SERVICE_ID becomes bioimage-io/model-finetune (single constant, imported by the serving path, the training pin, and availability probing), with comments updated to match. The RPC contract is byte-identical, so no call-site changes.

## Test plan

The model-finetune service was verified live before this flip: training-session state migrated from the old app is listed and a fine-tuned checkpoint serves inference by session id, and a full μSAM segmentation run through the UI against the new service id passed during the earlier hold. Production smoke after deploy covers the annotate page's μSAM path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)