### PR TITLE
fix(edit): keep the Review tab when it is opened from a URL

### DIFF
--- a/src/components/Edit.tsx
+++ b/src/components/Edit.tsx
@@ -772,7 +772,16 @@ const Edit: React.FC = () => {
     }
   };
 
-  const handleFileSelect = async (file: FileNode) => {
+  /**
+   * Load a file into the editor.
+   *
+   * `preserveTab` loads the file WITHOUT switching to the Files tab. The
+   * review panel derives its state (validation, unsaved changes, the Test
+   * Model gate) from the loaded RDF file, so the RDF has to be read even when
+   * the user asked for the Review tab. Rewriting the tab param there is what
+   * made `?tab=review` deep links bounce into the editor.
+   */
+  const handleFileSelect = async (file: FileNode, options?: { preserveTab?: boolean }) => {
     // First check if the file still exists in our files array
     const fileExists = files.some(f => f.path === file.path);
     if (!fileExists) {
@@ -785,7 +794,7 @@ const Edit: React.FC = () => {
 
     // Only update URL if it's different from current selection
     const currentPath = searchParams.get('tab')?.substring(1);
-    if (currentPath !== file.path) {
+    if (!options?.preserveTab && currentPath !== file.path) {
       handleTabChange('files', file.path);
     }
     
@@ -1755,13 +1764,18 @@ const Edit: React.FC = () => {
           handleFileSelect(fileToSelect);
         }
       } else {
-        setActiveTab(tabParam as 'files' | 'review' || 'files');
-        
-        // If no specific file is selected and the RDF spec file exists, select it
+        const tab = (tabParam as 'files' | 'review') || 'files';
+        setActiveTab(tab);
+
+        // If no specific file is selected and the RDF spec file exists, select it.
+        // On the Review tab keep the tab param: the review panel needs the RDF
+        // loaded for its validation and test gates, but selecting a file the
+        // normal way rewrites `tab` to `@rdf.yaml` and drops the user into the
+        // editor, so a `?tab=review` link could never open the review view.
         if (!selectedFile) {
           const rdfFile = files.find(file => endsWithRdfFileName(file.path));
           if (rdfFile) {
-            handleFileSelect(rdfFile);
+            handleFileSelect(rdfFile, { preserveTab: tab === 'review' });
           }
         }
       }


### PR DESCRIPTION
## Motivation

Opening a model's edit page with the review tab in the URL never showed the review tab. The page loaded, immediately swapped itself over to the RDF file editor, and rewrote the address bar to match:

```
https://bioimage.io/#/edit/bioimage-io%2F<alias>/stage?tab=review
  ->  .../stage?tab=%40rdf.yaml
```

Anyone following a shared or bookmarked review link, which is how review threads and bug reports refer to a model under review, landed somewhere else with no indication that a redirect had happened. The only way to reach the review view was to load the page and switch tabs by hand.

## Solution

The effect that reconciles the `tab` search param set `activeTab` to `'review'` correctly, then fell through to the "no file selected, open the RDF" default in the same branch. `handleFileSelect` unconditionally pushed `tab=@<path>`, clobbering the tab it had just set. On a fresh load `selectedFile` is null by definition, so the review tab lost every time.

The RDF still has to be loaded on the review tab: `ReviewPublishArtifact` derives `isContentValid`, `hasContentChanged` and the Test Model gate from it. So rather than skipping the preload, `handleFileSelect` takes a `preserveTab` option that loads the file without touching the tab param. That yields exactly the state you already get by clicking "Review & Publish" from the editor.

## Behaviour

| Entry point | Before | After |
|---|---|---|
| `?tab=review` | rewritten to `?tab=%40rdf.yaml`, RDF editor shown | stays `?tab=review`, review panel shown |
| `?tab=@README.md` | README shown | unchanged |
| no `tab` param | `?tab=%40rdf.yaml`, RDF editor shown | unchanged |
| "Back to Edit" from review | `?tab=%40rdf.yaml` | unchanged |

## Test plan

Driven headlessly against a model in review, signed in with reviewer permissions, for all four entry points above. Each was checked for the resulting URL, whether the review panel rendered, and uncaught page errors (0 in every case).

On the `?tab=review` deep link the review view populates completely: artifact card, status badge, version history, comment thread, Admin Review Area and the Publish action.

`react-scripts build` exits 0.

## Files

- `src/components/Edit.tsx` - `handleFileSelect` gains an optional `preserveTab`; the tab-reconciling effect passes it when the target tab is `review`.
