### PR TITLE
Badge BioEngine apps that hold a slice of a GPU

### DIFF
--- a/src/components/bioengine/DeploymentCard.tsx
+++ b/src/components/bioengine/DeploymentCard.tsx
@@ -122,6 +122,12 @@ interface DeploymentCardProps {
       num_gpus?: number;
       memory?: number;
     };
+    // `not disable_gpu` on the worker (apps/manager.py). True whenever the app
+    // was not explicitly deployed CPU-only, which covers both whole-GPU apps
+    // (num_gpus > 0) and apps that ask for a slice by VRAM instead, where
+    // num_gpus stays 0. It is the only GPU signal the worker reports for the
+    // latter: application_resources.VRAM_MB is 0 on every app today.
+    gpu_enabled?: boolean;
     service_ids?: {  // New: independent service IDs
       websocket_service_id?: string;
       webrtc_service_id?: string;
@@ -164,6 +170,12 @@ const DeploymentCard: React.FC<DeploymentCardProps> = ({
   };
 
   const resources = deployment.resources ?? null;
+
+  // An app can hold a GPU without reserving a whole one: asking by VRAM
+  // (gpu_memory_mb) leaves num_gpus at 0, so gating the badge on the count
+  // alone made every partial-GPU app read as CPU-only on the card.
+  const wholeGpus = resources?.num_gpus != null && resources.num_gpus > 0 ? resources.num_gpus : 0;
+  const showsGpuBadge = wholeGpus > 0 || deployment.gpu_enabled === true;
 
   // Get MCP URL from websocket service ID
   const getMcpUrl = (): string | null => {
@@ -418,15 +430,14 @@ const DeploymentCard: React.FC<DeploymentCardProps> = ({
             </div>
           )}
 
-          {resources && (
+          {(showsGpuBadge || (resources && (
             (resources.num_cpus != null && resources.num_cpus > 0) ||
-            (resources.num_gpus != null && resources.num_gpus > 0) ||
             (resources.memory != null && resources.memory > 0)
-          ) && (
+          ))) && (
             <div>
               <p className="text-sm font-medium text-gray-700 mb-2">Resources:</p>
               <div className="flex flex-wrap gap-2">
-                {resources.num_cpus != null && resources.num_cpus > 0 && (
+                {resources?.num_cpus != null && resources.num_cpus > 0 && (
                   <span className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-blue-50 text-blue-700 border border-blue-200">
                     <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2z" />
@@ -434,15 +445,20 @@ const DeploymentCard: React.FC<DeploymentCardProps> = ({
                     {resources.num_cpus} CPU{resources.num_cpus !== 1 ? 's' : ''}
                   </span>
                 )}
-                {resources.num_gpus != null && resources.num_gpus > 0 && (
-                  <span className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-purple-50 text-purple-700 border border-purple-200">
+                {showsGpuBadge && (
+                  <span
+                    className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-purple-50 text-purple-700 border border-purple-200"
+                    title={wholeGpus > 0
+                      ? undefined
+                      : 'This app runs with GPU access but does not reserve a whole device.'}
+                  >
                     <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                     </svg>
-                    {resources.num_gpus} GPU{resources.num_gpus !== 1 ? 's' : ''}
+                    {wholeGpus > 0 ? `${wholeGpus} GPU${wholeGpus !== 1 ? 's' : ''}` : 'Shared GPU'}
                   </span>
                 )}
-                {resources.memory != null && resources.memory > 0 && (
+                {resources?.memory != null && resources.memory > 0 && (
                   <span className="inline-flex items-center px-2 py-1 rounded text-xs font-medium bg-green-50 text-green-700 border border-green-200">
                     <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4" />

--- a/tests/worker-gpu-badge.spec.ts
+++ b/tests/worker-gpu-badge.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import { BASE_URL } from './baseUrl';
+
+// Regression guard for issue #0027.
+//
+// A BioEngine app can hold a GPU in two ways. Whole-GPU apps set num_gpus.
+// Partial-GPU apps ask by VRAM instead (gpu_memory_mb), which leaves num_gpus
+// at 0. The worker dashboard used to gate its GPU badge on num_gpus > 0 alone,
+// so a partial-GPU app rendered no badge and read as CPU-only on the card.
+//
+// Rather than assert against a fixed app list, this spec asks the worker what
+// it is actually running and cross-checks every card against that answer. The
+// live deployment set changes constantly, so a hardcoded expectation would rot
+// within days.
+//
+// Requires: HYPHA_TOKEN (falls back to /data/nmechtel/bioengine/.env) and a dev
+// server at E2E_BASE_URL.
+
+test.use({ baseURL: BASE_URL });
+
+const HYPHA_SERVER_URL = process.env.HYPHA_SERVER_URL || 'https://hypha.aicell.io';
+
+// A worker's client id carries a random suffix that changes on every roll, so
+// the spec globs for the site and resolves the concrete id from the response.
+const WORKER_GLOB = process.env.E2E_WORKER_GLOB || 'bioengine-worker-denbi-*:bioengine-worker';
+
+type AppStatus = {
+  gpu_enabled?: boolean;
+  application_resources?: { num_gpus?: number };
+  deployed_by_worker_client_id?: string;
+};
+
+function readHyphaToken(): string | undefined {
+  if (process.env.HYPHA_TOKEN) return process.env.HYPHA_TOKEN;
+  try {
+    return fs.readFileSync('/data/nmechtel/bioengine/.env', 'utf8').match(/HYPHA_TOKEN=(\S+)/)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+/** The badge text the card should carry for an app, or null when it should carry none. */
+function expectedGpuBadge(app: AppStatus): string | null {
+  const n = app.application_resources?.num_gpus ?? 0;
+  if (n > 0) return `${n} GPU${n !== 1 ? 's' : ''}`;
+  return app.gpu_enabled === true ? 'Shared GPU' : null;
+}
+
+test('worker dashboard badges every GPU app, including partial-GPU ones', async ({ page, request }, testInfo) => {
+  const token = readHyphaToken();
+  if (!token) {
+    test.skip();
+    return;
+  }
+  test.setTimeout(180000);
+
+  const statusUrl =
+    `${HYPHA_SERVER_URL}/bioimage-io/services/${WORKER_GLOB}/get_app_status?_mode=first`;
+  const res = await request.get(statusUrl, { headers: { Authorization: `Bearer ${token}` }, timeout: 60000 });
+  expect(res.ok(), `get_app_status failed: ${res.status()}`).toBeTruthy();
+  const apps: Record<string, AppStatus> = await res.json();
+
+  const appIds = Object.keys(apps).filter((k) => apps[k] && typeof apps[k] === 'object');
+  if (appIds.length === 0) {
+    testInfo.annotations.push({
+      type: 'skip-reason',
+      description: 'no apps deployed on the worker, so there are no cards to check.',
+    });
+    test.skip();
+    return;
+  }
+
+  const clientId = appIds.map((id) => apps[id].deployed_by_worker_client_id).find(Boolean);
+  expect(clientId, 'worker did not report deployed_by_worker_client_id').toBeTruthy();
+  const serviceId = `bioimage-io/${clientId}:bioengine-worker`;
+
+  await page.addInitScript(({ tok, expiry }) => {
+    localStorage.setItem('token', tok);
+    localStorage.setItem('tokenExpiry', expiry);
+  }, { tok: token, expiry: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString() });
+
+  await page.goto(`/#/bioengine/worker?service_id=${encodeURIComponent(serviceId)}`);
+  await expect(page.getByText(/Application ID:/).first()).toBeVisible({ timeout: 90000 });
+  // The cards mount per app as their status resolves, so let the list settle
+  // before reading it rather than racing the slowest card.
+  await expect
+    .poll(() => page.getByText(/Application ID:/).count(), { timeout: 60000 })
+    .toBeGreaterThan(0);
+  await page.waitForTimeout(3000);
+
+  const badgesByApp: Record<string, string[] | null> = await page.evaluate(() => {
+    const out: Record<string, string[] | null> = {};
+    const idParagraphs = [...document.querySelectorAll('p')].filter((p) =>
+      p.textContent?.trim().startsWith('Application ID:')
+    );
+    for (const p of idParagraphs) {
+      const appId = (p.textContent || '').replace('Application ID:', '').trim();
+      // Walk up to the smallest ancestor that holds this card's Resources
+      // section and exactly one Application ID, so a two-column grid can never
+      // hand back the neighbouring card's badges.
+      let node: HTMLElement | null = p.parentElement;
+      let root: HTMLElement | null = null;
+      for (let i = 0; i < 12 && node; i++) {
+        const ps = [...node.querySelectorAll('p')];
+        const ownIds = ps.filter((q) => q.textContent?.trim().startsWith('Application ID:')).length;
+        const resLabel = ps.find((q) => q.textContent?.trim() === 'Resources:');
+        if (ownIds > 1) break;
+        if (resLabel && ownIds === 1) { root = node; break; }
+        node = node.parentElement;
+      }
+      if (!root) { out[appId] = null; continue; }
+      const resLabel = [...root.querySelectorAll('p')].find((q) => q.textContent?.trim() === 'Resources:');
+      const section = resLabel?.parentElement;
+      out[appId] = section ? [...section.querySelectorAll('span')].map((s) => (s.textContent || '').trim()) : null;
+    }
+    return out;
+  });
+
+  let partialGpuChecked = 0;
+  const missingCards: string[] = [];
+
+  for (const appId of appIds) {
+    const badges = badgesByApp[appId];
+    if (badges == null) {
+      // An app can be undeployed between the status call and the render.
+      missingCards.push(appId);
+      continue;
+    }
+    const expectedBadge = expectedGpuBadge(apps[appId]);
+    const actualBadge = badges.find((b) => /GPU/.test(b));
+
+    if (expectedBadge === null) {
+      expect(actualBadge, `${appId} is CPU-only but the card shows "${actualBadge}"`).toBeUndefined();
+    } else {
+      expect(actualBadge, `${appId} should show "${expectedBadge}"`).toBe(expectedBadge);
+      if (expectedBadge === 'Shared GPU') partialGpuChecked += 1;
+    }
+  }
+
+  if (missingCards.length > 0) {
+    testInfo.annotations.push({
+      type: 'note',
+      description: `no card rendered for ${missingCards.join(', ')} (undeployed mid-run).`,
+    });
+  }
+
+  // The whole point of #0027 is the partial-GPU case. Say so out loud when the
+  // live worker happens not to be running one, so a green result is not read as
+  // proof that case still works.
+  if (partialGpuChecked === 0) {
+    testInfo.annotations.push({
+      type: 'note',
+      description:
+        'no partial-GPU app (gpu_enabled with num_gpus 0) was deployed, so the #0027 case itself was not exercised.',
+    });
+  }
+});


### PR DESCRIPTION
## Motivation

An app running on the BioEngine worker dashboard can hold a GPU without reserving a whole one. Whole-GPU apps set `num_gpus`. Partial-GPU apps ask by VRAM instead (`gpu_memory_mb`), which leaves `num_gpus` at 0.

The deployment card gated its GPU badge on `num_gpus > 0`, so a partial-GPU app rendered no badge at all and read as CPU-only to anyone looking at the card. The Federated U-Net on the deNBI worker is the reported case: it really is using a GPU slice, and the card said nothing about it.

## Solution

The badge now renders whenever the app is `gpu_enabled`, and keeps the count only when there is a whole-device count to report. Otherwise it reads "Shared GPU" rather than claiming a device the app does not hold, with a title explaining that it runs with GPU access but does not reserve a whole device.

`gpu_enabled` is the only GPU signal available for the partial case. The app payload carries no `gpu_memory_mb`, and `application_resources.VRAM_MB` reads 0 on every app today including the whole-GPU ones, so it cannot carry the number. Note that `gpu_enabled` is `not disable_gpu` on the worker and `disable_gpu` defaults to false, so it means "GPU not explicitly disabled", which is a superset of "uses a GPU". The badge wording is chosen to stay truthful under that ambiguity rather than asserting a precise allocation the dashboard cannot see.

The Resources section's own gate now includes the GPU case, so an app reporting no CPU or memory figure still renders the section for its badge, and the two remaining badges read `resources` optionally to match.

## Behaviour

Against the deNBI worker:

| App | Worker reports | Card shows |
| --- | --- | --- |
| Cellpose3 Runner | `gpu_enabled=false, num_gpus=0` | no GPU badge (unchanged) |
| Model Runner | `gpu_enabled=true, num_gpus=1` | `1 GPU` (unchanged) |
| BioImageIO Fine-tune | `gpu_enabled=true, num_gpus=2` | `2 GPUs` (unchanged) |
| Federated U-Net | `gpu_enabled=true, num_gpus=0` | `Shared GPU` (previously nothing) |

## Test plan

- `tests/worker-gpu-badge.spec.ts` asks the worker what it is running via `get_app_status` and cross-checks every rendered card against that answer. It resolves the worker's rotating client id from `deployed_by_worker_client_id` in the response and globs the site with `_mode=first`, so no app list or worker id is hardcoded and the spec does not rot as deployments turn over. It annotates itself when no partial-GPU app happens to be deployed, so a green run is not mistaken for coverage of the case it exists to guard.
- Falsification check: with the fix reverted the spec fails with the reported symptom (expected `Shared GPU`, received `undefined`). With the fix it passes in 8.1 s.
- `react-scripts build` exits 0.

## Files

| Area | Files |
| --- | --- |
| Badge logic | `src/components/bioengine/DeploymentCard.tsx` |
| Regression guard | `tests/worker-gpu-badge.spec.ts` |
