### PR TITLE
Prefill a readable default model name in the fine-tune export dialog

### DIFF
--- a/src/components/colab/ExportModelDialog.tsx
+++ b/src/components/colab/ExportModelDialog.tsx
@@ -68,6 +68,31 @@ const extractNounFromId = (id: string): string => {
   return parts[parts.length - 1];
 };
 
+const VIT_SIZE_LABELS: Record<string, string> = { t: 'ViT-T', b: 'ViT-B', l: 'ViT-L', h: 'ViT-H' };
+
+const CELLPOSE_NAMES: Record<string, string> = {
+  cpsam: 'Cellpose-SAM',
+  cpdino: 'Cellpose-DINO',
+  'cpdino-vitb': 'Cellpose-DINO (ViT-B)',
+};
+
+/**
+ * Human-readable default title for a model fine-tuned from `modelType`, so a
+ * draft never lands in the zoo carrying an underscored `model_type`-style name.
+ * Both backends are covered, keyed on the same `cp` prefix `tagsForModel` uses
+ * so the title and the tags can never disagree about which one a run came from.
+ * An unrecognised type degrades to the bare architecture family rather than
+ * echoing the raw id back at the user.
+ */
+const defaultModelName = (modelType?: string): string => {
+  const mt = (modelType || '').trim().toLowerCase();
+  if (!mt) return 'Fine-tuned model';
+  if (mt.startsWith('cp')) return `Fine-tuned ${CELLPOSE_NAMES[mt] || 'Cellpose'}`;
+  const size = VIT_SIZE_LABELS[mt.match(/^vit_([tblh])/)?.[1] ?? ''];
+  const modality = mt.includes('_em_organelles') ? 'EM Organelles' : mt.includes('_lm') ? 'LM Generalist' : '';
+  return ['Fine-tuned SAM', modality, size && `(${size})`].filter(Boolean).join(' ');
+};
+
 const ExportModelDialog: React.FC<ExportModelDialogProps> = ({
   open,
   onClose,
@@ -80,7 +105,7 @@ const ExportModelDialog: React.FC<ExportModelDialogProps> = ({
   splitName,
   onExported,
 }) => {
-  const [name, setName] = useState('');
+  const [name, setName] = useState(() => defaultModelName(session.model_type));
   const [description, setDescription] = useState('');
   const [license, setLicense] = useState('CC-BY-4.0');
   const [authors, setAuthors] = useState<AuthorRow[]>([{ name: user?.email || '', affiliation: '' }]);


### PR DESCRIPTION
## Motivation

The fine-tune export dialog opened with an empty Name field. Whatever the user typed there (or failed to type) became the title of a draft model in the zoo, so an export could land carrying an underscored `model_type`-style name, or no name at all.

## Solution

Prefill the field with a title derived from the base model type the run was fine-tuned from, matching the style of the published zoo entries.

The micro-SAM / Cellpose split is keyed on the same `cp` model_type prefix that `tagsForModel` in the same file already uses, so the generated title and the generated tags cannot disagree about which backend a run came from. An unrecognised model type degrades to the bare architecture family rather than echoing the raw id back at the user.

The field stays fully editable. This only changes what it starts as.

## Behaviour

| `model_type` | Prefilled name |
| --- | --- |
| `vit_t_lm` / `vit_b_lm` / `vit_l_lm` | Fine-tuned SAM LM Generalist (ViT-T / ViT-B / ViT-L) |
| `vit_t_em_organelles` / `vit_b_em_organelles` / `vit_l_em_organelles` | Fine-tuned SAM EM Organelles (ViT-T / ViT-B / ViT-L) |
| `cpsam` | Fine-tuned Cellpose-SAM |
| `cpdino` | Fine-tuned Cellpose-DINO |
| `cpdino-vitb` | Fine-tuned Cellpose-DINO (ViT-B) |
| `vit_b` (plain SAM) | Fine-tuned SAM (ViT-B) |
| unrecognised `cp*` | Fine-tuned Cellpose |
| missing / empty | Fine-tuned model |

The dialog is conditionally rendered at its call site in `Finetune.tsx`, so it remounts on every open and the `useState` initializer always sees the current export target rather than a stale one.

## Test plan

- Production build passes (`react-scripts build`, exit 0).
- The naming function was exercised over every `model_type` in the training catalogue (all nine entries in `trainingModels.ts`), plus the plain-SAM group, an unknown `cp*` type, and the empty and undefined cases. Output is the table above.

## Files

- `src/components/colab/ExportModelDialog.tsx` — add `defaultModelName`, use it as the Name field's initial state.
