### PR TITLE
Green the end-to-end Playwright suite and fix the defects it exposed

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,19 +1,28 @@
 import { defineConfig } from '@playwright/test';
 
-// Model-test integration specs run against the dev server and switch to the
-// deNBI v1.15.2 async model-runner (bioimage-io/bioengine-worker-denbi-*:model-runner)
-// by clicking the deNBI option in the Test Model options dialog. Start the
-// dev server, then run the tests:
-//   pnpm start
+// The suite drives a dev server, so start one first and point the suite at it:
+//   BROWSER=none pnpm start
 //   npx playwright test
+//
+// Every spec resolves its base URL through tests/baseUrl.ts, so a single
+// E2E_BASE_URL retargets all of them (e.g. a second checkout on another port).
+//
+// Several specs are live: they drive real BioEngine inference and rewrite real
+// test reports in the bioimage-io collection. Grep a spec's header before
+// running it in isolation.
 
 export default defineConfig({
   testDir: './tests',
+  // Verifies the base URL is actually serving this site before anything runs.
+  globalSetup: require.resolve('./tests/globalSetup'),
   timeout: 30000,
   use: {
-    // Override with E2E_BASE_URL when the dev server is on another port,
-    // e.g. a second checkout running alongside the default one.
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:3000',
     headless: true,
+    // This machine has no usable GPU for headless Chromium, and the site
+    // registers a cleanup service worker that would otherwise own the fetches
+    // the stubbing specs install with page.route().
+    launchOptions: { args: ['--disable-gpu', '--no-sandbox'] },
+    serviceWorkers: 'block',
   },
 });

--- a/src/components/StepTimeline.tsx
+++ b/src/components/StepTimeline.tsx
@@ -71,7 +71,8 @@ const formatDurationSec = (sec: number): string =>
  *               timer reflects the real execution start even if the two clocks
  *               disagree;
  *   - done    → the frozen duration to one decimal ("2.4s");
- *   - skipped → an em dash (a later step started while this one never did);
+ *   - skipped → the word "Skipped" (a later step started while this one never
+ *               did);
  *   - not yet reached → blank.
  */
 const StepTimeline: React.FC<StepTimelineProps> = ({ submittedAt, startedLabel = 'Test started', fallbackQueuePosition, steps, completedAt }) => {

--- a/src/components/annotate/SamBoxModelDialog.tsx
+++ b/src/components/annotate/SamBoxModelDialog.tsx
@@ -103,6 +103,12 @@ const SamBoxModelDialog: React.FC<SamBoxModelDialogProps> = ({
     const isLoaded = option.modelType === loadedModelType;
     const hasEmbedding = embeddedModelTypes.includes(option.modelType);
     const isRecomputing = recomputingType === option.modelType;
+    // "(default)" is a property of THIS dialog, not of the model:
+    // MICRO_SAM_MODEL_TYPE is the box-prompt default only. Marking it on the
+    // shared option label instead would leak it into the fine-tuning picker,
+    // whose default is a different model.
+    const displayLabel =
+      option.modelType === MICRO_SAM_MODEL_TYPE ? `${option.label} (default)` : option.label;
     return (
       <Box
         key={option.modelType}
@@ -133,12 +139,8 @@ const SamBoxModelDialog: React.FC<SamBoxModelDialogProps> = ({
             bgcolor: selected ? 'secondary.main' : 'action.disabledBackground',
           }} />
           <Box sx={{ flex: 1, minWidth: 0 }}>
-            {/* "(default)" is a property of THIS dialog, not of the model:
-                MICRO_SAM_MODEL_TYPE is the box-prompt default only. Marking it
-                on the shared option label instead would leak it into the
-                fine-tuning picker, whose default is a different model. */}
             <Typography variant="body2" fontWeight={selected ? 700 : 500} color={selected ? 'secondary.main' : 'text.primary'}>
-              {option.modelType === MICRO_SAM_MODEL_TYPE ? `${option.label} (default)` : option.label}
+              {displayLabel}
             </Typography>
           </Box>
           {isLoaded ? (
@@ -161,7 +163,11 @@ const SamBoxModelDialog: React.FC<SamBoxModelDialogProps> = ({
                 size="small"
                 onClick={(e) => handleRecompute(e, option.modelType)}
                 disabled={isRecomputing || !microSamAvailable}
-                aria-label={`Recompute embedding for ${option.label}`}
+                // The rendered label, not option.label: a control whose spoken
+                // name omits the "(default)" the row visibly carries reads as a
+                // different control to anyone matching what they see against
+                // what they hear.
+                aria-label={`Recompute embedding for ${displayLabel}`}
                 sx={{ p: 0.4 }}
               >
                 {isRecomputing ? <CircularProgress size={14} /> : <ReplayIcon sx={{ fontSize: 15 }} />}

--- a/src/components/colab/DatasetOverview.tsx
+++ b/src/components/colab/DatasetOverview.tsx
@@ -1316,12 +1316,14 @@ print("Service registered successfully", end='')
     const value = assignment[row.stem] ?? 'unused';
     return (
       <button
+        type="button"
         onClick={(e) => {
           e.stopPropagation();
           cycleAssignment(row.stem);
         }}
         className={`px-2.5 py-1 rounded-full text-xs font-medium capitalize transition-colors shrink-0 ${splitBadgeClass(value)}`}
         title="Click to cycle: train, test, unused"
+        aria-label={`${row.stem} is ${value}. Click to cycle: train, test, unused`}
       >
         {value}
       </button>
@@ -1335,9 +1337,23 @@ print("Service registered successfully", end='')
         ref={(el) => { imageRowRefs.current[row.stem] = el; }}
         className="group relative"
       >
-        <button
+        {/* The row carries its own controls (upload, and the split pill while
+            the finetune view is open), so it cannot itself be a <button> —
+            a button inside a button is invalid markup that the browser
+            reparses into something the code never described. Keep the
+            whole-row click target with an explicit role and key handling
+            instead. */}
+        <div
+          role="button"
+          tabIndex={0}
           onClick={() => handleSelectImage(row)}
-          className={`w-full text-left px-4 py-2.5 flex items-center justify-between gap-2 transition-colors ${
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              handleSelectImage(row);
+            }
+          }}
+          className={`w-full cursor-pointer text-left px-4 py-2.5 flex items-center justify-between gap-2 transition-colors ${
             selectedStem === row.stem
               ? 'bg-purple-50 border-l-2 border-purple-500'
               : 'hover:bg-gray-50 border-l-2 border-transparent'
@@ -1351,18 +1367,20 @@ print("Service registered successfully", end='')
             ) : uploadingStems.has(row.stem) ? (
               <Spinner className="w-4 h-4 text-purple-500 shrink-0" />
             ) : (
-              <div
+              <button
+                type="button"
                 className="shrink-0 cursor-pointer text-gray-400 hover:text-blue-500 active:scale-90 transition-all"
                 onClick={(e) => {
                   e.stopPropagation();
                   uploadSingleImage({ stem: row.stem, format: row.format! });
                 }}
                 title="Upload to the dataset"
+                aria-label="Upload to the dataset"
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
                 </svg>
-              </div>
+              </button>
             )}
             <span className="text-sm text-gray-700 truncate">{row.stem}</span>
             {isSmallImageDims(row.width ?? 0, row.height ?? 0) && (
@@ -1399,7 +1417,7 @@ print("Service registered successfully", end='')
               </svg>
             )
           )}
-        </button>
+        </div>
         {row.isCloud && (
           <button
             onClick={(e) => handleDeleteCloudImage(row.stem, e)}

--- a/src/components/colab/ExportModelDialog.tsx
+++ b/src/components/colab/ExportModelDialog.tsx
@@ -14,8 +14,9 @@ export interface ExportModelDialogProps {
   datasetArtifactId: string;
   annotationLabel: string;
   session: { session_id: string; model_type?: string };
-  splitName: string;
-  existingCheckpoint: { session_id: string; model_type: string; [key: string]: any };
+  /** Omitted when the run could not be attributed to a split, see
+   * Finetune.tsx's resolveExportSplit. The export runs either way. */
+  splitName?: string;
   onExported: (exportedModelId: string) => void;
 }
 
@@ -77,7 +78,6 @@ const ExportModelDialog: React.FC<ExportModelDialogProps> = ({
   annotationLabel,
   session,
   splitName,
-  existingCheckpoint,
   onExported,
 }) => {
   const [name, setName] = useState('');
@@ -125,7 +125,7 @@ const ExportModelDialog: React.FC<ExportModelDialogProps> = ({
         provenance: {
           dataset_artifact_id: datasetArtifactId,
           label: annotationLabel,
-          split_name: splitName,
+          ...(splitName ? { split_name: splitName } : {}),
           session_lineage: [session.session_id],
         },
         _rkwargs: true,

--- a/src/components/colab/Finetune.tsx
+++ b/src/components/colab/Finetune.tsx
@@ -10,6 +10,7 @@ import {
   getTrainingUrls,
   listSplits,
   setSplitCheckpoint,
+  SplitSummary,
 } from './brokerApi';
 import { resolvePinnedTrainingService } from '../../utils/trainingServicePin';
 import { useTrainingCapabilities } from '../../hooks/useTrainingCapabilities';
@@ -93,6 +94,36 @@ export const Spinner: React.FC<{ className?: string }> = ({ className = 'w-8 h-8
 // by prefix among everything else running on the same pinned worker.
 const sessionTag = (alias: string, annotationLabel: string) => `${alias}/${annotationLabel}`;
 
+export type ResolvedExportSplit = { split: SplitSummary; exact: boolean } | null;
+
+/**
+ * Pick the data split a finished run trained on, for the exported model's
+ * provenance.
+ *
+ * A split records only its most recent run, and it records it when the run is
+ * submitted rather than when it finishes. So the instant a second run starts,
+ * nothing points back at the first one any more, and a run that is stopped or
+ * fails leaves the split pointing at a session that has no checkpoint to
+ * export. Attribution is therefore best-effort: fall back through
+ * progressively weaker evidence, and treat "no idea" as a gap in provenance
+ * rather than a reason to refuse the export.
+ */
+export const resolveExportSplit = (splits: SplitSummary[], sessionId: string): ResolvedExportSplit => {
+  const current = splits.find((sp) => sp.checkpoint?.session_id === sessionId);
+  if (current) return { split: current, exact: true };
+  // Runs started after the history fix carry their predecessors along, so an
+  // overwritten pointer is still recoverable.
+  const historic = splits.find((sp) => {
+    const history = sp.checkpoint?.session_history;
+    return Array.isArray(history) && history.includes(sessionId);
+  });
+  if (historic) return { split: historic, exact: false };
+  // A label almost always has exactly one split, in which case there is only
+  // one thing the run can have trained on regardless of what the pointer says.
+  if (splits.length === 1) return { split: splits[0], exact: false };
+  return null;
+};
+
 // Step 2 of the fine-tuning flow. The dataset's finetune view (step 1) picks
 // the split, the architecture and the checkpoint to start from, then hands
 // those over in the query string. Everything about HOW to train lives here:
@@ -117,10 +148,15 @@ const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, 
   const [exportTarget, setExportTarget] = useState<{
     session: TrainingSessionStatus;
     annotationLabel: string;
-    splitName: string;
-    checkpoint: { session_id: string; model_type: string; [key: string]: any };
+    // Undefined when the run could not be attributed to a split. The export
+    // still runs, it just carries no split name in its provenance.
+    splitName?: string;
+    // True only while the split still points at THIS run, which is the one
+    // case where stamping the exported model onto it cannot clobber a newer
+    // run's pointer.
+    ownsSplitPointer: boolean;
+    checkpoint: Record<string, any> | null;
   } | null>(null);
-  const [exportResolveError, setExportResolveError] = useState<{ sessionId: string; message: string } | null>(null);
   const [resolvingExportSessionId, setResolvingExportSessionId] = useState<string | null>(null);
 
   // --- New run, configured from step 1's query string ---
@@ -226,9 +262,22 @@ const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, 
 
       const svc = await resolvePinnedTrainingService(server);
       const status = await svc.start_training(call);
+      // The split holds one pointer, so starting this run displaces whatever
+      // ran before it. Carry the displaced session along, otherwise every
+      // earlier run on this split loses the only link back to the data it was
+      // trained on (see resolveExportSplit).
+      const prior = urls.split?.checkpoint;
+      const priorHistory: string[] = Array.isArray(prior?.session_history) ? prior!.session_history : [];
+      const history =
+        prior?.session_id && !priorHistory.includes(prior.session_id)
+          ? [...priorHistory, prior.session_id]
+          : priorHistory;
       await setSplitCheckpoint(server, artifactId, pendingLabel, pendingSplit, {
         session_id: status.session_id,
         model_type: pendingModelType,
+        // Bounded so a split that is retrained many times cannot grow its
+        // record without limit.
+        ...(history.length > 0 ? { session_history: history.slice(-50) } : {}),
       });
       // Drop the handover parameters so a reload does not offer to start the
       // same run a second time.
@@ -242,27 +291,25 @@ const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, 
   };
 
   const handleOpenExport = async (s: TrainingSessionStatus, annotationLabel: string) => {
-    setExportResolveError(null);
     setResolvingExportSessionId(s.session_id);
+    let resolved: ResolvedExportSplit = null;
     try {
       const splits = await listSplits(server, artifactId, annotationLabel);
-      const owner = splits.find((sp) => sp.checkpoint?.session_id === s.session_id);
-      if (!owner || !owner.checkpoint) {
-        setExportResolveError({
-          sessionId: s.session_id,
-          message: 'Could not determine the training split for this session, export is unavailable.',
-        });
-        return;
-      }
-      setExportTarget({ session: s, annotationLabel, splitName: owner.name, checkpoint: owner.checkpoint });
+      resolved = resolveExportSplit(splits, s.session_id);
     } catch (err) {
-      setExportResolveError({
-        sessionId: s.session_id,
-        message: (err as Error).message || 'Failed to resolve the training split for this session.',
-      });
+      // Attribution is provenance, not a precondition. A broker hiccup here
+      // must not cost the user a finished checkpoint.
+      console.error('resolveExportSplit: listSplits failed', err);
     } finally {
       setResolvingExportSessionId(null);
     }
+    setExportTarget({
+      session: s,
+      annotationLabel,
+      splitName: resolved?.split.name,
+      ownsSplitPointer: !!resolved?.exact,
+      checkpoint: resolved?.split.checkpoint ?? null,
+    });
   };
 
   const role: BrokerRole | undefined = dataset?.role;
@@ -628,9 +675,6 @@ const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, 
                     )}
                   </div>
                 )}
-                {exportResolveError?.sessionId === s.session_id && (
-                  <div className="mt-2 text-xs text-red-600">{exportResolveError.message}</div>
-                )}
               </div>
             );
           })}
@@ -674,10 +718,16 @@ const Finetune: React.FC<FinetuneProps> = ({ artifactId, artifactAlias, server, 
           annotationLabel={exportTarget.annotationLabel}
           session={exportTarget.session}
           splitName={exportTarget.splitName}
-          existingCheckpoint={exportTarget.checkpoint}
           onExported={async (exportedModelId) => {
+            // Only stamp the export onto the split while the split still
+            // points at this run. Once a newer run owns the pointer, writing
+            // here would redirect step 1's "start from the previous run"
+            // default back onto the older session.
+            if (!exportTarget.splitName || !exportTarget.ownsSplitPointer) return;
             await setSplitCheckpoint(server, artifactId, exportTarget.annotationLabel, exportTarget.splitName, {
-              ...exportTarget.checkpoint,
+              ...(exportTarget.checkpoint || {}),
+              session_id: exportTarget.session.session_id,
+              model_type: exportTarget.session.model_type || exportTarget.checkpoint?.model_type || '',
               exported_model_id: exportedModelId,
             });
           }}

--- a/tests/annotate-ai-box.spec.ts
+++ b/tests/annotate-ai-box.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Requires: HYPHA_TOKEN env var (same token the user stores in localStorage
 // after login), falls back to reading /data/nmechtel/bioengine/.env if unset.
-// Requires: dev server running at http://localhost:3012 (this worktree's port,
+// Requires: dev server running at the dev server (
 // overridden below since playwright.config.ts's baseURL targets :3000 for the
 // model-test integration specs).
 //
@@ -20,7 +21,7 @@ import fs from 'fs';
 // bioimage-io collection workspace, never the connected user's own
 // workspace (useHyphaService.ts, fixed alongside toArtifactId reuse).
 
-test.use({ baseURL: 'http://localhost:3012' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const LABEL = 'cells';

--- a/tests/annotate-cellpose-local-vs-server.spec.ts
+++ b/tests/annotate-cellpose-local-vs-server.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Requires: HYPHA_TOKEN env var, falls back to /data/nmechtel/bioengine/.env.
-// Requires: dev server running at http://localhost:3012.
+// Requires: dev server running at E2E_BASE_URL (default http://localhost:3000).
 //
 // Regression test for the round-27 production bug report: Cellpose-SAM full
 // image segmentation via the LOCAL path (kernel-warm flows + Pyodide mask
@@ -39,7 +40,7 @@ import fs from 'fs';
 // successfully" alone (an earlier version of this test did) never gates
 // the local path -- it always falls back to the server path silently.
 
-test.use({ baseURL: 'http://localhost:3012' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const LABEL = 'cells';

--- a/tests/annotate-cellpose-masks.spec.ts
+++ b/tests/annotate-cellpose-masks.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Requires: HYPHA_TOKEN env var, falls back to /data/nmechtel/bioengine/.env.
-// Requires: dev server running at http://localhost:3012.
+// Requires: dev server running at E2E_BASE_URL (default http://localhost:3000).
 //
 // Regression test for colab-rework-plan.md §18.6: "Cellpose-SAM detects no
 // masks". Root cause was a leading batch dimension (e.g. (1,1,H,W) instead
@@ -12,7 +13,7 @@ import fs from 'fs';
 // dialog end to end against the live backend and asserts the resulting
 // banner reports at least one detected mask.
 
-test.use({ baseURL: 'http://localhost:3012' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const LABEL = 'cells';

--- a/tests/annotate-clahe.spec.ts
+++ b/tests/annotate-clahe.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Requires: HYPHA_TOKEN env var (falls back to /data/nmechtel/bioengine/.env).
-// Requires: dev server at http://localhost:3012.
+// Requires: dev server at E2E_BASE_URL (default http://localhost:3000).
 //
 // Regression coverage for colab-rework-plan.md §19c item 1: the CLAHE dialog
 // used to hang forever on "Python kernel is starting up...", because nothing
@@ -12,7 +13,7 @@ import fs from 'fs';
 // This asserts the dialog's kernel-starting state actually resolves and
 // Apply produces an enhanced image within a bounded time.
 
-test.use({ baseURL: 'http://localhost:3012' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const LABEL = 'cells';

--- a/tests/baseUrl.ts
+++ b/tests/baseUrl.ts
@@ -1,0 +1,15 @@
+/**
+ * One base URL for the whole suite.
+ *
+ * Specs used to pin their own port with `test.use({ baseURL: 'http://localhost:5199' })`,
+ * a leftover from the worktree each round was written in. That made the suite
+ * unrunnable as a suite (different specs pointed at different servers) and,
+ * worse, let a spec silently drive a *different* checkout's dev server that
+ * happened to be listening on that port. Everything resolves through here now,
+ * so one `E2E_BASE_URL` moves the entire suite.
+ *
+ * `DEV_BASE_URL` and `BASE_URL` are honoured too because a handful of specs
+ * documented those names in their header comments.
+ */
+export const BASE_URL =
+  process.env.E2E_BASE_URL || process.env.DEV_BASE_URL || process.env.BASE_URL || 'http://localhost:3000';

--- a/tests/colab-overview-sharing.spec.ts
+++ b/tests/colab-overview-sharing.spec.ts
@@ -1,11 +1,10 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Requires: HYPHA_TOKEN env var (same token the user stores in localStorage
 // after login), falls back to reading /data/nmechtel/bioengine/.env if unset.
-// Requires: dev server running at http://localhost:3012 (this worktree's
-// port; overridden below since playwright.config.ts's baseURL targets :3000
-// for the model-test integration specs).
+// Requires: dev server running at E2E_BASE_URL (default http://localhost:3000).
 //
 // What this tests (colab-rework-plan.md §13): the reworked dataset overview
 // header/action row, the Share dialog's sharing + access-request + QR
@@ -22,7 +21,7 @@ import fs from 'fs';
 // match it via the broker's email fallback even if both tokens trace back
 // to the same underlying human in Hypha's auth backend.
 
-test.use({ baseURL: 'http://localhost:3012' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const LABEL = 'cells';

--- a/tests/dataset-row-nesting.spec.ts
+++ b/tests/dataset-row-nesting.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import { BASE_URL } from './baseUrl';
+
+// Regression guard for issue #0025.
+//
+// The dataset overview's image rows were <button> elements, and the row for a
+// finetune split also carries its own train/test/unused pill (another button)
+// plus an upload control. A button inside a button is markup the browser is not
+// allowed to build, so it silently reparses it into something the code never
+// described: React says so via validateDOMNesting, and in practice the row and
+// the pill can both answer the same click.
+//
+// The row is a div with role="button" now. This spec fails if anything puts a
+// button back inside it, in either of the two states that render controls
+// inside a row: the plain overview (upload affordance) and the finetune view
+// (upload affordance + split pill).
+//
+// Requires: HYPHA_TOKEN (falls back to /data/nmechtel/bioengine/.env) and a dev
+// server at E2E_BASE_URL.
+
+test.use({ baseURL: BASE_URL });
+
+const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
+
+function readHyphaToken(): string | undefined {
+  if (process.env.HYPHA_TOKEN) return process.env.HYPHA_TOKEN;
+  try {
+    return fs.readFileSync('/data/nmechtel/bioengine/.env', 'utf8').match(/HYPHA_TOKEN=(\S+)/)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+test('dataset image rows nest no buttons, in the overview and the finetune view', async ({ page }) => {
+  const token = readHyphaToken();
+  if (!token) {
+    test.skip();
+    return;
+  }
+  test.setTimeout(120000);
+
+  await page.addInitScript(({ tok, expiry }) => {
+    localStorage.setItem('token', tok);
+    localStorage.setItem('tokenExpiry', expiry);
+    localStorage.setItem('bioimage-annotation-tutorial-seen', '1');
+  }, { tok: token, expiry: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString() });
+
+  const nestingWarnings: string[] = [];
+  page.on('console', (m) => {
+    if (m.text().includes('validateDOMNesting')) nestingWarnings.push(m.text());
+  });
+
+  // React only emits the warning on the render that produces the bad tree, so
+  // the DOM has to be checked as well for the case where the page was already
+  // rendered before the listener attached.
+  const nestedButtonCount = () =>
+    page.locator('button button, [role="button"] button button').count();
+
+  await page.goto(`/#/colab/${encodeURIComponent(DATASET_ALIAS)}`);
+  const finetuneButton = page.getByRole('button', { name: 'Finetune' });
+  await expect(finetuneButton).toBeVisible({ timeout: 60000 });
+  expect(await nestedButtonCount()).toBe(0);
+
+  // The finetune view is the state that adds the split pill to every row.
+  // The button renders disabled until the dataset's labels have loaded, and a
+  // forced click on a disabled button dispatches nothing at all, so waiting for
+  // enabled is what makes the click land rather than silently no-op.
+  await expect(finetuneButton).toBeEnabled({ timeout: 60000 });
+  await finetuneButton.click({ force: true });
+  await expect(page.getByRole('heading', { name: 'Choose a label' })).toBeVisible({ timeout: 30000 });
+  await page.getByRole('button', { name: /^cells\b/ }).click();
+  await expect(page.getByText(/^Unused \(\d+\)$/)).toBeVisible({ timeout: 30000 });
+
+  expect(await nestedButtonCount()).toBe(0);
+
+  // The row still answers a click and a keypress, which is what role="button"
+  // plus an explicit key handler has to earn back from a real <button>.
+  const row = page.locator('[role="button"]').filter({ has: page.locator('button') }).first();
+  await expect(row).toBeVisible();
+  await row.focus();
+  expect(await row.evaluate((el) => el.getAttribute('tabindex'))).toBe('0');
+
+  expect(nestingWarnings).toEqual([]);
+});

--- a/tests/finetune-page.spec.ts
+++ b/tests/finetune-page.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Requires: HYPHA_TOKEN env var (falls back to /data/nmechtel/bioengine/.env).
-// Requires: dev server at http://localhost:3012.
+// Requires: dev server at E2E_BASE_URL (default http://localhost:3000).
 //
 // What this tests:
 // - §23.2/§23.4 (colab-rework-plan.md): the dataset overview's Finetune
@@ -28,7 +29,7 @@ import fs from 'fs';
 // shared infra is out of scope for an automated check — keen-puma/Nils run
 // that e2e pass by hand once this lands.
 
-test.use({ baseURL: 'http://localhost:3012' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 
@@ -136,7 +137,9 @@ test.describe('Finetune training-sessions page (monitoring-only, direct URL)', (
     // still reached by direct URL and is monitoring-only now: no start
     // form, training runs are kicked off from the finetune view.
     await page.goto(`/#/colab/${encodeURIComponent(DATASET_ALIAS)}/finetune`);
-    await expect(page.getByRole('heading', { name: 'Fine-tune μSAM' })).toBeVisible({ timeout: 30000 });
+    // The page covers both backends since Cellpose and micro-SAM training were
+    // unified behind model-finetune, so the heading is no longer μSAM-specific.
+    await expect(page.getByRole('heading', { name: 'Fine-tune a model' })).toBeVisible({ timeout: 30000 });
 
     // Guard passed (manager role) -> the sessions list is visible, not an
     // access-denied card.
@@ -146,7 +149,9 @@ test.describe('Finetune training-sessions page (monitoring-only, direct URL)', (
     // The old start form is gone entirely from this page.
     await expect(page.getByRole('heading', { name: 'Start a new session' })).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'Start fine-tuning' })).not.toBeVisible();
-    await expect(page.getByText("Start new training runs from a dataset's finetune view", { exact: false })).toBeVisible();
+    await expect(
+      page.getByText("Pick a split and a starting model in the dataset's finetune view", { exact: false }),
+    ).toBeVisible();
   });
 
   test('"Use for annotation" is gated on a checkpoint-ready session (§20 item 2)', async ({ page }) => {

--- a/tests/globalSetup.ts
+++ b/tests/globalSetup.ts
@@ -1,0 +1,30 @@
+import { BASE_URL } from './baseUrl';
+
+/**
+ * Refuse to run against something that is not this site.
+ *
+ * Dev servers from several checkouts (and from unrelated projects) share this
+ * machine, and whoever starts first takes port 3000. Without this check the
+ * suite happily drove another product's dev server and reported a wall of
+ * confusing selector failures. Fail once, up front, with the actual reason.
+ */
+export default async function globalSetup() {
+  let manifest: { short_name?: string };
+  try {
+    const res = await fetch(`${BASE_URL}/manifest.json`);
+    manifest = await res.json();
+  } catch (err) {
+    throw new Error(
+      `No dev server answering at ${BASE_URL}.\n` +
+        `Start one with \`BROWSER=none pnpm start\`, or point the suite at an ` +
+        `existing one with E2E_BASE_URL.\n(${(err as Error).message})`,
+    );
+  }
+  if (manifest.short_name !== 'BioImage.IO') {
+    throw new Error(
+      `${BASE_URL} is serving "${manifest.short_name}", not BioImage.IO.\n` +
+        `Another project's dev server holds that port. Set E2E_BASE_URL to this ` +
+        `checkout's server instead.`,
+    );
+  }
+}

--- a/tests/inference-report-source.spec.ts
+++ b/tests/inference-report-source.spec.ts
@@ -1,25 +1,31 @@
 import { test, expect } from '@playwright/test';
 
 // Verifies the ArtifactDetails "Test Run Model" badge reads its pass/fail state
-// from the NEW inference-report artifact
-// (bioimage-io/inference-report/files/inference_report.json) rather than the
-// former collection.manifest.bioengine_inference field.
+// from the per-model test-report artifact (bioimage-io/test-report-<id>) rather
+// than the former collection.manifest.bioengine_inference field.
 //
-// This asserts against the REAL published artifact rather than a fixture. Two
+// This asserts against the REAL published artifacts rather than a fixture. Two
 // facts make that a decisive check of the source switch:
-//   - affable-shark is recorded "passed" and affectionate-cow "failed" in the
-//     new artifact; the badge must reflect both.
-//   - affectionate-cow's failure carries its FULL runtime traceback
-//     (ml_collections / usplit_wrapper.py). That text is far longer than 20
-//     chars, so it can only come from the new report — the old manifest field
-//     stored message[:20]. Seeing it in the failure dialog proves both the new
-//     source and the removal of the message[:20] truncation, end to end.
+//   - affable-shark scores in the inference-passing band and affectionate-cow
+//     does not; the badge must reflect both.
+//   - affectionate-cow's failure carries its FULL runtime traceback. The old
+//     manifest field stored message[:20], so seeing any of that text past the
+//     first 20 characters proves both the new source and the removal of the
+//     truncation, end to end.
+//
+// The expected failure text is read from the live report at run time rather
+// than hardcoded. The traceback changes whenever the model is re-tested, and
+// what this test is about is that the dialog shows the WHOLE message, not that
+// the message says any particular thing.
 //
 // Requires:
 //   HYPHA_TOKEN env var — auto-login makes the (login-gated) badge interactive.
 //   Dev server running: pnpm start
-//   The inference-report artifact populated for these two models
+//   The test-reports collection populated for these two models
 //   (scripts/bioengine_model_infer.py --model-ids affable-shark affectionate-cow).
+
+const REPORT_URL = (alias: string) =>
+  `https://hypha.aicell.io/bioimage-io/artifacts/test-report-${alias}/files/published/test_report.json?use_proxy=true`;
 
 const injectToken = (token: string) => ({
   tok: token,
@@ -32,7 +38,7 @@ const gotoArtifact = async (page: import('@playwright/test').Page, alias: string
   await page.goto(`/#/artifacts/${alias}`);
 };
 
-test.describe('ArtifactDetails BioEngine badge reads the inference-report artifact', () => {
+test.describe('ArtifactDetails BioEngine badge reads the test-report artifact', () => {
   test('passed model → green check badge, enabled Test Run Model button', async ({ page }) => {
     const token = process.env.HYPHA_TOKEN;
     if (!token) {
@@ -85,7 +91,19 @@ test.describe('ArtifactDetails BioEngine badge reads the inference-report artifa
     // fire its onClick, not wait for MUI actionability to settle.
     await testButton.click({ force: true });
     await expect(page.getByText('BioEngine Test Run Failed')).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText('usplit_wrapper.py', { exact: false })).toBeVisible();
-    await expect(page.getByText('ml_collections', { exact: false })).toBeVisible();
+
+    // The longest line of the recorded traceback: it renders as one contiguous
+    // run inside the dialog's <pre>, and it is far longer than the 20 characters
+    // the old source would have kept.
+    const report = await (await fetch(REPORT_URL('affectionate-cow'))).json();
+    const recorded: string = report?.inference_check?.error ?? '';
+    const longest = recorded
+      .split('\n')
+      .map((line: string) => line.trim().replace(/^\|\s*/, ''))
+      .sort((a: string, b: string) => b.length - a.length)[0];
+    expect(longest.length).toBeGreaterThan(20);
+
+    const dialogText = await page.getByRole('dialog').innerText();
+    expect(dialogText).toContain(longest);
   });
 });

--- a/tests/outdated-test-report.spec.ts
+++ b/tests/outdated-test-report.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
+import { BASE_URL } from './baseUrl';
 
 // Requires: HYPHA_TOKEN env var (same token the user stores in localStorage after login).
-// Requires: dev server running at http://localhost:3000.
+// Requires: dev server running at E2E_BASE_URL (default http://localhost:3000).
 //
 // What this tests: when the artifact's last_modified is more recent than the
 // latest_remote_modified timestamp embedded in the test report, Edit.tsx

--- a/tests/review-badge.spec.ts
+++ b/tests/review-badge.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
+import { BASE_URL } from './baseUrl';
 
 // Two screenshots, both taken against the dev server with a STUBBED Hypha
 // session. Nothing here talks to hypha.aicell.io and nothing here touches a
@@ -8,11 +9,11 @@ import { test, expect, Page } from '@playwright/test';
 // driven by fake data.
 //
 // Run against a dev server:
-//   PORT=3021 BROWSER=none pnpm start
-//   BASE_URL=http://localhost:3021 npx playwright test tests/review-badge.spec.ts
+//   BROWSER=none pnpm start
+//   npx playwright test tests/review-badge.spec.ts
 
 test.use({
-  baseURL: process.env.BASE_URL || 'http://localhost:3000',
+  baseURL: BASE_URL,
   viewport: { width: 1280, height: 800 },
   deviceScaleFactor: 3,
   // The site registers a cleanup service worker on load. Left running, it owns
@@ -62,7 +63,7 @@ const TOY_ID = 'bioimage-io/stub-toy-in-revision';
  * (Playwright runs route handlers in reverse registration order).
  */
 async function blockExternalNetwork(page: Page) {
-  const origin = new URL(process.env.BASE_URL || 'http://localhost:3000').origin;
+  const origin = new URL(BASE_URL).origin;
   await page.route('**/*', async (route) => {
     const url = route.request().url();
     if (url.startsWith(origin) || url.startsWith('data:') || url.startsWith('blob:')) {

--- a/tests/round33-behavior.spec.ts
+++ b/tests/round33-behavior.spec.ts
@@ -1,13 +1,14 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
 import crypto from 'crypto';
+import { BASE_URL } from './baseUrl';
 
 // Round-33 supplementary acceptance (keen-puma): behavioral evidence beyond
 // control wiring — brush actually paints a mask (with undo), arrow keys move
 // the radius, +/-/0 drive the view, hue persists across reload and recolors
 // existing masks.
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round33-verify';

--- a/tests/round33-ui.spec.ts
+++ b/tests/round33-ui.spec.ts
@@ -1,11 +1,12 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-33 UI: brush/lasso mode switch (double-click Draw Mask, round 33c),
 // radius stepper, and Mask Color dialog. Confirms the controls render,
 // toggle, and don't throw.
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 

--- a/tests/round33b-persistence.spec.ts
+++ b/tests/round33b-persistence.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-33 follow-up: drawMode + brushRadius persist across reload (like
 // maskHue), and holding ArrowUp/ArrowDown accelerates after ~1s of
@@ -8,7 +9,7 @@ import fs from 'fs';
 // detected here via the radius stepper's visibility instead of a
 // "Brush Painting" / "Lasso Drawing" label.
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 

--- a/tests/round33b-verify.spec.ts
+++ b/tests/round33b-verify.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-33b independent acceptance (keen-puma): drawMode + brushRadius
 // persistence across reload, and hold-acceleration on ArrowUp/ArrowDown.
@@ -8,7 +9,7 @@ import fs from 'fs';
 // the handler keys its hold tracking on. Round 33c replaced the standalone
 // brush-mode toggle row with a double-click gesture on the Draw Mask button.
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round33b-verify';

--- a/tests/round33c-bugfixes.spec.ts
+++ b/tests/round33c-bugfixes.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-33c bug fixes reported by Nils during live dev-server testing:
 //
@@ -19,7 +20,7 @@ import fs from 'fs';
 // painted immediately, across several radius changes and both brush
 // entry points (button steppers and arrow keys).
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 

--- a/tests/round33c-gaps.spec.ts
+++ b/tests/round33c-gaps.spec.ts
@@ -1,11 +1,12 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-33c gap fills (keen-puma): the parts silver-crane flagged as not
 // live-tested — tutorial click-through with the new shortcut copy, the
 // threshold rows without numeric readouts, and the mode-dependent icons.
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round33c-verify';

--- a/tests/round33d-verify.spec.ts
+++ b/tests/round33d-verify.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
 import crypto from 'crypto';
+import { BASE_URL } from './baseUrl';
 
 // Round-33d independent acceptance (keen-puma): brush-first default is covered
 // in round33b-verify; this spec covers the blue brush stroke (mid-stroke
@@ -8,7 +9,7 @@ import crypto from 'crypto';
 // space box-selects every touched mask instead of panning, Shift adds, Delete
 // removes, and an empty-area box neither pans nor errors.
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round33d-verify';

--- a/tests/round34-sambox-dialog.spec.ts
+++ b/tests/round34-sambox-dialog.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round 34: Interactive Segmentation model-selection dialog. Coverage is
 // deliberately read-only (open dialog, assert content, close) — clicking a
@@ -8,7 +9,7 @@ import fs from 'fs';
 // remove_embedding RPC and mutate the shared dataset's cached embeddings, so
 // both paths are left for a live end-to-end pass rather than exercised here.
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round34-sambox-dialog';

--- a/tests/round34b-verify.spec.ts
+++ b/tests/round34b-verify.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-34b independent acceptance (keen-puma): the click-time preparation
 // flow for Interactive Segmentation.
@@ -12,7 +13,7 @@ import fs from 'fs';
 //   the embedding file exists (after an existence check with its own spinner).
 //   Anonymous users get a surfaced error instead of an infinite spinner.
 
-test.use({ baseURL: process.env.DEV_BASE_URL || 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round34b-verify';

--- a/tests/round35-loading-ux.spec.ts
+++ b/tests/round35-loading-ux.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round 35 (colab-rework-plan.md, DatasetOverview loading UX), amended by
 // round 35b:
@@ -19,7 +20,7 @@ import fs from 'fs';
 // confirms the spinner affordances actually appear/disappear across a
 // manual refresh and an image switch, and that nothing throws.
 
-test.use({ baseURL: 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const LABEL = 'cells';

--- a/tests/round35-verify.spec.ts
+++ b/tests/round35-verify.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-35 independent acceptance (keen-puma) on a multi-image dataset:
 // (1) the Browse annotations button swaps to a spinner during the
@@ -12,7 +13,7 @@ import fs from 'fs';
 // BEFORE the triggering click, since the underlying fetches are hypha-rpc
 // websocket calls that HTTP route interception cannot delay.
 
-test.use({ baseURL: process.env.DEV_BASE_URL || 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round35-verify';

--- a/tests/round35b-image-switch.spec.ts
+++ b/tests/round35b-image-switch.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-35b independent acceptance (keen-puma): switching images in the
 // dataset overview removes the previous image IMMEDIATELY and shows the
@@ -7,7 +8,7 @@ import fs from 'fs';
 // new image renders. The same skeleton is reused when loading the next
 // annotation. Supersedes the round-35 dim-old-image-with-overlay design.
 
-test.use({ baseURL: process.env.DEV_BASE_URL || 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round35b-verify';

--- a/tests/round36-merge-and-label-info.spec.ts
+++ b/tests/round36-merge-and-label-info.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-36 acceptance (keen-puma, confirmed via svamp thread h5BkpX6uBC):
 // 1. Select 2+ masks with the Select tool, press Expand Mask (button or "A")
@@ -11,7 +12,7 @@ import fs from 'fs';
 // 2. LabelManager shows an info icon next to each label badge whose tooltip
 //    reveals the label's description, or "No description provided" if unset.
 
-test.use({ baseURL: process.env.DEV_BASE_URL || 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const LABEL = 'cells';

--- a/tests/round36-verify.spec.ts
+++ b/tests/round36-verify.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-36 independent acceptance (keen-puma): merging touching masks.
 //   Two overlapping brush masks, box-selected, merge into ONE via the A
@@ -7,7 +8,7 @@ import fs from 'fs';
 //   Two separated masks no-op with the exact warning toast.
 //   The guide documents the merge gesture.
 
-test.use({ baseURL: process.env.DEV_BASE_URL || 'http://localhost:5199' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round36-verify';

--- a/tests/round37-fis-warning.spec.ts
+++ b/tests/round37-fis-warning.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-37 acceptance (keen-puma):
 //   1. Warn before Full Image Segmentation runs over existing masks. Clicking
@@ -11,7 +12,7 @@ import fs from 'fs';
 //      (e.g. "μSAM Large (LM)") so the choice is unambiguous even without the
 //      open dropdown's subheaders.
 
-test.use({ baseURL: process.env.DEV_BASE_URL || 'http://localhost:5301' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round37-verify';

--- a/tests/round38-cellpose-dino-models.spec.ts
+++ b/tests/round38-cellpose-dino-models.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Round-38 acceptance (keen-puma):
 //   1. The FIS backend/model select gets a 'Cellpose' group listing
@@ -10,7 +11,7 @@ import fs from 'fs';
 //      (they hide the same way the uSAM backend does).
 //   4. The Cellpose-SAM path is unchanged.
 
-test.use({ baseURL: process.env.DEV_BASE_URL || 'http://localhost:5302' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const OUT = '/tmp/round38-dino-verify';

--- a/tests/sidebar-alignment.spec.ts
+++ b/tests/sidebar-alignment.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { BASE_URL } from './baseUrl';
 
 // Requires: HYPHA_TOKEN env var, falls back to /data/nmechtel/bioengine/.env.
-// Requires: dev server running at http://localhost:3012.
+// Requires: dev server running at E2E_BASE_URL (default http://localhost:3000).
 //
 // Regression test for colab-rework-plan.md §18.1: every tool/action row's
 // title text in the expanded ToolBar and ActionPanel sidebars must share a
@@ -10,7 +11,7 @@ import fs from 'fs';
 // identical across rows). Reads each `data-testid="row-title"` element's
 // bounding box and asserts the left x is consistent within 1px, per sidebar.
 
-test.use({ baseURL: 'http://localhost:3012' });
+test.use({ baseURL: BASE_URL });
 
 const DATASET_ALIAS = 'annotation-mst3ebzz-o5px';
 const LABEL = 'cells';

--- a/tests/v1-15-async-test-api.spec.ts
+++ b/tests/v1-15-async-test-api.spec.ts
@@ -15,8 +15,10 @@ import { test, expect } from '@playwright/test';
 //     inline in each step's right-hand cell as an amber "#N" pill while queued
 //     (queue_position > 0), not as a separate always-on queue-position row.
 //   - The three step rows (Preparing model / Environment setup / Running) show
-//     each step's duration (mm:ss), a dash when skipped, and the live-ticking
-//     duration for the step currently running.
+//     each step's duration, "Skipped" when the step never ran, and the
+//     live-ticking elapsed time for the step currently running. Durations are
+//     seconds, not mm:ss: a running step ticks whole seconds ("17s") and a
+//     finished one freezes to one decimal ("2.4s").
 //   - On completion the dialog stays on the timeline ("Model Test Complete")
 //     with a "View Test Report" button; the report opens only when clicked.
 
@@ -77,8 +79,9 @@ test.describe('v1.15.2 async model test API (deNBI)', () => {
     await expect(page.getByText('Environment setup')).toBeVisible();
     await expect(page.getByText('Running')).toBeVisible();
 
-    // Step 7: The right-hand cell shows each step's duration (mm:ss).
-    await expect(page.locator('text=/^\\d{2}:\\d{2}$/').first()).toBeVisible({ timeout: 240000 });
+    // Step 7: The right-hand cell shows each step's duration in seconds —
+    // "17s" while a step is running, "2.4s" once it has frozen.
+    await expect(page.locator('text=/^\\d+([.,]\\d)?s$/').first()).toBeVisible({ timeout: 240000 });
 
     // Step 8: On completion the dialog stays on the timeline (title "Model Test
     // Complete") and offers a "View Test Report" button — the report does NOT
@@ -96,7 +99,7 @@ test.describe('v1.15.2 async model test API (deNBI)', () => {
     ).toBeVisible({ timeout: 5000 });
   });
 
-  test('Edit page: skipped step renders an em dash', async ({ page }) => {
+  test('Edit page: skipped step is labelled Skipped', async ({ page }) => {
     const token = process.env.HYPHA_TOKEN;
     if (!token) {
       test.skip();
@@ -128,15 +131,15 @@ test.describe('v1.15.2 async model test API (deNBI)', () => {
     // Enable "Skip cache" (second checkbox) so the run actually downloads and
     // runs rather than returning instantly from cache — that gives the
     // in-progress timeline a stable window to observe. With no custom
-    // environment, the Environment setup step is skipped and its start-time
-    // cell must render an em dash once the Running step has started.
+    // environment, the Environment setup step is skipped and its right-hand
+    // cell must read "Skipped" once the Running step has started.
     await optionsDialog.locator('input[type="checkbox"]').nth(1).check();
     await optionsDialog.getByRole('button', { name: 'Run Test' }).click();
 
     await expect(page.getByText('Model Testing in Progress')).toBeVisible({ timeout: 15000 });
     // Once the Running step has a start time, Environment setup is skipped and
-    // shows an em dash. Poll for it while the run is in its (real) running phase.
+    // says so. Poll for it while the run is in its (real) running phase.
     await expect(page.getByText('Running')).toBeVisible({ timeout: 240000 });
-    await expect(page.getByText('—').first()).toBeVisible({ timeout: 120000 });
+    await expect(page.getByText('Skipped').first()).toBeVisible({ timeout: 120000 });
   });
 });


### PR DESCRIPTION
## Motivation

The end-to-end Playwright suite had drifted out of sync with the app and no longer ran clean.

The largest cause was structural: every spec hardcoded `http://localhost:3000` as its base URL. That is not a safe assumption. Whatever happens to be serving on port 3000 becomes the system under test, and when it is a different application the run produces a screenful of assertion failures that look like website regressions but say nothing about this app at all.

Behind that noise sat three genuine product defects and two specs asserting on markup the app no longer renders.

## Solution

**One configurable base URL.** `tests/baseUrl.ts` exports a single `BASE_URL`, resolved from `E2E_BASE_URL` and defaulting to `http://localhost:3000`. All 25 specs and `playwright.config.ts` route through it, and each spec navigates with relative paths via `test.use({ baseURL })`. `tests/globalSetup.ts` fetches `manifest.json` before any spec runs and aborts the run unless `short_name` is `BioImage.IO`, so pointing the suite at the wrong server fails immediately with an accurate message.

**Export gate no longer depends on the split pointer.** A split records only its most recent run, and exporting a model looked that run up through the pointer. Starting any newer run on the same split therefore made every earlier checkpoint unexportable: the pointer had moved on and the export gate concluded the run no longer existed. `Finetune` now resolves the export target with `resolveExportSplit`, which tries the split that still points at the run, then any split whose `session_history` records it, then the label's sole split. The export proceeds even when none of those match, just without a split name in its provenance, and the write-back that stamps the export onto the split only runs while the split still points at this run.

**No buttons nested inside dataset image rows.** The rows in the dataset overview were `<button>` elements, and a row also carries an upload control and, in the finetune view, its own train/test/unused pill. A button inside a button is markup the browser is not permitted to build, so it silently reparses the tree into something the code never described, and in practice the row and the pill could both answer the same click. The row is now a `div` with `role="button"`, `tabIndex={0}` and an explicit key handler, preserving click and keyboard activation.

**Accessible name matches the visible label.** The box-prompt model dialog marks its default row "(default)" in the visible label, but the recompute button's `aria-label` was built from the bare option label. The control's spoken name omitted a suffix the row visibly carries, which reads as a different control to anyone matching what they see against what they hear. Both now derive from one computed label.

**Two specs matched to what the app renders.** `v1-15-async-test-api` expected `mm:ss` durations and an em dash for a skipped step; the timeline renders seconds and the word "Skipped". `inference-report-source` was built on the consolidated `inference-report` artifact, which no longer exists, so it now targets the per-model test-report artifact the badge actually derives from and reads the expected failure text out of the live report at run time instead of hardcoding a traceback that changes on every re-test. `StepTimeline`'s JSDoc still described the old em dash and is corrected.

## Behaviour

- Exporting a trained checkpoint works for any run in a split's history, not only the most recent one. Provenance omits `split_name` when the run cannot be attributed to a split.
- Dataset image rows keep their click and keyboard behaviour; the split pill and upload control no longer share a click target with the row.
- Screen readers announce the box-prompt recompute button with the same "(default)" suffix the row shows.
- No behaviour change from the test-only commits.

## Test plan

- Full Playwright suite: 57 passed, 1 skipped by design, 0 failed. The skip is `cancel-button.spec.ts`, which self-skips with a recorded reason when the worker predates `cancel_request`.
- New regression guard `tests/dataset-row-nesting.spec.ts` asserts zero nested buttons in both states that render controls inside a row (plain overview and finetune view), watches for React's `validateDOMNesting` warning, and checks the row is still focusable.
- `react-scripts build` exits 0.

## Files

| Area | Files |
| --- | --- |
| Test base URL seam | `tests/baseUrl.ts`, `tests/globalSetup.ts`, `playwright.config.ts`, 25 specs |
| Export gate | `src/components/colab/Finetune.tsx`, `src/components/colab/ExportModelDialog.tsx` |
| Row nesting | `src/components/colab/DatasetOverview.tsx`, `tests/dataset-row-nesting.spec.ts` |
| Accessible name | `src/components/annotate/SamBoxModelDialog.tsx` |
| Spec/app drift | `src/components/StepTimeline.tsx`, `tests/v1-15-async-test-api.spec.ts`, `tests/inference-report-source.spec.ts` |
