### PR TITLE
Sync RDF authors/maintainers into Hypha artifact permissions

### DIFF
--- a/src/components/Edit.tsx
+++ b/src/components/Edit.tsx
@@ -14,7 +14,7 @@ import ReviewPublishArtifact from './ReviewPublishArtifact';
 import yaml from 'js-yaml';
 import RDFEditor from './RDFEditor';
 import { calculateSHA256, calculateFileSHA256 } from '../utils/sha256';
-import { getArtifactRights, getIsReviewer } from '../utils/roles';
+import { getArtifactRights, getIsReviewer, buildContributorPermissions } from '../utils/roles';
 import { isInternalArtifactFile } from '../utils/internalFiles';
 import { BIOIMAGEIO_YAML, RDF_YAML, isRdfFileName, endsWithRdfFileName, detectRdfFileName } from '../utils/rdfFile';
 import { HYPHA_SERVER_URL } from '../config/hypha';
@@ -450,6 +450,40 @@ const Edit: React.FC = () => {
   // a no-op, since the changes have already landed in the committed version.
   const commitIfStaged = async (comment: string): Promise<void> => {
     if (!artifactManager || !artifactId) return;
+
+    // Sync authors/maintainers into config.permissions before committing, so
+    // the grant lands in base config (permission checks never read the staged
+    // overlay). Read the authoritative staged state first — list/route state
+    // may not carry `.staging`. Best-effort: a failure here must not block
+    // the commit itself.
+    try {
+      const currentArtifact = await artifactManager.read({
+        artifact_id: artifactId,
+        stage: true,
+        _rkwargs: true
+      });
+      if (currentArtifact.staging) {
+        const currentConfig = (currentArtifact.config as Record<string, any>) || {};
+        const contributorPermissions = buildContributorPermissions(
+          currentArtifact.manifest,
+          currentConfig.permissions as Record<string, string> | undefined,
+          currentConfig.contributor_permission_keys as string[] | undefined,
+        );
+        await artifactManager.edit({
+          artifact_id: artifactId,
+          config: {
+            ...currentConfig,
+            permissions: contributorPermissions.permissions,
+            contributor_permission_keys: contributorPermissions.contributorKeys
+          },
+          stage: true,
+          _rkwargs: true
+        });
+      }
+    } catch (permErr) {
+      console.error('Could not sync author/maintainer permissions before commit:', permErr);
+    }
+
     // Don't gate on a client-side `staging` field: the default (committed) read
     // reports staging=null by backend design — it's only surfaced on a
     // stage=true read. Instead attempt the commit and treat the backend's
@@ -1333,13 +1367,24 @@ const Edit: React.FC = () => {
         });
       }
 
+      // Sync authors/maintainers into config.permissions alongside the
+      // download_weights patch below (this edit is already unstaged, so it
+      // lands directly in base config where permission checks read from).
+      const contributorPermissions = buildContributorPermissions(
+        artifact.manifest,
+        artifact.config?.permissions,
+        artifact.config?.contributor_permission_keys,
+      );
+
       // add create_zip_file to download_weights
       const newConfig = {
         ...artifact.config,
         download_weights:{
           ...artifact.config.download_weights,
           create_zip_file: 1.0
-        }
+        },
+        permissions: contributorPermissions.permissions,
+        contributor_permission_keys: contributorPermissions.contributorKeys
       };
 
       // update the manifest

--- a/src/components/ReviewArtifacts.tsx
+++ b/src/components/ReviewArtifacts.tsx
@@ -15,7 +15,7 @@ import { Pagination } from './ArtifactGrid';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { IconButton, Tooltip } from '@mui/material';
 import SearchBar from './SearchBar';
-import { getIsReviewer, getIsCollectionAdmin, fetchCollectionOwners, isPublished, buildReviewerPermissions, COLLECTION_WORKSPACE } from '../utils/roles';
+import { getIsReviewer, getIsCollectionAdmin, fetchCollectionOwners, isPublished, buildReviewerPermissions, buildContributorPermissions, COLLECTION_WORKSPACE } from '../utils/roles';
 import { getDeletionRequest } from '../utils/deletionRequest';
 import RequestDeletionDialog from './RequestDeletionDialog';
 import DeclineDeletionDialog from './DeclineDeletionDialog';
@@ -573,9 +573,20 @@ const ReviewArtifacts: React.FC = () => {
             collection?.config as { permissions?: Record<string, string> } | undefined,
             currentConfig.permissions as Record<string, string> | undefined
           );
+          // Also sync the model's own authors/maintainers (matched by email)
+          // into the same permissions map.
+          const contributorPermissions = buildContributorPermissions(
+            currentArtifact.manifest,
+            permissions,
+            currentConfig.contributor_permission_keys as string[] | undefined,
+          );
           await artifactManager.edit({
             artifact_id: artifact.id,
-            config: { ...currentConfig, permissions },
+            config: {
+              ...currentConfig,
+              permissions: contributorPermissions.permissions,
+              contributor_permission_keys: contributorPermissions.contributorKeys
+            },
             stage: true,
             _rkwargs: true
           });

--- a/src/components/Upload.tsx
+++ b/src/components/Upload.tsx
@@ -18,7 +18,7 @@ import { calculateSHA256, calculateFileSHA256 } from '../utils/sha256';
 import { updateManifestSha256 } from '../utils/sha-handling';
 import { BIOIMAGEIO_YAML, RDF_YAML, isRdfFileName, endsWithRdfFileName, findRdfFile } from '../utils/rdfFile';
 import { isInternalArtifactFile } from '../utils/internalFiles';
-import { buildReviewerPermissions } from '../utils/roles';
+import { buildReviewerPermissions, buildContributorPermissions } from '../utils/roles';
 
 // Helper function to extract weight file paths from manifest
 const extractWeightFiles = (manifest: any): string[] => {
@@ -934,6 +934,14 @@ const Upload: React.FC<UploadProps> = ({ artifactId }) => {
         undefined,
       );
 
+      // Also grant the manifest's own authors/maintainers (matched by email)
+      // write access from creation, same rw+ level as reviewers.
+      const contributorPermissions = buildContributorPermissions(
+        manifest,
+        reviewerPermissions,
+        undefined,
+      );
+
       // Create new artifact with type-specific alias pattern
       const artifact = await artifactManager.create({
         parent_id: "bioimage-io/bioimage.io",
@@ -942,7 +950,8 @@ const Upload: React.FC<UploadProps> = ({ artifactId }) => {
         manifest: manifest,
         config: {
           publish_to: "sandbox_zenodo",
-          permissions: reviewerPermissions
+          permissions: contributorPermissions.permissions,
+          contributor_permission_keys: contributorPermissions.contributorKeys
         },
         stage: true,
         _rkwargs: true,

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -8,6 +8,16 @@ export interface Author {
   name: string;
   orcid?: string;
   affiliation?: string;
+  email?: string;
+  github_user?: string;
+}
+
+export interface Maintainer {
+  name: string;
+  orcid?: string;
+  affiliation?: string;
+  email?: string;
+  github_user?: string;
 }
 
 export interface Citation {
@@ -91,6 +101,7 @@ export interface ArtifactInfo {
     covers?: string[];
     documentation?: string;
     authors?: Author[];
+    maintainers?: Maintainer[];
     cite?: Citation[];
     links?: {
       url: string;
@@ -114,6 +125,8 @@ export interface ArtifactInfo {
   config?: {
     permissions?: Record<string, string>;
     download_weights?: Record<string, number>;
+    /** Emails granted `rw+` by the authors/maintainers permission sync, so the next run can revoke ones no longer listed. */
+    contributor_permission_keys?: string[];
     [key: string]: any;
   };
   name?: string; // From manifest
@@ -151,6 +164,7 @@ export interface Manifest {
   badges?: Badge[];
   covers?: string[];
   authors?: Author[];
+  maintainers?: Maintainer[];
   cite?: Citation[];
   documentation?: Documentation;
   links?: Link[];

--- a/src/utils/roles.test.ts
+++ b/src/utils/roles.test.ts
@@ -1,0 +1,63 @@
+import { buildContributorPermissions, CONTRIBUTOR_PERMISSION_LEVEL } from './roles';
+
+describe('buildContributorPermissions', () => {
+  it('grants rw+ to a new author/maintainer matched by email', () => {
+    const result = buildContributorPermissions(
+      { authors: [{ email: 'author@example.com' }], maintainers: [{ email: 'maintainer@example.com' }] },
+      {},
+      undefined,
+    );
+    expect(result.permissions['author@example.com']).toBe(CONTRIBUTOR_PERMISSION_LEVEL);
+    expect(result.permissions['maintainer@example.com']).toBe(CONTRIBUTOR_PERMISSION_LEVEL);
+    expect(result.contributorKeys.sort()).toEqual(['author@example.com', 'maintainer@example.com']);
+  });
+
+  it('normalizes email casing/whitespace and skips entries without email', () => {
+    const result = buildContributorPermissions(
+      { authors: [{ email: '  Someone@Example.com  ' }, { name: 'no-email' } as any] },
+      {},
+      undefined,
+    );
+    expect(Object.keys(result.permissions)).toEqual(['someone@example.com']);
+  });
+
+  it('never downgrades an existing owner (*) or already-rw+ entry', () => {
+    const result = buildContributorPermissions(
+      { authors: [{ email: 'owner@example.com' }] },
+      { 'owner@example.com': '*' },
+      undefined,
+    );
+    expect(result.permissions['owner@example.com']).toBe('*');
+  });
+
+  it('revokes a dropped contributor whose entry is still exactly rw+', () => {
+    const result = buildContributorPermissions(
+      { authors: [] },
+      { 'former@example.com': CONTRIBUTOR_PERMISSION_LEVEL },
+      ['former@example.com'],
+    );
+    expect(result.permissions['former@example.com']).toBeUndefined();
+    expect(result.contributorKeys).toEqual([]);
+  });
+
+  it('leaves a dropped contributor alone if the entry no longer matches what this sync granted', () => {
+    const result = buildContributorPermissions(
+      { authors: [] },
+      { 'promoted@example.com': '*' },
+      ['promoted@example.com'],
+    );
+    expect(result.permissions['promoted@example.com']).toBe('*');
+    expect(result.contributorKeys).toEqual([]);
+  });
+
+  it('never touches permission entries unrelated to authors/maintainers', () => {
+    const result = buildContributorPermissions(
+      { authors: [{ email: 'author@example.com' }] },
+      { 'github|105947657': 'rw+', 'uploader@example.com': '*' },
+      [],
+    );
+    expect(result.permissions['github|105947657']).toBe('rw+');
+    expect(result.permissions['uploader@example.com']).toBe('*');
+    expect(result.permissions['author@example.com']).toBe(CONTRIBUTOR_PERMISSION_LEVEL);
+  });
+});

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -127,6 +127,81 @@ export function buildReviewerPermissions(
   return permissions;
 }
 
+/**
+ * The permission level granted to a model's RDF authors/maintainers. Same
+ * level as reviewers: edit, add/remove files, create versions, commit; not
+ * delete.
+ */
+export const CONTRIBUTOR_PERMISSION_LEVEL = 'rw+';
+
+interface ContributorEntry {
+  email?: string;
+}
+
+export interface ContributorManifest {
+  authors?: ContributorEntry[];
+  maintainers?: ContributorEntry[];
+}
+
+export interface ContributorPermissionsResult {
+  permissions: Record<string, string>;
+  contributorKeys: string[];
+}
+
+function contributorEmails(manifest: ContributorManifest | null | undefined): Set<string> {
+  const emails = new Set<string>();
+  const collect = (entries?: ContributorEntry[]) => {
+    for (const entry of entries || []) {
+      const email = entry?.email?.trim().toLowerCase();
+      if (email) emails.add(email);
+    }
+  };
+  collect(manifest?.authors);
+  collect(manifest?.maintainers);
+  return emails;
+}
+
+/**
+ * Build the `config.permissions` map (and the provenance list that should
+ * accompany it) for a model's current RDF authors/maintainers, matched by
+ * email. Every author/maintainer with an email gets `rw+`, never downgrading
+ * an existing `*` or `rw+` entry.
+ *
+ * Also revokes access for anyone who *was* granted access by a previous run
+ * of this function (tracked via `previousContributorKeys`, meant to be
+ * persisted as `config.contributor_permission_keys`) but is no longer an
+ * author/maintainer. A revoke only happens if the entry still holds exactly
+ * `rw+` — if it has since become something else (e.g. an uploader's `*`, or
+ * a reviewer/ops grant), this function is no longer the sole owner of that
+ * entry and leaves it alone, only dropping it from the provenance list.
+ *
+ * This is what makes the sync safe to run on every commit without clobbering
+ * permissions granted for unrelated reasons (uploader, reviewer, manual ops).
+ */
+export function buildContributorPermissions(
+  manifest: ContributorManifest | null | undefined,
+  existingPermissions: Record<string, string> | null | undefined,
+  previousContributorKeys: string[] | null | undefined,
+): ContributorPermissionsResult {
+  const permissions: Record<string, string> = { ...(existingPermissions || {}) };
+  const desired = contributorEmails(manifest);
+
+  for (const key of previousContributorKeys || []) {
+    if (desired.has(key)) continue;
+    if (permissions[key] === CONTRIBUTOR_PERMISSION_LEVEL) {
+      delete permissions[key];
+    }
+  }
+
+  for (const key of desired) {
+    const current = permissions[key];
+    if (current === '*' || current === CONTRIBUTOR_PERMISSION_LEVEL) continue;
+    permissions[key] = CONTRIBUTOR_PERMISSION_LEVEL;
+  }
+
+  return { permissions, contributorKeys: Array.from(desired) };
+}
+
 /** The Hypha workspace that owns the model collection. */
 export const COLLECTION_WORKSPACE = 'bioimage-io';
 


### PR DESCRIPTION
## Summary
- Authors and maintainers listed in a model's RDF, matched by email, now automatically hold `rw+` (edit/commit, no delete) on the Hypha artifact.
- Someone removed from `authors`/`maintainers` loses that grant again, but only if the entry still holds exactly what this sync set previously, so permissions granted for other reasons (uploader `*`, collection reviewers, manual ops grants) are never touched.
- Sync runs wherever a model's permissions actually reach committed base config: model creation, committing staged edits, publishing a draft, and a reviewer accepting a model.

## Behaviour
- New `buildContributorPermissions` in `src/utils/roles.ts` builds the permission map from a manifest's `authors`/`maintainers` emails, plus a `contributorKeys` provenance list persisted as `config.contributor_permission_keys`. That provenance list is what makes safe revocation possible without any metadata on the permissions map itself.
- Wired into `Upload.tsx` (`create()`), `Edit.tsx` (`commitIfStaged`, `handlePublish`), and `ReviewArtifacts.tsx` (`handleAccept`), mirroring the existing `buildReviewerPermissions` pattern already used at those same call sites.
- `Author`/`Maintainer` types in `src/types/artifact.ts` gained optional `email`/`github_user` fields (already present in real RDF data, e.g. via the raw-YAML editor) and a `maintainers` field was added to the manifest types.

## Test plan
- Added `src/utils/roles.test.ts` covering grant, never-downgrade, revoke-only-if-still-owned, leave-alone-if-reassigned, and untouched-unrelated-entries cases.
- Verified the same cases at runtime against the compiled logic (this repo's `pnpm test`/`tsc --noEmit` are both broken independent of this change: the pinned CRA jest config rejects the repo's own `setupFilesAfterEnv` override, and the pinned TypeScript 3.9.10 can't parse several dependencies' modern `.d.ts` files).
- Syntax-checked all modified files.