### PR TITLE
Pick the nightly test environment per model

### DIFF
--- a/.github/workflows/model-testing.yml
+++ b/.github/workflows/model-testing.yml
@@ -19,6 +19,15 @@ on:
         description: 'Model-runner service id (leave empty for bioimage-io/model-runner)'
         required: false
         type: string
+      environment:
+        description: 'Test environment: auto (per-model policy), or force custom / standard. Forcing alone is inert on models with a current cached report - tick skip_cache to actually re-test and overwrite the published report'
+        required: false
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - custom
+          - standard
 
 jobs:
   test-bioimageio-models:
@@ -60,6 +69,7 @@ jobs:
         MODEL_IDS="${{ github.event.inputs.model_ids || '' }}"
         SKIP_CACHE="${{ github.event.inputs.skip_cache || 'false' }}"
         SERVICE_ID="${{ github.event.inputs.service_id || '' }}"
+        ENVIRONMENT="${{ github.event.inputs.environment || 'auto' }}"
 
         # Build command arguments
         ARGS=""
@@ -75,6 +85,10 @@ jobs:
 
         if [ -n "$SERVICE_ID" ]; then
           ARGS="$ARGS --service-id $SERVICE_ID"
+        fi
+
+        if [ -n "$ENVIRONMENT" ] && [ "$ENVIRONMENT" != "auto" ]; then
+          ARGS="$ARGS --environment $ENVIRONMENT"
         fi
 
         echo "Running: python -u bioengine_model_test.py $ARGS"

--- a/scripts/bioengine_model_test.py
+++ b/scripts/bioengine_model_test.py
@@ -23,9 +23,60 @@ DEFAULT_SERVICE_ID = "bioimage-io/model-runner"
 TEST_TIMEOUT_SECONDS = 300
 TEST_POLL_INTERVAL_SECONDS = 3
 
+# Models that must be tested in the environment declared by their own RDF
+# (``weights.<format>.dependencies.source``) rather than in the model-runner's
+# serving runtime.
+#
+# The default is the serving runtime, deliberately: that is the interpreter the
+# website actually runs inference in, so a pass there is the signal that matters
+# to users. A model belongs on this list only when it genuinely cannot run in
+# the serving runtime and is expected to be consumed through its own
+# environment instead.
+#
+# Note that the runner silently downgrades the request to the serving runtime
+# for any model that declares no dependencies, so listing such a model has no
+# effect. Keep the list to models that really declare an environment.
+CUSTOM_ENV_MODEL_IDS = {
+    # Cellpose 3.x models. The serving runtime ships Cellpose 4, whose API
+    # dropped the modules these models import, so they only test green in the
+    # conda-forge ``cellpose=3.1.0`` environment pinned into each artifact.
+    # Inference for these is served by the separate cellpose3-runner app.
+    "famous-fish",
+    "happy-elephant",
+    "merry-gorilla",
+    "thoughtful-chipmunk",
+    # micro-sam / Segment Anything models. Their published packages need
+    # ``micro_sam`` (and ``mobile_sam`` for the vit_t variants), which the
+    # serving runtime does not carry.
+    "diplomatic-bug",
+    "faithful-chicken",
+    "greedy-whale",
+    "humorous-crab",
+    "idealistic-rat",
+    "noisy-ox",
+}
+
+
+def wants_custom_env(model_id: str, environment: str = "auto") -> bool:
+    """Decide which environment a model's test should run in.
+
+    Args:
+        model_id: Bare model alias, e.g. ``famous-fish``.
+        environment: ``auto`` consults ``CUSTOM_ENV_MODEL_IDS``; ``custom`` and
+            ``standard`` force the choice for every model in the run.
+
+    Returns:
+        True to run the test in the model's own declared environment.
+    """
+    if environment == "custom":
+        return True
+    if environment == "standard":
+        return False
+    return model_id in CUSTOM_ENV_MODEL_IDS
+
 
 async def run_test(
-    runner: ObjectProxy, model_id: str, skip_cache: bool
+    runner: ObjectProxy, model_id: str, skip_cache: bool, custom_environment: bool
 ) -> dict:
     """Submit a model test and wait for the report via the async runner API.
 
@@ -38,7 +89,10 @@ async def run_test(
     ``TEST_TIMEOUT_SECONDS``.
     """
     run_id = await runner.test(
-        model_id=model_id, stage=False, cache="skip" if skip_cache else "check"
+        model_id=model_id,
+        stage=False,
+        cache="skip" if skip_cache else "check",
+        custom_environment=custom_environment,
     )
 
     # Legacy synchronous runners returned the report dict directly instead of a
@@ -64,6 +118,7 @@ async def test_bmz_models(
     reports_dir: Optional[Path] = None,
     skip_cache: bool = False,
     service_id: str = DEFAULT_SERVICE_ID,
+    environment: str = "auto",
 ) -> None:
     """Test BioImage.IO models and generate test reports.
 
@@ -77,6 +132,7 @@ async def test_bmz_models(
         reports_dir: Directory where per-model JSON test reports are written.
         skip_cache: Whether to skip cache during model testing.
         service_id: Fully-qualified id of the model-runner service to use.
+        environment: ``auto``, ``custom`` or ``standard``. See wants_custom_env.
 
     Raises:
         RuntimeError: If fetching model IDs fails.
@@ -125,10 +181,16 @@ async def test_bmz_models(
     for model_id in model_ids:
         model_start_time = time.time()
 
+        custom_environment = wants_custom_env(model_id, environment)
+
         try:
-            print(f"Testing model '{model_id}'...")
+            env_label = "custom" if custom_environment else "standard"
+            print(f"Testing model '{model_id}' ({env_label} environment)...")
             test_report = await run_test(
-                model_runner, model_id=model_id, skip_cache=skip_cache
+                model_runner,
+                model_id=model_id,
+                skip_cache=skip_cache,
+                custom_environment=custom_environment,
             )
 
             model_execution_time = time.time() - model_start_time
@@ -430,6 +492,21 @@ def main():
         help="Skip cache during model testing",
     )
     parser.add_argument(
+        "--environment",
+        choices=["auto", "custom", "standard"],
+        default="auto",
+        help="Test environment: 'auto' (default) runs the models listed in "
+        "CUSTOM_ENV_MODEL_IDS in their own declared environment and everything "
+        "else in the model-runner's serving runtime; 'custom' and 'standard' "
+        "force one choice for every model in the run. Forcing does NOT "
+        "currently bypass the report cache: if a current report exists the "
+        "runner returns it unchanged, recorded environment included, so the "
+        "force is silently inert. Pair it with --skip-cache to actually "
+        "re-test. Once environment-aware cache reuse lands the force will "
+        "miss the cache on its own, re-test, and overwrite the single report "
+        "slot for that (model, stage). Neither behaviour is a dry run",
+    )
+    parser.add_argument(
         "--service-id",
         default=DEFAULT_SERVICE_ID,
         help=f"Model-runner service id to test against (default: {DEFAULT_SERVICE_ID})",
@@ -457,6 +534,7 @@ def main():
                 reports_dir=reports_dir,
                 skip_cache=args.skip_cache,
                 service_id=args.service_id,
+                environment=args.environment,
             )
         )
 


### PR DESCRIPTION
## Motivation

The nightly model-testing workflow called model-runner's `test()` without
`custom_environment`, so every model in the zoo was tested in the runner's own
serving runtime. That default is correct for most models, but it is guaranteed
to fail for models that cannot run in that runtime at all:

- The four Cellpose 3.x models (`famous-fish`, `happy-elephant`,
  `merry-gorilla`, `thoughtful-chipmunk`) import modules the Cellpose 4 API
  removed. Each artifact pins a conda-forge `cellpose=3.1.0` environment
  precisely so its test can run, and the nightly never asked for it. Their
  inference is served by the separate cellpose3-runner app.
- The six micro-sam models need `micro_sam` (and `mobile_sam` for the vit_t
  variants), which the serving runtime does not carry.

Until model-runner 2.0.0 rolled out, these failures were masked. The report
currency check keys on the installed `bioimageio.core` / `bioimageio.spec`
versions, so the standard-environment test was short-circuited by a stale cache
hit rather than actually executed. The version bump invalidated the whole zoo
and the real result surfaced.

## Solution

Introduce an explicit `CUSTOM_ENV_MODEL_IDS` policy table in
`scripts/bioengine_model_test.py`, listing the models that must be tested in
the environment declared by their own RDF. Everything else keeps the serving
runtime.

That default is deliberate: the serving runtime is the interpreter the website
actually runs inference in, so a pass there is the signal that matters to
users. A model belongs on the list only when it genuinely cannot run in the
serving runtime and is expected to be consumed through its own environment.

Note that the runner silently downgrades a custom request back to the serving
runtime for any model that declares no dependencies, so listing such a model
has no effect. The table only names models that really declare an environment.

## Behaviour

`--environment {auto,custom,standard}`, surfaced as a `workflow_dispatch`
input:

- `auto` (default, and what the cron uses) applies the per-model policy table.
- `custom` / `standard` force one choice for every model in the run.

Forcing does not currently bypass the report cache. If a current report exists
the runner returns it unchanged, recorded environment included, so the force is
inert on its own. Pair it with `skip_cache` to actually re-test. Both the
`--help` text and the dispatch input description say so, since the dispatch
form is where the choice is made.

Because the currency check ignores the recorded test environment, existing
reports are not invalidated by this change. Affected models pick up the correct
environment on their next genuine cache miss, so the migration is a one-time
re-test rather than a permanent increase in nightly work.

## Test plan

- `--environment` and the policy helper exercised for all three values against
  the model-runner API; submitted runs carry the intended `custom_environment`
  flag.
- Workflow YAML parses and the argument wiring was checked for each input
  combination, including the `auto` path that adds no flag.
- The six micro-sam staged models were run in the default environment and
  report `test_environment=standard`, confirming the flag reaches the runner.

## Files

- `scripts/bioengine_model_test.py` — policy table, `wants_custom_env()`,
  `custom_environment` threaded into `run_test()`, `--environment` flag.
- `.github/workflows/model-testing.yml` — `environment` dispatch input and
  argument wiring.
