### PR TITLE
fix(detail): resolve workspace-qualified model URLs

### DIFF
--- a/src/components/ArtifactDetails.tsx
+++ b/src/components/ArtifactDetails.tsx
@@ -28,7 +28,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import WarningIcon from '@mui/icons-material/Warning';
 import ModelRunner from './ModelRunner';
 import HintTooltip from './HintTooltip';
-import { resolveHyphaUrl, resolveTestReportUrl, extractFilePath } from '../utils/urlHelpers';
+import { resolveHyphaUrl, resolveTestReportUrl, extractFilePath, resolveArtifactRouteId } from '../utils/urlHelpers';
 import { BIOIMAGEIO_YAML, RDF_YAML } from '../utils/rdfFile';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
@@ -169,7 +169,9 @@ const ArtifactDetails = () => {
 
   useEffect(() => {
     if (id) {
-      fetchResource(`bioimage-io/${id}`, version);
+      // The id can arrive bare or workspace-qualified, see resolveArtifactRouteId.
+      const resolved = resolveArtifactRouteId(id, version);
+      fetchResource(resolved.artifactId, resolved.version);
     }
   }, [id, fetchResource, version]);
 

--- a/src/store/hyphaStore.ts
+++ b/src/store/hyphaStore.ts
@@ -585,9 +585,12 @@ export const useHyphaStore = create<HyphaState>((set, get) => ({
   fetchResource: async (id: string, version?: string) => {
     set({ isLoading: true, selectedResource: null, error: null });
     try {
-      const [workspace, artifactName] = id.includes('/')
-        ? id.split('/')
-        : ['bioimage-io', id];
+      // Split on the FIRST slash only. A plain `split('/')` silently dropped
+      // everything past the second segment, so a malformed id resolved to some
+      // other artifact's URL instead of failing.
+      const separator = id.indexOf('/');
+      const workspace = separator === -1 ? 'bioimage-io' : id.slice(0, separator);
+      const artifactName = separator === -1 ? id : id.slice(separator + 1);
 
       const url = `${HYPHA_SERVER_URL}/${workspace}/artifacts/${artifactName}` + (version ? `?version=${version}` : '');
 

--- a/src/utils/urlHelpers.ts
+++ b/src/utils/urlHelpers.ts
@@ -62,3 +62,35 @@ export const resolveTestReportUrl = (artifactId: string, staged: boolean): strin
   const slot = staged ? 'staged' : 'published';
   return `${HYPHA_SERVER_URL}/bioimage-io/artifacts/test-report-${modelId}/files/${slot}/test_report.json?use_proxy=true`;
 };
+/** The workspace every artifact on this site lives in. */
+const ARTIFACT_WORKSPACE = 'bioimage-io';
+
+/**
+ * Turn the `:id` / `:version` params of the detail routes into the
+ * workspace-qualified id `fetchResource` expects.
+ *
+ * Two URL shapes have to resolve to the same artifact: the short one the app
+ * links to itself (`#/resources/affable-shark`) and the workspace-qualified one
+ * that Hypha, the Edit page and the API docs hand out
+ * (`#/resources/bioimage-io%2Faffable-shark`). React Router matches on the raw
+ * path and only decodes `%2F` when handing over the param, so in the qualified
+ * form `:id` already carries the workspace. Prefixing it a second time produced
+ * `bioimage-io/bioimage-io/<alias>`, which addressed no artifact at all.
+ *
+ * An *unencoded* slash is a different story: the router splits on it while
+ * matching, so `#/artifacts/bioimage-io/affable-shark` lands the workspace in
+ * `:id` and the alias in `:version`. That shape is folded back together here
+ * too, since it is what a human types by hand.
+ */
+export const resolveArtifactRouteId = (
+  id: string,
+  version?: string,
+): { artifactId: string; version?: string } => {
+  if (id === ARTIFACT_WORKSPACE && version) {
+    return { artifactId: `${ARTIFACT_WORKSPACE}/${version}`, version: undefined };
+  }
+  return {
+    artifactId: id.includes('/') ? id : `${ARTIFACT_WORKSPACE}/${id}`,
+    version,
+  };
+};


### PR DESCRIPTION
## Motivation

A model detail URL that carries the workspace in its id showed `Error: Failed to fetch artifact: bioimage-io` instead of the model:

- `https://bioimage.io/#/resources/bioimage-io%2Faffable-shark`
- `https://bioimage.io/#/artifacts/bioimage-io%2Fnaked-rabbit`

This is the id shape Hypha returns, the shape the Edit page URLs already use (`#/edit/bioimage-io%2F<alias>/stage`), and the shape a link in a ticket or a chat message is most likely to have. The site's own links always emit the bare alias, so in-app navigation was never affected and the failure only showed up on hand-assembled or copied URLs.

## Solution

React Router matches on the raw path and only percent-decodes a param when handing it to `useParams`, so for the qualified form `:id` arrives as `bioimage-io/<alias>`, workspace included. `ArtifactDetails` prefixed `bioimage-io/` unconditionally, producing the three-segment id `bioimage-io/bioimage-io/<alias>`. `fetchResource` then destructured `id.split('/')` into two variables, keeping the first two segments and dropping the alias, so the request went to `/bioimage-io/artifacts/bioimage-io`, which is not an artifact.

`resolveArtifactRouteId` in `utils/urlHelpers.ts` now normalises the route params before the fetch:

- an id that already carries a workspace is passed through unchanged;
- a bare alias is qualified with `bioimage-io` as before;
- the unencoded shape `#/artifacts/bioimage-io/<alias>` is folded back together. An unencoded slash *is* split by the router while matching, so there the workspace lands in `:id` and the alias in `:version`.

`fetchResource` splits on the first slash only. With a well-formed id the result is identical, but a malformed one now fails with a clear name instead of silently addressing a different artifact.

## Behaviour

| URL | Before | After |
|---|---|---|
| `#/resources/bioimage-io%2Faffable-shark` | "Failed to fetch artifact" | renders the model |
| `#/artifacts/bioimage-io%2Fnaked-rabbit` | "Failed to fetch artifact" | renders the model |
| `#/artifacts/bioimage-io/affable-shark` | "Failed to fetch artifact" | renders the model |
| `#/resources/affable-shark` | renders | unchanged |
| `#/artifacts/naked-rabbit` | renders | unchanged |
| `#/artifacts/affable-shark/v0` | renders | unchanged |

## Test plan

All six URL shapes above were loaded headless against a dev server. Each renders the model heading, description and documentation with zero page errors, and no "Failed to fetch artifact" text. Production build compiles.
