### PR TITLE
Stop discarding test reports that carry no model id

### DIFF
--- a/src/components/ArtifactDetails.tsx
+++ b/src/components/ArtifactDetails.tsx
@@ -365,7 +365,15 @@ const ArtifactDetails = () => {
     fetchBioengineStatus();
   }, [selectedResource?.id, selectedResource?.manifest?.type, isStaged]);
 
-  // Validation function to check if parsed JSON is a valid test report
+  // Validation function to check if parsed JSON is a valid test report.
+  //
+  // `id` is deliberately NOT required. It mirrors the RDF's optional top-level
+  // `id` field, so bioimageio emits `id: null` for any model whose rdf.yaml
+  // omits it (e.g. the CellposeDINO models). Requiring it here discarded
+  // otherwise-passing reports, which surfaced as "not tested" in the
+  // Compatibilities section while the Edit page showed the same report as
+  // passed. Nothing rendered from this report needs the id: the compatibility
+  // row reads `status` and `env`, and TestDetailsDialog already guards it.
   const isValidTestReport = (data: any): data is DetailedTestReport => {
     return (
       data &&
@@ -375,7 +383,6 @@ const ArtifactDetails = () => {
       typeof data.source_name === 'string' &&
       typeof data.type === 'string' &&
       typeof data.format_version === 'string' &&
-      typeof data.id === 'string' &&
       Array.isArray(data.details)
     );
   };

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -61,7 +61,8 @@ export interface TestDetail {
 export interface DetailedTestReport {
   name: string;
   source_name: string;
-  id: string;
+  /** Mirrors the RDF's optional top-level `id`; absent for models that omit it. */
+  id?: string;
   type: string;
   format_version: string;
   status: 'passed' | 'failed' | 'valid-format';


### PR DESCRIPTION
## Motivation

A model's test report is read by two pages, and they disagreed. The Edit page showed a
report as passed while the Compatibilities section of the same model's detail page showed
BioEngine as "not tested".

The cause is the `id` field. `id` is optional at the top level of a bioimageio RDF, and
`bioimageio.core` faithfully emits `id: null` in the generated test report for any model
whose `rdf.yaml` omits it. `ArtifactDetails.tsx` validated incoming reports with a
predicate that required `typeof data.id === 'string'`, so those reports were rejected
wholesale and the component fell back to its untested state. `Edit.tsx` reads the exact
same URL and applies no validation, hence the divergence.

This affects any model whose RDF has no top-level `id`, not a fixed list of models.

## Solution

Drop the `id` requirement from `isValidTestReport` and make `id` optional on the
`DetailedTestReport` type.

Nothing rendered from the report needs an id. The compatibility row reads `status` and
`env`, and `TestDetailsDialog` already guards its one usage with `{reportData.id && …}`,
so relaxing the type introduces no new unchecked access.

The remaining required fields (`name`, `status`, `source_name`, `type`, `format_version`,
and an array `details`) are unchanged, so malformed or empty payloads are still rejected.

## Behaviour

Before: models without a top-level RDF `id` render as "not tested" in Compatibilities, and
their version chip fails to open the detailed report dialog (the same predicate gates
`fetchDetailedTestReport`).

After: those reports load and render their real status. Models that already carried an `id`
are unaffected.

## Test plan

- `tsc --noEmit`: 2178 errors on the branch, 2178 with the two files reverted to `main`.
  Zero new errors, none in the touched files. The 2178 is a pre-existing repo-wide baseline.
- `react-scripts build` succeeds.
- Both predicates (old and new) replayed against six live published/staged test reports:
  the four affected slots go from rejected to accepted, the two that already had an `id`
  are accepted by both.
- Negative controls (`null`, `{}`, a partial object, and `details` not an array) are still
  rejected by the new predicate.

## Files

- `src/components/ArtifactDetails.tsx` — remove the `id` check from `isValidTestReport`,
  with a comment recording why the field can be absent.
- `src/types/artifact.ts` — `DetailedTestReport.id` becomes optional.
