### PR TITLE
feat(finetune): ask the trainer which base models fit, grey out the rest

### DIFF
--- a/src/components/annotate/CellposeConfigDialog.tsx
+++ b/src/components/annotate/CellposeConfigDialog.tsx
@@ -580,7 +580,7 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
                     return cellposeAvailable ? dinoOption.label : `${dinoOption.label} (unavailable)`;
                   }
                   const option = MICRO_SAM_MODEL_OPTIONS.find((o) => o.modelType === value);
-                  const label = option ? option.label.replace(' (default)', '') : value;
+                  const label = option ? option.label : value;
                   const marker = option?.group === 'em_organelles' ? 'EM' : 'LM';
                   return microSamAvailable
                     ? `μSAM ${label} (${marker})`
@@ -597,7 +597,7 @@ const CellposeConfigDialog: React.FC<CellposeConfigDialogProps> = ({
                       {MICRO_SAM_GROUP_LABELS[group]}
                     </ListSubheader>,
                     ...optionsInGroup.map((option) => {
-                      const shortLabel = option.label.replace(' (default)', '');
+                      const shortLabel = option.label;
                       const marker = option.group === 'em_organelles' ? 'EM' : 'LM';
                       return (
                         <MenuItem

--- a/src/components/annotate/SamBoxModelDialog.tsx
+++ b/src/components/annotate/SamBoxModelDialog.tsx
@@ -20,6 +20,7 @@ import ReplayIcon from '@mui/icons-material/Replay';
 import {
   MICRO_SAM_MODEL_OPTIONS,
   MICRO_SAM_GROUP_LABELS,
+  MICRO_SAM_MODEL_TYPE,
   MicroSamModelOption,
 } from '../../utils/microSamService';
 
@@ -132,8 +133,12 @@ const SamBoxModelDialog: React.FC<SamBoxModelDialogProps> = ({
             bgcolor: selected ? 'secondary.main' : 'action.disabledBackground',
           }} />
           <Box sx={{ flex: 1, minWidth: 0 }}>
+            {/* "(default)" is a property of THIS dialog, not of the model:
+                MICRO_SAM_MODEL_TYPE is the box-prompt default only. Marking it
+                on the shared option label instead would leak it into the
+                fine-tuning picker, whose default is a different model. */}
             <Typography variant="body2" fontWeight={selected ? 700 : 500} color={selected ? 'secondary.main' : 'text.primary'}>
-              {option.label}
+              {option.modelType === MICRO_SAM_MODEL_TYPE ? `${option.label} (default)` : option.label}
             </Typography>
           </Box>
           {isLoaded ? (

--- a/src/components/colab/DatasetOverview.tsx
+++ b/src/components/colab/DatasetOverview.tsx
@@ -41,6 +41,7 @@ import {
   updateSplit,
 } from './brokerApi';
 import { resolvePinnedMicroSamTrainingService } from '../../utils/microSamTrainingPin';
+import { useTrainingCapabilities } from '../../hooks/useTrainingCapabilities';
 import { isSmallImageDims, readImageDimensions, SMALL_IMAGE_WARNING_TEXT } from '../../utils/imageSize';
 import LabelManager from './LabelManager';
 import FinetuneView from './FinetuneView';
@@ -289,6 +290,12 @@ const DatasetOverview: React.FC<DatasetOverviewProps> = ({
   const [splitSaveError, setSplitSaveError] = useState<string | null>(null);
   const [showEmptyTestWarning, setShowEmptyTestWarning] = useState(false);
   const [ftModelType, setFtModelType] = useState<string>('vit_t_lm');
+  // Which base models the pinned model-finetune replica's GPU can actually
+  // fit. Fetched here rather than in FinetuneView because that panel is
+  // presentational and has no `server`; see utils/trainingCapabilities.ts for
+  // why this must come from the same pinned replica that runs the training.
+  const { capabilities: trainingCapabilities, loading: trainingCapabilitiesLoading } =
+    useTrainingCapabilities(finetuneViewOpen ? server : null);
   const [ftShowAdvanced, setFtShowAdvanced] = useState(false);
   const [ftNEpochs, setFtNEpochs] = useState(5);
   const [ftNObjectsPerBatch, setFtNObjectsPerBatch] = useState(8);
@@ -1893,6 +1900,8 @@ print("Service registered successfully", end='')
                 onSaveSplit={handleSaveSplit}
                 modelType={ftModelType}
                 onModelTypeChange={setFtModelType}
+                trainingCapabilities={trainingCapabilities}
+                trainingCapabilitiesLoading={trainingCapabilitiesLoading}
                 showAdvanced={ftShowAdvanced}
                 onToggleAdvanced={() => setFtShowAdvanced((v) => !v)}
                 nEpochs={ftNEpochs}

--- a/src/components/colab/FinetuneView.tsx
+++ b/src/components/colab/FinetuneView.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { SplitDoc, SplitSummary } from './brokerApi';
-import { MICRO_SAM_TRAINABLE_MODEL_OPTIONS, MICRO_SAM_GROUP_LABELS, MicroSamModelOption } from '../../utils/microSamService';
+import { MICRO_SAM_MODEL_OPTIONS, MICRO_SAM_GROUP_LABELS, MicroSamModelOption } from '../../utils/microSamService';
+import {
+  TrainingCapabilities,
+  describeTrainingGpu,
+  findModelCapability,
+  isModelTrainable,
+} from '../../utils/trainingCapabilities';
 
 export interface FinetuneViewRow {
   stem: string;
@@ -35,6 +41,12 @@ export interface FinetuneViewProps {
   onSaveSplit: () => void;
   modelType: string;
   onModelTypeChange: (value: string) => void;
+  // Live per-model "can this trainer fit it?" verdict from the pinned
+  // model-finetune replica. `null` means no verdict yet (still loading, or the
+  // call failed), in which case every base model stays selectable and the
+  // backend rejects an unfit one with a readable error.
+  trainingCapabilities: TrainingCapabilities | null;
+  trainingCapabilitiesLoading: boolean;
   showAdvanced: boolean;
   onToggleAdvanced: () => void;
   nEpochs: number;
@@ -109,6 +121,8 @@ const FinetuneView: React.FC<FinetuneViewProps> = ({
   onSaveSplit,
   modelType,
   onModelTypeChange,
+  trainingCapabilities,
+  trainingCapabilitiesLoading,
   showAdvanced,
   onToggleAdvanced,
   nEpochs,
@@ -150,6 +164,14 @@ const FinetuneView: React.FC<FinetuneViewProps> = ({
   const effectiveModelType = isCheckpointed ? activeSplit!.checkpoint!.model_type : modelType;
   const trainingSteps = nEpochs * Math.max(trainCount, 100);
   const durationEstimate = formatDurationEstimate(trainingSteps, effectiveModelType);
+
+  // Only explain the greying when there is something greyed out. With no
+  // capabilities yet (loading, or the call failed) nothing is disabled, so
+  // this is false and the note stays hidden.
+  const hasUnfitModel = MICRO_SAM_MODEL_OPTIONS.some(
+    (o) => !isModelTrainable(trainingCapabilities, o.modelType),
+  );
+  const trainerGpuLabel = describeTrainingGpu(trainingCapabilities, 'microsam');
 
   return (
     <div className="bg-white rounded-2xl border border-gray-200 p-4 h-full flex flex-col overflow-y-auto">
@@ -258,30 +280,55 @@ const FinetuneView: React.FC<FinetuneViewProps> = ({
             <label className="block text-xs font-medium text-gray-500 mb-1.5">Base model</label>
             <div className="mb-3 space-y-2">
               {(['lm', 'em_organelles'] as const).map((group) => {
-                const optionsInGroup = MICRO_SAM_TRAINABLE_MODEL_OPTIONS.filter((o: MicroSamModelOption) => o.group === group);
+                const optionsInGroup = MICRO_SAM_MODEL_OPTIONS.filter((o: MicroSamModelOption) => o.group === group);
                 if (optionsInGroup.length === 0) return null;
                 return (
                   <div key={group}>
                     <p className="text-[0.65rem] font-medium text-gray-400 mb-1">{MICRO_SAM_GROUP_LABELS[group]}</p>
                     <div className="flex gap-2">
-                      {optionsInGroup.map((opt: MicroSamModelOption) => (
-                        <button
-                          key={opt.modelType}
-                          onClick={() => onModelTypeChange(opt.modelType)}
-                          className={`flex-1 px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
-                            modelType === opt.modelType
-                              ? 'bg-purple-50 border-purple-300 text-purple-700'
-                              : 'bg-white border-gray-200 text-gray-600 hover:border-purple-200'
-                          }`}
-                        >
-                          {opt.label}
-                        </button>
-                      ))}
+                      {optionsInGroup.map((opt: MicroSamModelOption) => {
+                        // Every model is listed. The ones this trainer's GPU
+                        // cannot fit are rendered disabled with the backend's
+                        // own reason attached, rather than omitted, so "we
+                        // don't offer it" and "your hardware can't run it"
+                        // stop looking identical.
+                        const enabled = isModelTrainable(trainingCapabilities, opt.modelType);
+                        const reason = findModelCapability(trainingCapabilities, opt.modelType)?.reason;
+                        return (
+                          <button
+                            key={opt.modelType}
+                            onClick={() => onModelTypeChange(opt.modelType)}
+                            disabled={!enabled}
+                            title={enabled ? undefined : reason || 'This model is not trainable on the current GPU'}
+                            className={`flex-1 px-3 py-2 rounded-lg text-xs font-medium border transition-[background-color,border-color,color,transform] duration-150 ease-out ${
+                              !enabled
+                                ? 'bg-gray-50 border-gray-200 text-gray-400 cursor-not-allowed'
+                                : modelType === opt.modelType
+                                ? 'bg-purple-50 border-purple-300 text-purple-700 active:scale-[0.97]'
+                                : 'bg-white border-gray-200 text-gray-600 hover:border-purple-200 active:scale-[0.97]'
+                            }`}
+                          >
+                            {opt.label}
+                          </button>
+                        );
+                      })}
                     </div>
                   </div>
                 );
               })}
             </div>
+            {trainingCapabilitiesLoading ? (
+              <p className="text-[0.65rem] text-gray-400 -mt-2 mb-3">
+                Checking which models this trainer's GPU can fit...
+              </p>
+            ) : (
+              hasUnfitModel && (
+                <p className="text-[0.65rem] text-gray-400 -mt-2 mb-3">
+                  Greyed-out models need more memory than {trainerGpuLabel ?? 'the training GPU'} has.
+                  Hover one to see how much.
+                </p>
+              )
+            )}
           </>
         )}
 

--- a/src/hooks/useTrainingCapabilities.ts
+++ b/src/hooks/useTrainingCapabilities.ts
@@ -1,0 +1,60 @@
+/**
+ * React wrapper around `fetchTrainingCapabilities`. Mount it wherever a
+ * base-model picker renders; the underlying fetch is cached per tab, so several
+ * mounts cost one round-trip.
+ *
+ * Failure is not an error state the caller has to render. On failure the hook
+ * returns `capabilities: null`, which the `isModelTrainable` helper reads as
+ * "no verdict, leave everything enabled". `error` is exposed only so a caller
+ * can log it or explain the missing greying, never to block the picker.
+ */
+import { useEffect, useState } from 'react';
+import {
+  fetchTrainingCapabilities,
+  TrainingCapabilities,
+} from '../utils/trainingCapabilities';
+
+export interface UseTrainingCapabilitiesResult {
+  capabilities: TrainingCapabilities | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * @param server A connected hypha-rpc server proxy, or null while connecting.
+ *               Passing null keeps the hook idle rather than erroring, so a
+ *               picker can render before login completes.
+ */
+export function useTrainingCapabilities(server: any | null): UseTrainingCapabilitiesResult {
+  const [capabilities, setCapabilities] = useState<TrainingCapabilities | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!server) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchTrainingCapabilities(server)
+      .then((caps) => {
+        if (cancelled) return;
+        setCapabilities(caps);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        // Deliberately non-fatal: the picker falls back to offering everything
+        // and start_training rejects an unfit model with a readable error.
+        console.warn('[useTrainingCapabilities] Could not read trainer capabilities:', err);
+        setCapabilities(null);
+        setError((err as Error)?.message || String(err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [server]);
+
+  return { capabilities, loading, error };
+}

--- a/src/utils/microSamService.ts
+++ b/src/utils/microSamService.ts
@@ -45,16 +45,18 @@ export const MICRO_SAM_SERVICE_ID = 'bioimage-io/model-finetune';
 // generated the embedding. ('vit_b_lm' is the lighter fallback if ever needed.)
 export const MICRO_SAM_MODEL_TYPE = 'vit_l_lm';
 
-/** One selectable μSAM generalist in the Full Image Segmentation model
- *  picker. ``group`` drives which subheader an option renders under.
- *  ``trainableOnT4`` is fine-tuning-specific: serving (segmentation/
- *  annotation) never reads it, only MICRO_SAM_TRAINABLE_MODEL_OPTIONS
- *  filters on it. */
+/** One selectable μSAM generalist. Shared by the Full Image Segmentation
+ *  picker, the box-prompt picker, and the fine-tuning base-model picker.
+ *  ``group`` drives which subheader an option renders under.
+ *
+ *  This list owns presentation only (display label, grouping, order), because
+ *  the backend carries neither. Whether a model can actually be fine-tuned is
+ *  NOT recorded here: it depends on the training GPU, so it is read live from
+ *  ``get_training_capabilities`` (see utils/trainingCapabilities.ts). */
 export interface MicroSamModelOption {
   modelType: string;
   group: 'lm' | 'em_organelles';
   label: string;
-  trainableOnT4: boolean;
 }
 
 /** Human-readable subheader per group, in display order. Only groups that
@@ -70,27 +72,22 @@ export const MICRO_SAM_GROUP_LABELS: Record<MicroSamModelOption['group'], string
 // groups by `group` generically, so this array is the single place either
 // group's membership is defined.
 //
-// trainableOnT4: false on both "Large" entries per colab-rework-plan.md §20.2
-// and confirmed again on 0.10.0 (round-30, 2026-08-17, keen-puma relaying
-// live-kudu's 0.8.5 test): vit_l_* OOMs the deNBI T4 during fine-tuning,
-// serving is unaffected. Flip to true here once a backend fix lands. This is
-// training-only: the segmentation/annotation selector ignores this flag and
-// keeps offering all 6.
+// 2026-09-04: this list used to carry a `trainableOnT4` flag, and the Finetune
+// page filtered on it via a `MICRO_SAM_TRAINABLE_MODEL_OPTIONS` derived array,
+// which is why the "Large" entries silently never appeared there. The flag was
+// a one-off measurement against de.NBI's T4 and had no way to notice a GPU
+// upgrade or a second training site. model-finetune 0.14.0's
+// `get_training_capabilities` answers it live instead, so all 6 are listed
+// unconditionally here and the picker greys out whatever the trainer reports
+// it cannot fit. See utils/trainingCapabilities.ts.
 export const MICRO_SAM_MODEL_OPTIONS: MicroSamModelOption[] = [
-  { modelType: 'vit_t_lm', group: 'lm', label: 'Tiny', trainableOnT4: true },
-  { modelType: 'vit_b_lm', group: 'lm', label: 'Base', trainableOnT4: true },
-  { modelType: 'vit_l_lm', group: 'lm', label: 'Large (default)', trainableOnT4: false },
-  { modelType: 'vit_t_em_organelles', group: 'em_organelles', label: 'Tiny', trainableOnT4: true },
-  { modelType: 'vit_b_em_organelles', group: 'em_organelles', label: 'Base', trainableOnT4: true },
-  { modelType: 'vit_l_em_organelles', group: 'em_organelles', label: 'Large', trainableOnT4: false },
+  { modelType: 'vit_t_lm', group: 'lm', label: 'Tiny' },
+  { modelType: 'vit_b_lm', group: 'lm', label: 'Base' },
+  { modelType: 'vit_l_lm', group: 'lm', label: 'Large' },
+  { modelType: 'vit_t_em_organelles', group: 'em_organelles', label: 'Tiny' },
+  { modelType: 'vit_b_em_organelles', group: 'em_organelles', label: 'Base' },
+  { modelType: 'vit_l_em_organelles', group: 'em_organelles', label: 'Large' },
 ];
-
-/** Subset of MICRO_SAM_MODEL_OPTIONS safe to offer as a fine-tuning base
- *  model. Use this (not MICRO_SAM_MODEL_OPTIONS) for the Finetune page's
- *  base-model picker; the Full Image Segmentation / annotation picker should
- *  keep using the full list. */
-export const MICRO_SAM_TRAINABLE_MODEL_OPTIONS: MicroSamModelOption[] =
-  MICRO_SAM_MODEL_OPTIONS.filter((o) => o.trainableOnT4);
 
 /**
  * Resolve a fresh handle to the BioImageIO Fine-tune service. Cheap (one

--- a/src/utils/trainingCapabilities.ts
+++ b/src/utils/trainingCapabilities.ts
@@ -1,0 +1,150 @@
+/**
+ * Live "which base models can this trainer actually fine-tune?" verdict, from
+ * `get_training_capabilities()` on `bioimage-io/model-finetune` (0.14.0+).
+ *
+ * Why this exists
+ * ---------------
+ * The base-model pickers used to filter against a `trainableOnT4` boolean
+ * hardcoded in `microSamService.ts`. That boolean was measured once against
+ * de.NBI's Tesla T4 and then went stale by construction: upgrade the training
+ * GPU, or bring a second site with a bigger card online, and the picker keeps
+ * hiding models that would now train fine, with nothing to alert anyone. The
+ * backend now answers the question itself, so ask it.
+ *
+ * Which GPU is being described
+ * ----------------------------
+ * Deliberately resolved through `resolvePinnedMicroSamTrainingService`, NOT
+ * the load-balanced `resolveMicroSamService`. A fine-tuning session's state
+ * (checkpoints, status.json) lives on one replica's local disk, so every
+ * training call is already pinned to a single worker for the tab's lifetime.
+ * Routing capabilities through that same pin makes "the GPU that answered" and
+ * "the GPU that will run start_training" the same card by construction, rather
+ * than by luck. Without the pin, a second site with different hardware would
+ * silently make the picker advertise one worker's VRAM while training ran on
+ * another's.
+ *
+ * `trainable` is a hardware verdict, not a right-now verdict
+ * ---------------------------------------------------------
+ * The backend compares each model's minimum against the card's TOTAL memory,
+ * not its free memory, and that is intentional: a picker should answer "can
+ * this card ever train this model", not "is the card busy this second". A
+ * model can therefore read `trainable: true` and still OOM if another job holds
+ * the GPU. That surfaces as a clear `start_training` error, which is a better
+ * experience than a button that flickers with someone else's load. Never gate
+ * the UI on `free_mb`.
+ */
+import { resolvePinnedMicroSamTrainingService } from './microSamTrainingPin';
+
+/** Per-backend GPU report. `available: false` means that runtime is down. */
+export interface TrainingGpuInfo {
+  available: boolean;
+  total_mb?: number;
+  free_mb?: number;
+  device_name?: string;
+}
+
+/**
+ * One model's verdict. `trainable` is `null` (not `false`) when the backend's
+ * runtime is unavailable, so "too big for this card" and "we cannot tell right
+ * now" stay distinguishable; the UI disables both, but only the former can
+ * quote a memory shortfall.
+ */
+export interface TrainingModelCapability {
+  model_type: string;
+  /** 'microsam' | 'cellpose' today; treat as an open string set. */
+  backend: string;
+  min_gpu_memory_mb?: number;
+  trainable: boolean | null;
+  /** Human-readable, e.g. 'fits' or 'needs ~24000 MB, GPU has 14912 MB'. */
+  reason?: string;
+}
+
+export interface TrainingCapabilities {
+  gpus: Record<string, TrainingGpuInfo>;
+  models: TrainingModelCapability[];
+}
+
+/**
+ * Cached across the tab: capabilities describe hardware, which does not change
+ * between two clicks, and the pinned replica does not change either. Stored as
+ * the in-flight promise so concurrent mounts share one round-trip. Only the
+ * plain response is cached, never a service proxy (those expire).
+ */
+let capabilitiesPromise: Promise<TrainingCapabilities> | null = null;
+
+/** Drop the cache so the next read re-asks. Call after a Hypha reconnect. */
+export function resetTrainingCapabilitiesCache(): void {
+  capabilitiesPromise = null;
+}
+
+/**
+ * Fetch the trainer's capabilities, once per tab.
+ *
+ * @param server A connected hypha-rpc server proxy.
+ * @throws Whatever the RPC threw. Callers decide the fallback; see
+ *         `useTrainingCapabilities` for the one the pickers use.
+ */
+export async function fetchTrainingCapabilities(server: any): Promise<TrainingCapabilities> {
+  if (!capabilitiesPromise) {
+    capabilitiesPromise = (async () => {
+      const svc = await resolvePinnedMicroSamTrainingService(server);
+      const caps = await svc.get_training_capabilities();
+      if (!caps || !Array.isArray(caps.models)) {
+        throw new Error('get_training_capabilities returned an unexpected shape');
+      }
+      return caps as TrainingCapabilities;
+    })().catch((err) => {
+      // Don't cache a failure: a trainer that was down when the page loaded
+      // should become usable again without a reload.
+      capabilitiesPromise = null;
+      throw err;
+    });
+  }
+  return capabilitiesPromise;
+}
+
+/**
+ * Look one model up. Returns `undefined` for a model the backend doesn't know,
+ * which callers must treat as "no verdict", not as "not trainable" (see
+ * `isModelTrainable`).
+ */
+export function findModelCapability(
+  caps: TrainingCapabilities | null,
+  modelType: string,
+): TrainingModelCapability | undefined {
+  return caps?.models.find((m) => m.model_type === modelType);
+}
+
+/**
+ * Should the picker offer this model?
+ *
+ * Fails OPEN: with no capabilities (call failed, still loading, or the backend
+ * doesn't list this model) every model stays clickable. This is a deliberate
+ * choice over failing closed. A greyed-out picker is a dead end the user cannot
+ * argue with, whereas an over-permissive one costs at most one rejected click:
+ * `start_training` hard-rejects an unfit model with a message naming the
+ * shortfall and the models that do fit, so a bypass always fails safe.
+ */
+export function isModelTrainable(
+  caps: TrainingCapabilities | null,
+  modelType: string,
+): boolean {
+  const entry = findModelCapability(caps, modelType);
+  if (!entry) return true;
+  return entry.trainable !== false && entry.trainable !== null;
+}
+
+/**
+ * Short sentence naming the card the verdicts came from, for the line under a
+ * picker that has greyed-out entries. Returns null when the backend reported no
+ * usable GPU for that backend, in which case there is no number worth showing.
+ */
+export function describeTrainingGpu(
+  caps: TrainingCapabilities | null,
+  backend: string,
+): string | null {
+  const gpu = caps?.gpus?.[backend];
+  if (!gpu || !gpu.available) return null;
+  const name = gpu.device_name || 'the training GPU';
+  return gpu.total_mb ? `${name} (${gpu.total_mb} MB)` : name;
+}


### PR DESCRIPTION
## Motivation

The fine-tuning base-model picker decided what to offer from a `trainableOnT4`
boolean hardcoded in `microSamService.ts`, and filtered the list down to the
models where it was `true`. Two consequences:

The two "Large" micro-SAM generalists never appeared at all. A user who has read
the micro-SAM docs and wants the large generalist has no way to tell whether it
was forgotten, whether it is broken, or whether their hardware cannot run it.

The flag was measured once against de.NBI's Tesla T4, and had no mechanism for
ever becoming wrong out loud. Upgrade the training GPU, or bring a second site
with a bigger card online, and the picker would keep hiding models that had
become trainable, with nothing to notice.

`model-finetune` 0.14.0 added `get_training_capabilities()`, which answers the
question against the hardware actually present. This PR asks it.

## Solution

`MICRO_SAM_MODEL_OPTIONS` keeps owning presentation only (display label,
grouping, order), because the backend carries none of that. The trainability
verdict is read live and no longer stored alongside it, so
`MICRO_SAM_TRAINABLE_MODEL_OPTIONS` and `trainableOnT4` are removed.

All six generalists are listed. The ones the trainer reports it cannot fit are
rendered disabled, with the backend's own reason (`needs ~24000 MB, GPU has
14912 MB`) on hover and a line beneath the picker naming the card.

Three decisions worth stating explicitly, since each is a trap in the other
direction:

**Capabilities are read through the pinned service handle**
(`resolvePinnedMicroSamTrainingService`), not the load-balanced
`resolveMicroSamService`. A fine-tuning session's checkpoints and `status.json`
live on one replica's local disk, so training calls are already pinned to a
single worker for the tab's lifetime. Routing capabilities through that same pin
makes "the GPU that answered" and "the GPU that will run `start_training`" the
same card by construction rather than by luck. Without it, a second site with
different hardware would make the picker advertise one worker's VRAM while
training ran on another's.

**Gating reads `trainable` only, never `free_mb`.** The backend compares each
model's minimum against the card's total memory deliberately: the picker should
answer "can this card ever train this model", not "is the card busy this second".
A model can read `trainable: true` and still OOM if another job holds the GPU,
which surfaces as a clear `start_training` error. That is better than a picker
that flickers with someone else's load.

**Failure fails open.** With no capabilities (still loading, the call failed, or
the backend does not list the model) every option stays clickable. A greyed-out
picker is a dead end the user cannot argue with, whereas an over-permissive one
costs at most one rejected click: `start_training` hard-rejects an unfit model
with a message naming the shortfall and the models that do fit.

## Behaviour

| | Before | After |
| --- | --- | --- |
| Models offered | 4 (both "Large" hidden) | all 6 |
| Model the GPU cannot fit | absent | disabled, reason on hover |
| Training GPU is upgraded | picker unchanged until someone edits the source | picker follows |
| Capabilities call fails | n/a | all 6 enabled, backend rejects an unfit choice |

No behaviour change for the annotation and box-prompt pickers, which never read
the removed flag.

Separately, `"Large (default)"` was baked into the shared option label. It
described the box-prompt default, and two call sites in `CellposeConfigDialog`
were already stripping it back off with `.replace(' (default)', '')`. Leaving it
would have surfaced "Large (default)" in a picker whose default is Tiny, so the
marker moves into `SamBoxModelDialog`, the one place it is true, and both
workarounds go away.

## Scope

The Cellpose base-model picker is not included. `get_training_capabilities()`
covers both backends, but that picker starts training on
`bioimage-io/cellpose-finetuning`, which is not registered on either production
worker. Adding `cpdino` / `cpdino-vitb` there would extend a path with no
backend. Moving that flow onto `model-finetune` is a data-contract migration
rather than a picker change: `start_training` takes paired image and label
arrays, not an artifact id plus `metadata_dir`.

## Test plan

- `react-scripts build` passes; no new lint warnings (the two warnings in touched
  files are pre-existing and unrelated).
- `get_training_capabilities()` verified live against
  `bioimage-io/model-finetune` on de.NBI: 12 models returned, Tesla T4,
  14912 MB total. `vit_l_lm` and `vit_l_em_organelles` report
  `trainable: false` with `needs ~24000 MB, GPU has 14912 MB`; the four
  Tiny/Base entries report `fits`. This matches the flag the picker previously
  hardcoded, so the visible model set is unchanged on today's hardware and the
  two Large entries become explained rather than absent.

The picker itself was not driven in a browser: the Finetune view sits behind
login and a dataset.

## Files

- `src/utils/trainingCapabilities.ts` (new) — fetch and cache the verdict from
  the pinned replica; `isModelTrainable` / `findModelCapability` /
  `describeTrainingGpu` helpers.
- `src/hooks/useTrainingCapabilities.ts` (new) — React wrapper; failure is not
  an error state the caller has to render.
- `src/utils/microSamService.ts` — drop `trainableOnT4` and
  `MICRO_SAM_TRAINABLE_MODEL_OPTIONS`; plain "Large" label.
- `src/components/colab/FinetuneView.tsx` — render all six, disable and explain
  the unfit ones.
- `src/components/colab/DatasetOverview.tsx` — fetch capabilities while the
  finetune view is open and pass them down.
- `src/components/annotate/SamBoxModelDialog.tsx` — mark its own default.
- `src/components/annotate/CellposeConfigDialog.tsx` — remove the two
  strip-the-suffix workarounds.
