### PR TITLE
fix(details): render a FileDescr license instead of crashing the page

### DIFF
--- a/src/components/ArtifactDetails.tsx
+++ b/src/components/ArtifactDetails.tsx
@@ -28,7 +28,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import WarningIcon from '@mui/icons-material/Warning';
 import ModelRunner from './ModelRunner';
 import HintTooltip from './HintTooltip';
-import { resolveHyphaUrl, resolveTestReportUrl } from '../utils/urlHelpers';
+import { resolveHyphaUrl, resolveTestReportUrl, extractFilePath } from '../utils/urlHelpers';
 import { BIOIMAGEIO_YAML, RDF_YAML } from '../utils/rdfFile';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
@@ -2140,7 +2140,25 @@ const ArtifactDetails = () => {
                 <GavelIcon sx={{ mr: 1, verticalAlign: 'middle' }} />
                 License
               </Typography>
-              <Typography variant="body1" sx={{ color: '#4b5563', fontWeight: 500 }}>{manifest.license}</Typography>
+              {/* `license` is either an SPDX identifier or, since spec 0.5.11, a
+                  FileDescr pointing at a custom license file. Render the
+                  identifier as text and the file as a link to it, never the
+                  raw descriptor: a bare object here throws and blanks the page. */}
+              {manifest.license && typeof manifest.license !== 'string' ? (
+                <Link
+                  href={resolveHyphaUrl(manifest.license, selectedResource.id)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  sx={{ color: '#2563eb', fontWeight: 500, display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                >
+                  {extractFilePath(manifest.license)}
+                  <OpenInNewIcon sx={{ fontSize: 16 }} />
+                </Link>
+              ) : (
+                <Typography variant="body1" sx={{ color: '#4b5563', fontWeight: 500 }}>
+                  {manifest.license || 'Not specified'}
+                </Typography>
+              )}
             </CardContent>
           </Card>
         </Grid>

--- a/src/components/Edit.tsx
+++ b/src/components/Edit.tsx
@@ -18,7 +18,7 @@ import { getArtifactRights, getIsReviewer, buildContributorPermissions } from '.
 import { isInternalArtifactFile } from '../utils/internalFiles';
 import { BIOIMAGEIO_YAML, RDF_YAML, isRdfFileName, endsWithRdfFileName, detectRdfFileName } from '../utils/rdfFile';
 import { HYPHA_SERVER_URL } from '../config/hypha';
-import { resolveTestReportUrl } from '../utils/urlHelpers';
+import { resolveTestReportUrl, extractFilePath } from '../utils/urlHelpers';
 import { updateManifestSha256, updateRdfFileReference } from '../utils/sha-handling';
 
 // Helper function to extract weight file paths from manifest
@@ -1488,8 +1488,11 @@ const Edit: React.FC = () => {
       const fileType = selectedFile.name.split('.').pop()?.toUpperCase() || 'Unknown';
       
       // Check if this is a cover image
+      // covers entries are plain paths on older models and FileDescr objects on
+      // spec 0.5.11+ ones; comparing the raw entry never matches the latter, so
+      // the oversized-cover warning silently stopped firing for new models.
       const isCoverImage = artifactInfo?.manifest?.covers?.some(
-        cover => cover === selectedFile.name
+        cover => extractFilePath(cover) === selectedFile.name
       );
       
       // Determine warning status for cover images

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -98,8 +98,8 @@ export interface ArtifactInfo {
     id_emoji?: string | null;
     tags?: string[];
     badges?: Badge[];
-    covers?: string[];
-    documentation?: string;
+    covers?: FileRef[];
+    documentation?: FileRef;
     authors?: Author[];
     maintainers?: Maintainer[];
     cite?: Citation[];
@@ -109,7 +109,7 @@ export interface ArtifactInfo {
       label: string;
     }[];
     git_repo?: string;
-    license?: string;
+    license?: FileRef;
     uploader: Uploader;
     status?: string;
   };
@@ -133,6 +133,20 @@ export interface ArtifactInfo {
   description?: string; // From manifest
   _id?: string; // Internal ID
 }
+
+/**
+ * bioimageio.spec 0.5.11 turned several path-valued RDF fields into a union:
+ * either the plain relative path they always were, or a FileDescr object
+ * carrying the path plus its checksum. `license` is the same union with one
+ * extra member, a bare SPDX identifier, which is a string but NOT a path.
+ * Anything reading these fields must normalize first (see utils/urlHelpers).
+ */
+export interface FileDescr {
+  source: string;
+  sha256?: string;
+}
+
+export type FileRef = string | FileDescr;
 
 export interface Documentation {
   url?: string;

--- a/src/utils/bookmarkUtils.ts
+++ b/src/utils/bookmarkUtils.ts
@@ -1,8 +1,11 @@
+import { FileRef } from '../types/artifact';
+
 export interface BookmarkedArtifact {
   id: string;
   name: string;
   description: string;
-  covers?: string[];
+  /** Same string-or-FileDescr union the RDF carries; resolve with resolveHyphaUrl. */
+  covers?: FileRef[];
   icon?: string;
 }
 

--- a/src/utils/urlHelpers.ts
+++ b/src/utils/urlHelpers.ts
@@ -1,4 +1,5 @@
 import { HYPHA_SERVER_URL } from '../config/hypha';
+import { FileRef } from '../types/artifact';
 
 /**
  * bioimageio.spec 0.5.11 changed several fields from plain string paths to
@@ -7,9 +8,15 @@ import { HYPHA_SERVER_URL } from '../config/hypha';
  * ones it's a descriptor. Normalize both shapes here so every consumer
  * (covers, documentation, etc.) can pass the raw value straight through.
  */
-type FileLike = string | { source?: string } | null | undefined;
+type FileLike = FileRef | null | undefined;
 
-const extractPath = (input: FileLike): string => {
+/**
+ * Returns the relative path a manifest field points at, for both shapes.
+ * Use this instead of touching the field directly: rendering a FileDescr as a
+ * React child throws ("objects are not valid as a React child"), and comparing
+ * one to a filename silently never matches.
+ */
+export const extractFilePath = (input: FileLike): string => {
   if (!input) return '';
   if (typeof input === 'string') return input;
   return typeof input.source === 'string' ? input.source : '';
@@ -23,7 +30,7 @@ const extractPath = (input: FileLike): string => {
  */
 
 export const resolveHyphaUrl = (path: FileLike, resourceId: string, use_proxy: boolean = false): string => {
-  const source = extractPath(path);
+  const source = extractFilePath(path);
   if (!source) return '';
 
   // If the source is already a full URL, return it as is


### PR DESCRIPTION
## Motivation

`bioimageio.spec` 0.5.11 widened the RDF `license` field from a bare SPDX
identifier to `LicenseId | DeprecatedLicenseId | None | FileDescr`. A model that
ships its own license file therefore carries `{source, sha256}` there instead of
a string.

`ArtifactDetails` rendered `{manifest.license}` straight into JSX. Rendering a
bare object as a React child throws React error #31 ("objects are not valid as a
React child"), which unmounts the entire React root rather than just breaking one
component. The result was a fully blank page for any such model: both the model
detail page and the preview dialog on the review page. `bioimage-io/naked-rabbit`
is a live example.

## Solution

Render an SPDX identifier as text exactly as before, and render a `FileDescr` as a
link to the license file, resolved through `resolveHyphaUrl`.

The same string-or-`FileDescr` union already applied to `covers` and
`documentation`, and `urlHelpers` already normalised both shapes correctly. But
the manifest types still declared them `string[]` and `string`, so nothing
prevented a descriptor from being treated as a string. That lying type is what let
this reach production. This PR introduces `FileRef = string | FileDescr` and
widens all three fields, so the next occurrence of this class of bug is a compile
error instead of a blank page. `urlHelpers`' internal path extractor is exported as
`extractFilePath` for callers that need the path rather than a URL.

Widening the types surfaced one existing instance of the same bug. `Edit.tsx`
matched cover images with `cover === selectedFile.name`, which never matches a
`FileDescr`, so the oversized-cover warning had silently stopped firing for
0.5.11+ models.

## Behaviour

| `license` in the RDF | Before | After |
| --- | --- | --- |
| `"CC-BY-4.0"` | rendered as text | unchanged |
| `{source: "LICENSE_SAM.txt", sha256: …}` | blank page, React error #31 | link to the license file |
| absent | blank | "Not specified" |

No migration needed. Both shapes are spec-valid and both are handled.

## Test plan

- `react-scripts build` passes; no new lint warnings.
- Verified against a production build with two real models, checking for page
  errors in the console:
  - `bioimage-io/naked-rabbit` (`format_version` 0.5.12, `license` is a
    `FileDescr`) renders `LICENSE_SAM.txt` as a link, and the linked file URL
    returns 200.
  - `bioimage-io/affable-shark` (`license` is `"CC-BY-4.0"`) is unchanged.

The edit and bookmark entry points require a reviewer login and were not driven
directly. They render through the same component, and no other object-into-JSX
render was found behind either path.

## Files

- `src/components/ArtifactDetails.tsx` — render the license as text or as a link.
- `src/types/artifact.ts` — add `FileDescr` / `FileRef`; widen `covers`,
  `documentation`, `license`.
- `src/utils/urlHelpers.ts` — export `extractFilePath`.
- `src/components/Edit.tsx` — normalise cover paths before comparing filenames.
- `src/utils/bookmarkUtils.ts` — widen `covers` to match the manifest type.
